### PR TITLE
opens possibility to build images of various Sonic versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 #
 FROM golang:1.22 AS client-build
 
-# Download Sonic dependencies from the default bracnch first to cache them.
+# Download Sonic dependencies from the default branch first to cache them.
 # We assume tags/branches do not change majority of dependencies.
 RUN git clone https://github.com/0xsoniclabs/sonic.git /client
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,27 +11,44 @@
 # The build is done in independent stages, to allow for
 # caching of the intermediate results.
 
-# Stage 0: load dependencies
-FROM golang:1.22 AS client-dependencies
+#
+# Stage 1a: Build Client
+#
+# It prepeares an image with dependencies for the client.
+# Its caches the dependencies first, so that the build is faster.
+#
+# It checks out the required version of the client, and builds it.
+#
+FROM golang:1.22 AS client-build
 
+# Download Sonic dependencies from the default bracnch first to cache them.
+# We assume tags/branches do not change majority of dependencies.
+RUN git clone https://github.com/0xsoniclabs/sonic.git /client
+
+# Download Client dependencies from the default bracnch
 WORKDIR /client
-COPY client/go.mod ./go.mod
 RUN go mod download
 
+# Checkout required Client version and build it
+ARG CLIENT_VERSION=main
+WORKDIR /client
+RUN git checkout ${CLIENT_VERSION}
+RUN --mount=type=cache,target=/root/.cache/go-build make sonicd sonictool
+
+#
+# Stage 1b: Build Norma
+#
+# It prepeares an image with dependencies for the norma.
+# Its caches the dependencies first, so that the build is faster.
+#
+# It checks out the local version of the norma, and builds it.
+#
+FROM golang:1.22 AS norma-build
+
+# Download Norma dependencies first to cache them for faster build when Norma changes.
 WORKDIR /
 COPY go.mod go.mod
 RUN go mod download
-
-# Stage 1: build the client
-FROM client-dependencies AS client-build
-
-WORKDIR /client
-
-# Copy the client code into the image.
-COPY client/ ./
-
-# Build sonic with caching
-RUN --mount=type=cache,target=/root/.cache/go-build make sonicd sonictool
 
 # Build norma itself
 WORKDIR /norma
@@ -55,7 +72,7 @@ RUN apt-get update && \
     apt-get install iproute2 iputils-ping -y
 
 COPY --from=client-build /client/build/sonicd /client/build/sonictool ./
-COPY --from=client-build /norma/build/normatool ./
+COPY --from=norma-build /norma/build/normatool ./
 
 ENV STATE_DB_IMPL="geth"
 ENV VM_IMPL="geth"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,17 @@ BUILD_DIR := $(CURDIR)/build
 
 .PHONY: all test clean
 
-all: normatool build-sonic-docker-image norma
+# Define a list of client versions
+CLIENT_VERSIONS := v2.0.2 v2.0.1 v2.0.0
+
+all: \
+    normatool \
+    norma \
+    pull-hello-world-image \
+    pull-alpine-image \
+    pull-prometheus-image \
+    build-sonic-docker-image \
+    $(foreach version, $(CLIENT_VERSIONS), build-sonic-docker-image-$(version)) \
 
 pull-hello-world-image:
 	DOCKER_BUILDKIT=1 docker image pull hello-world
@@ -31,6 +41,10 @@ pull-prometheus-image:
 
 build-sonic-docker-image:
 	DOCKER_BUILDKIT=1 docker build . -t sonic
+
+# Build various client versions
+$(foreach version, $(CLIENT_VERSIONS), build-sonic-docker-image-$(version)):
+	DOCKER_BUILDKIT=1 docker build --build-arg CLIENT_VERSION=$($(subst build-sonic-docker-image-,,$@)) . -t sonic:$(subst build-sonic-docker-image-,,$@)
 
 generate-abi: load/contracts/abi/Counter.abi load/contracts/abi/ERC20.abi load/contracts/abi/Store.abi load/contracts/abi/UniswapV2Pair.abi load/contracts/abi/UniswapRouter.abi load/contracts/abi/Helper.abi # requires installed solc and Ethereum abigen - check README.md
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.3
 
 require (
-	github.com/0xsoniclabs/sonic v0.0.0-00010101000000-000000000000
+	github.com/0xsoniclabs/sonic v0.0.0-20250205152531-9d2223dbefd8
 	github.com/docker/docker v27.3.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/ethereum/go-ethereum v1.14.8
@@ -109,8 +109,6 @@ require (
 	pgregory.net/rand v1.0.2 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
-
-replace github.com/0xsoniclabs/sonic => ./client
 
 replace github.com/ethereum/go-ethereum => github.com/0xsoniclabs/go-ethereum v0.0.0-20241022121122-7063a6b506bd
 

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/0xsoniclabs/carmen/go v0.0.0-20250113102336-97f8b8616eff h1:ItY2JgmM0
 github.com/0xsoniclabs/carmen/go v0.0.0-20250113102336-97f8b8616eff/go.mod h1:/u6oDZBv6eyPs9K7Ug5D4aL9l1Q7N43BnWEUPsvKmYw=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20241022121122-7063a6b506bd h1:rrj5Iv72cwtmC1AAsMhI5qw6wPs3cKGB935OjqZpqjU=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20241022121122-7063a6b506bd/go.mod h1:p4knNH76zBuqbEfc6CbZTOnaQNU0WvhzW5f0qq6aMoU=
+github.com/0xsoniclabs/sonic v0.0.0-20250205152531-9d2223dbefd8 h1:4G7bqChbRO6dk0TZbVYUb+sdEhLt1lVyuob2JfCCcA8=
+github.com/0xsoniclabs/sonic v0.0.0-20250205152531-9d2223dbefd8/go.mod h1:14Gy7WjTxNqD2GLoMvlhz/hvxNuLd9wT0RVfo51rWPk=
 github.com/0xsoniclabs/tosca v0.0.0-20250109073452-a7eb49bdbd45 h1:4PD4GwrMVkEdBCDRdinviL4AvD4mYSsbeX1uAJ70NY0=
 github.com/0xsoniclabs/tosca v0.0.0-20250109073452-a7eb49bdbd45/go.mod h1:ZjONKDZS84n/Ne0Rlt56X4O3Xz3r4jRUB440p7UrPZ0=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=


### PR DESCRIPTION
This PR update `Dockerfile` and build process to allow for building multiple versions of the Sonic client. 

It parametrises the Dockerfile to checkout a specified version of Sonic client from git. It means that the client version from the `client/` directory is no more used. 

`Makefile` was updated to build Docker images from all Sonic tags we have at the moment. 

This is a first step to run various versions of the client in an experiment.  Next steps will be:
1. unlink the `client/` dir
2. extend scenario configuration to define an image
3. possibly make startup scripts also configurable to accomodate changes in start-up procedure of the client    