### PR TITLE
unlinks client submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "sonic"]
-	path = client
-	url =  https://github.com/0xsoniclabs/sonic.git


### PR DESCRIPTION
This PR unlinks `client/` submodule from the project.

Norma is being updated to support multiple versions of the client running in the Norma network. To support this, the client will be checked out from its git repository and the client directory becomes redundant. 