### PR TITLE
Kjezek/configurable image name

### DIFF
--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -208,6 +208,11 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 	}
 	nodeIsCheater := false
 
+	image := driver.ClientDockerImageName
+	if node.Client.ImageName != "" {
+		image = node.Client.ImageName
+	}
+
 	for i := 0; i < instances; i++ {
 		name := fmt.Sprintf("%s-%d", node.Name, i)
 		var instance = new(driver.Node)
@@ -218,6 +223,7 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 			func() error {
 				newNode, err := net.CreateNode(&driver.NodeConfig{
 					Name:      name,
+					Image:     image,
 					Validator: nodeIsValidator,
 					Cheater:   nodeIsCheater,
 				})

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -208,7 +208,7 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 	}
 	nodeIsCheater := false
 
-	image := driver.ClientDockerImageName
+	image := driver.DefaultClientDockerImageName
 	if node.Client.ImageName != "" {
 		image = node.Client.ImageName
 	}

--- a/driver/monitoring/monitor_test.go
+++ b/driver/monitoring/monitor_test.go
@@ -169,6 +169,7 @@ func TestMonitorIntegrationPrometheusLogReceived(t *testing.T) {
 	})
 	node, err := opera.StartOperaDockerNode(client, nil, &opera.OperaNodeConfig{
 		Label:         "test",
+		Image:         driver.ClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	if err != nil {

--- a/driver/monitoring/monitor_test.go
+++ b/driver/monitoring/monitor_test.go
@@ -169,7 +169,7 @@ func TestMonitorIntegrationPrometheusLogReceived(t *testing.T) {
 	})
 	node, err := opera.StartOperaDockerNode(client, nil, &opera.OperaNodeConfig{
 		Label:         "test",
-		Image:         driver.ClientDockerImageName,
+		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	if err != nil {

--- a/driver/monitoring/node/cpu_profile_test.go
+++ b/driver/monitoring/node/cpu_profile_test.go
@@ -35,7 +35,7 @@ func TestCanCollectCpuProfileDateFromOperaNode(t *testing.T) {
 	})
 	node, err := opera.StartOperaDockerNode(docker, nil, &opera.OperaNodeConfig{
 		Label:         "test",
-		Image:         driver.ClientDockerImageName,
+		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	if err != nil {

--- a/driver/monitoring/node/cpu_profile_test.go
+++ b/driver/monitoring/node/cpu_profile_test.go
@@ -35,6 +35,7 @@ func TestCanCollectCpuProfileDateFromOperaNode(t *testing.T) {
 	})
 	node, err := opera.StartOperaDockerNode(docker, nil, &opera.OperaNodeConfig{
 		Label:         "test",
+		Image:         driver.ClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	if err != nil {

--- a/driver/monitoring/node/prom_log_source_test.go
+++ b/driver/monitoring/node/prom_log_source_test.go
@@ -100,7 +100,7 @@ func TestLogsIntegrationGetRealMetric(t *testing.T) {
 	})
 	node, err := opera.StartOperaDockerNode(client, nil, &opera.OperaNodeConfig{
 		Label:         "test",
-		Image:         driver.ClientDockerImageName,
+		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	if err != nil {

--- a/driver/monitoring/node/prom_log_source_test.go
+++ b/driver/monitoring/node/prom_log_source_test.go
@@ -100,6 +100,7 @@ func TestLogsIntegrationGetRealMetric(t *testing.T) {
 	})
 	node, err := opera.StartOperaDockerNode(client, nil, &opera.OperaNodeConfig{
 		Label:         "test",
+		Image:         driver.ClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	if err != nil {

--- a/driver/network.go
+++ b/driver/network.go
@@ -26,6 +26,8 @@ import (
 
 //go:generate mockgen -source network.go -destination network_mock.go -package driver
 
+const ClientDockerImageName = "sonic"
+
 // Network abstracts an execution environment for running scenarios.
 // Implementations may run nodes and applications locally, in docker images, or
 // remotely, on actual nodes. The interface is used by the scenario driver
@@ -94,6 +96,7 @@ type NodeConfig struct {
 	Name      string
 	Validator bool
 	Cheater   bool
+	Image     string
 	// TODO: add other parameters as needed
 	//  - features to include on the node
 	//  - state DB configuration

--- a/driver/network.go
+++ b/driver/network.go
@@ -26,7 +26,8 @@ import (
 
 //go:generate mockgen -source network.go -destination network_mock.go -package driver
 
-const ClientDockerImageName = "sonic"
+// DefaultClientDockerImageName is the name of the docker image to use for clients.
+const DefaultClientDockerImageName = "sonic"
 
 // Network abstracts an execution environment for running scenarios.
 // Implementations may run nodes and applications locally, in docker images, or

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -122,6 +122,7 @@ func NewLocalNetwork(config *driver.NetworkConfig) (*LocalNetwork, error) {
 			validatorId := i + 1
 			nodeConfig := node.OperaNodeConfig{
 				ValidatorId:   &validatorId,
+				Image:         driver.ClientDockerImageName,
 				NetworkConfig: config,
 				Label:         fmt.Sprintf("_validator-%d", validatorId),
 			}
@@ -205,6 +206,7 @@ func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error
 	if config.Cheater {
 		_, err := n.createNode(&node.OperaNodeConfig{
 			Label:         "cheater-" + config.Name,
+			Image:         config.Image,
 			NetworkConfig: &n.config,
 			ValidatorId:   &newValId,
 		})
@@ -215,6 +217,7 @@ func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error
 
 	return n.createNode(&node.OperaNodeConfig{
 		Label:         config.Name,
+		Image:         config.Image,
 		NetworkConfig: &n.config,
 		ValidatorId:   &newValId,
 	})

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -122,7 +122,7 @@ func NewLocalNetwork(config *driver.NetworkConfig) (*LocalNetwork, error) {
 			validatorId := i + 1
 			nodeConfig := node.OperaNodeConfig{
 				ValidatorId:   &validatorId,
-				Image:         driver.ClientDockerImageName,
+				Image:         driver.DefaultClientDockerImageName,
 				NetworkConfig: config,
 				Label:         fmt.Sprintf("_validator-%d", validatorId),
 			}

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -51,7 +51,7 @@ func TestLocalNetwork_CanStartNodesAndShutThemDown(t *testing.T) {
 			nodes := []driver.Node{}
 			for i := 0; i < N; i++ {
 				node, err := net.CreateNode(&driver.NodeConfig{
-					Image: driver.ClientDockerImageName,
+					Image: driver.DefaultClientDockerImageName,
 					Name:  fmt.Sprintf("T-%d", i),
 				})
 				if err != nil {
@@ -177,7 +177,7 @@ func TestLocalNetwork_CanPerformNetworkShutdown(t *testing.T) {
 	for i := 0; i < N; i++ {
 		_, err := net.CreateNode(&driver.NodeConfig{
 			Name:  fmt.Sprintf("T-%d", i),
-			Image: driver.ClientDockerImageName,
+			Image: driver.DefaultClientDockerImageName,
 		})
 		if err != nil {
 			t.Errorf("failed to create node: %v", err)
@@ -238,7 +238,7 @@ func TestLocalNetwork_Shutdown_Graceful(t *testing.T) {
 	for i := 0; i < N; i++ {
 		_, err := net.CreateNode(&driver.NodeConfig{
 			Name:  fmt.Sprintf("T-%d", i),
-			Image: driver.ClientDockerImageName,
+			Image: driver.DefaultClientDockerImageName,
 		})
 		if err != nil {
 			t.Errorf("failed to create node: %v", err)
@@ -317,7 +317,7 @@ func TestLocalNetwork_NotifiesListenersOnNodeStartup(t *testing.T) {
 
 	net.CreateNode(&driver.NodeConfig{
 		Name:  "Test",
-		Image: driver.ClientDockerImageName,
+		Image: driver.DefaultClientDockerImageName,
 	})
 
 	activeNodes = net.GetActiveNodes()
@@ -377,7 +377,7 @@ func TestLocalNetwork_CanRemoveNode(t *testing.T) {
 			for i := 0; i < N; i++ {
 				node, err := net.CreateNode(&driver.NodeConfig{
 					Name:  fmt.Sprintf("T-%d", i),
-					Image: driver.ClientDockerImageName,
+					Image: driver.DefaultClientDockerImageName,
 				})
 				if err != nil {
 					t.Errorf("failed to create node: %s", err)

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -65,8 +65,6 @@ func init() {
 	}
 }
 
-const operaDockerImageName = "sonic"
-
 // OperaNode implements the driver's Node interface by running a go-opera
 // client on a generic host.
 type OperaNode struct {
@@ -78,6 +76,8 @@ type OperaNode struct {
 type OperaNodeConfig struct {
 	// The label to be used to name this node. The label should not be empty.
 	Label string
+	// The Docker image to use for the node.
+	Image string
 	// The ID of the validator, nil if the node should not be a validator.
 	ValidatorId *int
 	// The configuration of the network the configured node should be part of.
@@ -113,7 +113,7 @@ func StartOperaDockerNode(client *docker.Client, dn *docker.Network, config *Ope
 			return nil, err
 		}
 		return client.Start(&docker.ContainerConfig{
-			ImageName:       operaDockerImageName,
+			ImageName:       config.Image,
 			ShutdownTimeout: &shutdownTimeout,
 			PortForwarding:  portForwarding,
 			Environment: map[string]string{

--- a/driver/node/opera_test.go
+++ b/driver/node/opera_test.go
@@ -45,7 +45,7 @@ func TestOperaNode_StartAndStop(t *testing.T) {
 	})
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
-		Image:         driver.ClientDockerImageName,
+		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	t.Cleanup(func() {
@@ -73,7 +73,7 @@ func TestOperaNode_RpcServiceIsReadyAfterStartup(t *testing.T) {
 	})
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
-		Image:         driver.ClientDockerImageName,
+		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	t.Cleanup(func() {
@@ -102,7 +102,7 @@ func TestOperaNode_StreamLog(t *testing.T) {
 
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
-		Image:         driver.ClientDockerImageName,
+		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	if err != nil {
@@ -156,7 +156,7 @@ func TestOperaNode_MetricsExposed(t *testing.T) {
 
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
-		Image:         driver.ClientDockerImageName,
+		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	if err != nil {
@@ -202,7 +202,7 @@ func TestClient_Stop_Graceful(t *testing.T) {
 
 	node, err := StartOperaDockerNode(client, nil, &OperaNodeConfig{
 		Label:         "test",
-		Image:         driver.ClientDockerImageName,
+		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	if err != nil {

--- a/driver/node/opera_test.go
+++ b/driver/node/opera_test.go
@@ -45,6 +45,7 @@ func TestOperaNode_StartAndStop(t *testing.T) {
 	})
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
+		Image:         driver.ClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	t.Cleanup(func() {
@@ -72,6 +73,7 @@ func TestOperaNode_RpcServiceIsReadyAfterStartup(t *testing.T) {
 	})
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
+		Image:         driver.ClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	t.Cleanup(func() {
@@ -100,6 +102,7 @@ func TestOperaNode_StreamLog(t *testing.T) {
 
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
+		Image:         driver.ClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	if err != nil {
@@ -153,6 +156,7 @@ func TestOperaNode_MetricsExposed(t *testing.T) {
 
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
+		Image:         driver.ClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	if err != nil {
@@ -198,6 +202,7 @@ func TestClient_Stop_Graceful(t *testing.T) {
 
 	node, err := StartOperaDockerNode(client, nil, &OperaNodeConfig{
 		Label:         "test",
+		Image:         driver.ClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	if err != nil {

--- a/scenarios/test/various_client_versions.yml
+++ b/scenarios/test/various_client_versions.yml
@@ -1,0 +1,55 @@
+# This scenario simulates a network with the various versions of the client.
+# It stars a few nodes each running a different version of the client.
+# It deploys a few applications and sends a decent number of transactions.
+
+# The name of the scenario
+name: Network Consistency
+
+# The duration of the scenario's runtime, in seconds.
+duration: 180
+
+# The number of validator nodes in the network.
+num_validators: 1
+
+# The network scenario to exercise. 
+nodes:
+  - name: observer-A
+    start: 10
+    instances: 1
+    client:
+      imagename: "sonic:v2.0.2"
+
+  - name: observer-B
+    start: 10
+    instances: 1
+    client:
+      imagename: "sonic:v2.0.1"
+
+  - name: validator-A
+    start: 10
+    instances: 1
+    client:
+      imagename: "sonic:v2.0.0"
+      type: validator
+
+# In the network, there is a single application producing a constant load.
+applications:
+  - name: counter
+    type: counter
+    users: 20           # number of users using the app
+    rate:
+      constant: 10     # Tx/s
+
+  - name: erc20
+    type: erc20
+    start: 60
+    users: 20           # number of users using the app
+    rate:
+      constant: 10     # Tx/s
+
+  - name: uniswap
+    type: uniswap
+    start: 80
+    users: 20           # number of users using the app
+    rate:
+      constant: 10     # Tx/s

--- a/scenarios/test/various_client_versions.yml
+++ b/scenarios/test/various_client_versions.yml
@@ -32,7 +32,7 @@ nodes:
       imagename: "sonic:v2.0.0"
       type: validator
 
-# In the network, there is a single application producing a constant load.
+# In the network, there is a few applications producing the load.
 applications:
   - name: counter
     type: counter


### PR DESCRIPTION
This PR propagates image name from scenario configuration. The image name is used when starting the container, which allows for running various client versions. 

An example configuration is presented.   