### PR TITLE
allows for free-form network rules configuration

### DIFF
--- a/driver/network.go
+++ b/driver/network.go
@@ -74,12 +74,10 @@ type Network interface {
 type NetworkConfig struct {
 	// NumberOfValidators is the (static) number of validators in the network.
 	NumberOfValidators int
-	// MaxBlockGas is the maximum gas limit for a block in the network.
-	MaxBlockGas uint64
-	// MaxEpochGas is the maximum gas limit for an epoch in the network.
-	MaxEpochGas uint64
 	// RoundTripTime is the average round trip time between nodes in the network.
 	RoundTripTime time.Duration
+	// NetworkRules is a map of network rules to be applied to the network.
+	NetworkRules map[string]string
 }
 
 // NetworkListener can be registered to networks to get callbacks whenever there

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"golang.org/x/exp/maps"
 	"io"
 	"regexp"
 	"slices"
@@ -105,27 +106,31 @@ func StartOperaDockerNode(client *docker.Client, dn *docker.Network, config *Ope
 
 	host, err := network.RetryReturn(network.DefaultRetryAttempts, 1*time.Second, func() (*docker.Container, error) {
 		ports, err := network.GetFreePorts(len(operaServices.Services()))
+		if err != nil {
+			return nil, err
+		}
+
 		portForwarding := make(map[network.Port]network.Port, len(ports))
 		for i, service := range operaServices.Services() {
 			portForwarding[service.Port] = ports[i]
 		}
-		if err != nil {
-			return nil, err
+
+		envs := map[string]string{
+			"VALIDATOR_ID":     validatorId,
+			"VALIDATORS_COUNT": fmt.Sprintf("%d", config.NetworkConfig.NumberOfValidators),
+			"NETWORK_LATENCY":  fmt.Sprintf("%v", config.NetworkConfig.RoundTripTime/2),
 		}
+		maps.Copy(envs, config.NetworkConfig.NetworkRules) // put in the network rules
+
 		return client.Start(&docker.ContainerConfig{
 			ImageName:       config.Image,
 			ShutdownTimeout: &shutdownTimeout,
 			PortForwarding:  portForwarding,
-			Environment: map[string]string{
-				"VALIDATOR_ID":     validatorId,
-				"VALIDATORS_COUNT": fmt.Sprintf("%d", config.NetworkConfig.NumberOfValidators),
-				"MAX_BLOCK_GAS":    fmt.Sprintf("%d", config.NetworkConfig.MaxBlockGas),
-				"MAX_EPOCH_GAS":    fmt.Sprintf("%d", config.NetworkConfig.MaxEpochGas),
-				"NETWORK_LATENCY":  fmt.Sprintf("%v", config.NetworkConfig.RoundTripTime/2),
-			},
-			Network: dn,
+			Environment:     envs,
+			Network:         dn,
 		})
 	})
+
 	if err != nil {
 		return nil, err
 	}

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"golang.org/x/exp/maps"
 	"io/fs"
 	"io/ioutil"
 	"os"
@@ -170,16 +171,15 @@ func runScenario(path, outputDir, label string, keepPrometheusRunning, skipCheck
 	clock := executor.NewWallTimeClock()
 
 	// Startup network.
-	fmt.Printf("Creating network with: \n")
-	fmt.Printf("    Network max block gas: %d\n", scenario.GetMaxBlockGas())
-	fmt.Printf("    Network max epoch gas: %d\n", scenario.GetMaxEpochGas())
-	fmt.Printf("    Network RoundTripTime: %v\n", scenario.GetRoundTripTime())
+	fmt.Printf("Network RoundTripTime: %v\n", scenario.GetRoundTripTime())
+	for k, v := range scenario.NetworkRules {
+		fmt.Printf("Network Rule: %s: %s\n", k, v)
+	}
 
 	net, err := local.NewLocalNetwork(&driver.NetworkConfig{
 		NumberOfValidators: scenario.GetNumValidators(),
-		MaxBlockGas:        scenario.GetMaxBlockGas(),
-		MaxEpochGas:        scenario.GetMaxEpochGas(),
 		RoundTripTime:      scenario.GetRoundTripTime(),
+		NetworkRules:       maps.Clone(scenario.NetworkRules),
 	})
 	if err != nil {
 		return err

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -25,48 +25,17 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const (
-	DefaultInstance = 1
-	// MaxBlockGas, MaxEpochGas defaults borrowed from example-genesis.json
-	DefaultMaxBlockGas = 20_500_000_000
-	DefaultMaxEpochGas = 1_500_000_000_000
-)
-
 // Scenario is the root element of a scenario description. It defines basic
 // scenario properties and lists a set of nodes and transaction source.
 type Scenario struct {
-	Name             string
-	Duration         float32
-	NumValidators    *int           `yaml:"num_validators,omitempty"`  // nil == 1
-	RoundTripTime    *time.Duration `yaml:"round_trip_time,omitempty"` // nil == 0
-	GenesisGasLimits GasLimits      `yaml:"genesis_gas_limit,omitempty"`
-	Nodes            []Node         `yaml:",omitempty"`
-	Applications     []Application  `yaml:",omitempty"`
-	Cheats           []Cheat        `yaml:",omitempty"`
-}
-
-// GasLimits is a configuration group for gas limit rules
-type GasLimits struct {
-	MaxBlockGas *uint64 `yaml:"max_block_gas,omitempty"`
-	MaxEpochGas *uint64 `yaml:"max_epoch_gas,omitempty"`
-}
-
-// GetMaxBlockGas returns MaxBlockGas
-func (s *Scenario) GetMaxBlockGas() uint64 {
-	if s.GenesisGasLimits.MaxBlockGas != nil {
-		return *s.GenesisGasLimits.MaxBlockGas
-	}
-
-	return DefaultMaxBlockGas
-}
-
-// GetMaxEpochGas returns MaxEpochGas
-func (s *Scenario) GetMaxEpochGas() uint64 {
-	if s.GenesisGasLimits.MaxEpochGas != nil {
-		return *s.GenesisGasLimits.MaxEpochGas
-	}
-
-	return DefaultMaxEpochGas
+	Name          string
+	Duration      float32
+	NumValidators *int              `yaml:"num_validators,omitempty"`  // nil == 1
+	RoundTripTime *time.Duration    `yaml:"round_trip_time,omitempty"` // nil == 0
+	Nodes         []Node            `yaml:",omitempty"`
+	Applications  []Application     `yaml:",omitempty"`
+	Cheats        []Cheat           `yaml:",omitempty"`
+	NetworkRules  map[string]string `yaml:"network_rules,omitempty"`
 }
 
 func (s *Scenario) GetNumValidators() int {

--- a/driver/parser/parser_test.go
+++ b/driver/parser/parser_test.go
@@ -154,3 +154,26 @@ func TestParseExampleWithCheats(t *testing.T) {
 		t.Fatalf("parsing of input failed: %v", err)
 	}
 }
+
+func TestNetwork_Rules(t *testing.T) {
+	scenario, err := ParseBytes([]byte(networkRules))
+	if err != nil {
+		t.Fatalf("parsing of input failed: %v", err)
+	}
+
+	if val := scenario.NetworkRules["MAX_BLOCK_GAS"]; val != "10_000_000" {
+		t.Errorf("MAX_BLOCK_GAS should be defined")
+	}
+
+	if val := scenario.NetworkRules["MAX_EPOCH_GAS"]; val != "100_000_000" {
+		t.Errorf("MAX_EPOCH_GAS should be defined")
+	}
+}
+
+var networkRules = `
+name: Network Rules Example
+
+network_rules:
+     MAX_BLOCK_GAS: 10_000_000
+     MAX_EPOCH_GAS: 100_000_000
+`

--- a/scenarios/test/baseline_check.yml
+++ b/scenarios/test/baseline_check.yml
@@ -8,6 +8,13 @@ duration: 60
 num_validators: 2
 round_trip_time: "200ms"
 
+# Network rules to be applied to the network.
+# It is an extensible list of key-value pairs.
+network_rules:
+    MAX_BLOCK_GAS: 20500000000
+    MAX_EPOCH_GAS: 1500000000000
+    YET_ANOTHER_RULE: abcd
+
 # In the network there is a single application producing constant load.
 applications:
   - name: load


### PR DESCRIPTION
This PR allows for defining a list of network rules in scenario configuration. 

This is implemented as a free form key-value list to be easily extensible and it does not have to be touched to support additional rules in the future. 

The way of old configuration was removed, it was not used anyway.