### PR TITLE
customise network rules

### DIFF
--- a/genesis/app/genesis_test.go
+++ b/genesis/app/genesis_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/0xsoniclabs/sonic/integration/makefakegenesis"
+	"github.com/urfave/cli/v2"
+	"os"
+	"path"
+	"strings"
+	"testing"
+)
+
+func TestExportGenesis(t *testing.T) {
+	const ValidatorCount = 9
+	const MaxBlockGas = 2000000
+
+	// Create a temporary file
+	tmpFile := path.Join(t.TempDir(), "genesis.json")
+
+	if err := os.Setenv("VALIDATORS_COUNT", fmt.Sprintf("%d", ValidatorCount)); err != nil {
+		t.Fatalf("failed to set VALIDATORS_COUNT: %v", err)
+	}
+	if err := os.Setenv("MAX_BLOCK_GAS", fmt.Sprintf("%d", MaxBlockGas)); err != nil {
+		t.Fatalf("failed to set MAX_BLOCK_GAS: %v", err)
+	}
+
+	defer func() {
+		if err := os.Unsetenv("VALIDATORS_COUNT"); err != nil {
+			t.Errorf("failed to unset VALIDATORS_COUNT: %v", err)
+		}
+
+		if err := os.Unsetenv("MAX_BLOCK_GAS"); err != nil {
+			t.Errorf("failed to unset MAX_BLOCK_GAS: %v", err)
+		}
+	}()
+
+	// Create a new CLI context with the file path argument
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	if err := set.Parse([]string{tmpFile}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+	ctx := cli.NewContext(app, set, nil)
+
+	// Call the exportGenesis function
+	if err := exportGenesis(ctx); err != nil {
+		t.Fatalf("failed to export genesis: %v", err)
+	}
+
+	// Read the generated file
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to read genesis.json: %v", err)
+	}
+
+	// Unmarshal the JSON content
+	var jsonGenesis makefakegenesis.GenesisJson
+	if err := json.Unmarshal(data, &jsonGenesis); err != nil {
+		t.Fatalf("failed to unmarshal genesis.json: %v", err)
+	}
+
+	// Verify network rules were updated
+	if got, want := jsonGenesis.Rules.Blocks.MaxBlockGas, uint64(MaxBlockGas); got != want {
+		t.Errorf("unexpected max block gas, wanted %v, got %v", want, got)
+	}
+
+	// Verify the number of validators
+	var validators int
+	for _, account := range jsonGenesis.Accounts {
+		if strings.HasPrefix(account.Name, "validator_") {
+			validators++
+		}
+	}
+
+	if got, want := validators, ValidatorCount; got != want {
+		t.Errorf("unexpected number of validators, wanted %v, got %v", want, got)
+	}
+}

--- a/genesis/genesis/genesis.go
+++ b/genesis/genesis/genesis.go
@@ -15,20 +15,15 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"math/big"
 	"os"
-	"strconv"
 	"time"
 )
 
 // GenerateJsonGenesis generates a genesis json file with the given number of validators
-// and other configurations.
+// and network rules configurations.
 // The file is written to the given path.
-func GenerateJsonGenesis(jsonFile string) error {
-
-	// configuration is read from environment variables and defaults
-	validatorsCount := os.Getenv("VALIDATORS_COUNT")
-
+func GenerateJsonGenesis(jsonFile string, validatorsCount int, rules *opera.Rules) error {
 	jsonGenesis := makefakegenesis.GenesisJson{
-		Rules:         opera.FakeNetRules(),
+		Rules:         *rules,
 		BlockZeroTime: time.Unix(100, 0), // genesis files in each container must have the same timestamp
 	}
 
@@ -66,14 +61,9 @@ func GenerateJsonGenesis(jsonFile string) error {
 		},
 	}
 
-	validatorsCountInt, err := strconv.ParseInt(validatorsCount, 10, 32)
-	if err != nil {
-		return fmt.Errorf("failed to parse validators count: %w", err)
-	}
-
 	// Create the validator account and provide some tokens.
 	totalSupply := futils.ToFtm(1000_000_000)
-	validators := makefakegenesis.GetFakeValidators(idx.Validator(validatorsCountInt))
+	validators := makefakegenesis.GetFakeValidators(idx.Validator(validatorsCount))
 	supplyEach := new(big.Int).Div(totalSupply, big.NewInt(int64(len(validators))))
 	for _, validator := range validators {
 		jsonGenesis.Accounts = append(jsonGenesis.Accounts, makefakegenesis.Account{

--- a/genesis/genesis/genesis_test.go
+++ b/genesis/genesis/genesis_test.go
@@ -24,16 +24,14 @@ import (
 
 func TestGenerateJsonGenesis(t *testing.T) {
 	// configure expected variables
-	const ValidatorCount = 9
-	if err := os.Setenv("VALIDATORS_COUNT", fmt.Sprintf("%d", ValidatorCount)); err != nil {
-		t.Fatalf("failed to set validator count: %v", err)
-	}
+	const ValidatorsCount = 9
 
 	// Create a temporary file
 	tmpFile := path.Join(t.TempDir(), "genesis.json")
 
 	// Call the GenerateJsonGenesis function
-	if err := GenerateJsonGenesis(tmpFile); err != nil {
+	rules := opera.FakeNetRules()
+	if err := GenerateJsonGenesis(tmpFile, ValidatorsCount, &rules); err != nil {
 		t.Fatalf("failed to generate genesis.json: %v", err)
 	}
 
@@ -67,7 +65,7 @@ func TestGenerateJsonGenesis(t *testing.T) {
 	}
 
 	// add validators to expected accounts
-	validators := makefakegenesis.GetFakeValidators(ValidatorCount)
+	validators := makefakegenesis.GetFakeValidators(ValidatorsCount)
 	totalSupply := utils.ToFtm(1000_000_000)
 	supplyEach := new(big.Int).Div(totalSupply, big.NewInt(int64(len(validators))))
 	for _, validator := range validators {

--- a/genesis/genesis/rules_config.go
+++ b/genesis/genesis/rules_config.go
@@ -27,7 +27,7 @@ var supportedNetworkRulesConfigurations = make(registry)
 // init registers all currently supported network rules.
 func init() {
 	// Blocks
-	register("MAX_BLOCK_GAS", naxBlockGas)
+	register("MAX_BLOCK_GAS", maxBlockGas)
 	register("MAX_EMPTY_BLOCK_SKIP_PERIOD", maxEmptyBlockSkipPeriod)
 
 	// Epochs

--- a/genesis/genesis/rules_config.go
+++ b/genesis/genesis/rules_config.go
@@ -1,0 +1,316 @@
+package genesis
+
+import (
+	"errors"
+	"fmt"
+	"github.com/0xsoniclabs/sonic/inter"
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"math/big"
+	"os"
+	"strconv"
+	"time"
+)
+
+// ruleKeyUpdater is a function that updates a rule in the network rules configuration for the given key.
+type ruleKeyUpdater func(key string, rules *opera.Rules) error
+
+// ruleUpdater is a function that updates a rule in the network rules configuration using the given value.
+type ruleUpdater func(value string, rules *opera.Rules) error
+
+// registry is a map of network rules configuration functions.
+type registry map[string]ruleKeyUpdater
+
+// supportedNetworkRulesConfigurations is a map of currently configured network rules.
+var supportedNetworkRulesConfigurations = make(registry)
+
+// init registers all currently supported network rules.
+func init() {
+	// Blocks
+	register("MAX_BLOCK_GAS", naxBlockGas)
+	register("MAX_EMPTY_BLOCK_SKIP_PERIOD", maxEmptyBlockSkipPeriod)
+
+	// Epochs
+	register("MAX_EPOCH_GAS", maxEpochGas)
+	register("MAX_EPOCH_DURATION", maxEpochDuration)
+
+	// Emitter
+	register("EMITTER_INTERVAL", emitterInterval)
+	register("EMITTER_STALL_THRESHOLD", emitterStallThreshold)
+	register("EMITTER_STALLED_INTERVAL", emitterStallInterval)
+
+	// Upgrades
+	register("UPGRADES_BERLIN", upgradesBerlin)
+	register("UPGRADES_LONDON", upgradesLondon)
+	register("UPGRADES_LLR", upgradesLlr)
+	register("UPGRADES_SONIC", upgradesSonic)
+
+	// Economy
+	register("MIN_GAS_PRICE", minGasPrice)
+	register("MIN_BASE_FEE", minBaseFee)
+	register("BLOCK_MISSED_SLACK", blockMissedSlack)
+	register("MAX_EVENT_GAS", maxEventGas)
+	register("EVENT_GAS", eventGas)
+	register("PARENT_GAS", parentGas)
+	register("EXTRA_DATA_GAS", extraDataGas)
+	register("BLOCK_VOTES_BASE_GAS", blockVotesBaseGas)
+	register("BLOCK_VOTE_GAS", blockVoteGas)
+	register("EPOCH_VOTE_GAS", epochVoteGas)
+	register("MISBEHAVIOUR_PROOF_GAS", misbehaviourProofGas)
+
+	register("SHORT_ALLOC_PER_SEC", shortAllocPerSec)
+	register("SHORT_MAX_ALLOC_PERIOD", shortMaxAllocPeriod)
+	register("SHORT_STARTUP_ALLOC_PERIOD", shortStartupAllocPeriod)
+	register("SHORT_MIN_STARTUP_GAS", shortMinStartupGas)
+
+	register("LONG_ALLOC_PER_SEC", longAllocPerSec)
+	register("LONG_MAX_ALLOC_PERIOD", longMaxAllocPeriod)
+	register("LONG_STARTUP_ALLOC_PERIOD", longStartupAllocPeriod)
+	register("LONG_MIN_STARTUP_GAS", longMinStartupGas)
+
+	// DAG rules
+	register("MAX_PARENTS", maxParents)
+	register("MAX_FREE_PARENTS", maxFreeParents)
+	register("MAX_EXTRA_DATA", maxExtraData)
+}
+
+// ConfigureNetworkRules configures the network rules based on the environment variables
+// applying all registered rules.
+func ConfigureNetworkRules(rules *opera.Rules) error {
+	var errs []error
+	for k, v := range supportedNetworkRulesConfigurations {
+		errs = append(errs, v(k, rules))
+	}
+
+	return errors.Join(errs...)
+}
+
+// register registers a new network rule configuration.
+func register(key string, apply ruleUpdater) {
+	supportedNetworkRulesConfigurations[key] = func(key string, rules *opera.Rules) error {
+		var err error
+		property := os.Getenv(key)
+		// apply only non-empty values
+		if property != "" {
+			err = apply(property, rules)
+		}
+		return err
+	}
+}
+
+var naxBlockGas = func(value string, rules *opera.Rules) (err error) {
+	rules.Blocks.MaxBlockGas, err = strconv.ParseUint(value, 10, 64)
+	return err
+}
+
+var maxEpochGas = func(value string, rules *opera.Rules) (err error) {
+	rules.Epochs.MaxEpochGas, err = strconv.ParseUint(value, 10, 64)
+	return err
+}
+
+var maxEmptyBlockSkipPeriod = func(value string, rules *opera.Rules) error {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return err
+	}
+	rules.Blocks.MaxEmptyBlockSkipPeriod = inter.Timestamp(duration)
+	return err
+}
+
+var maxEpochDuration = func(value string, rules *opera.Rules) error {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return err
+	}
+	rules.Epochs.MaxEpochDuration = inter.Timestamp(duration)
+	return err
+}
+
+var emitterInterval = func(value string, rules *opera.Rules) error {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return err
+	}
+	rules.Emitter.Interval = inter.Timestamp(duration)
+	return err
+}
+
+var emitterStallThreshold = func(value string, rules *opera.Rules) error {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return err
+	}
+	rules.Emitter.StallThreshold = inter.Timestamp(duration)
+	return err
+}
+
+var emitterStallInterval = func(value string, rules *opera.Rules) error {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return err
+	}
+	rules.Emitter.StalledInterval = inter.Timestamp(duration)
+	return err
+}
+
+var upgradesBerlin = func(value string, rules *opera.Rules) error {
+	rules.Upgrades.Berlin = value == "true"
+	return nil
+}
+
+var upgradesLondon = func(value string, rules *opera.Rules) error {
+	rules.Upgrades.London = value == "true"
+	return nil
+}
+
+var upgradesLlr = func(value string, rules *opera.Rules) error {
+	rules.Upgrades.Llr = value == "true"
+	return nil
+}
+
+var upgradesSonic = func(value string, rules *opera.Rules) error {
+	rules.Upgrades.Sonic = value == "true"
+	return nil
+}
+
+var minGasPrice = func(value string, rules *opera.Rules) error {
+	var ok bool
+	var err error
+	number := new(big.Int)
+	rules.Economy.MinGasPrice, ok = number.SetString(value, 10)
+	if !ok {
+		err = fmt.Errorf("cannot parse %s as a number", value)
+	}
+	return err
+}
+
+var minBaseFee = func(value string, rules *opera.Rules) error {
+	var ok bool
+	var err error
+	number := new(big.Int)
+	rules.Economy.MinBaseFee, ok = number.SetString(value, 10)
+	if !ok {
+		err = fmt.Errorf("cannot parse %s as a number", value)
+	}
+	return err
+}
+
+var blockMissedSlack = func(value string, rules *opera.Rules) error {
+	number, err := strconv.ParseUint(value, 10, 64)
+	rules.Economy.BlockMissedSlack = idx.Block(number)
+	return err
+}
+
+var maxEventGas = func(value string, rules *opera.Rules) (err error) {
+	rules.Economy.Gas.MaxEventGas, err = strconv.ParseUint(value, 10, 64)
+	return err
+}
+
+var eventGas = func(value string, rules *opera.Rules) (err error) {
+	rules.Economy.Gas.EventGas, err = strconv.ParseUint(value, 10, 64)
+	return err
+}
+
+var parentGas = func(value string, rules *opera.Rules) (err error) {
+	rules.Economy.Gas.ParentGas, err = strconv.ParseUint(value, 10, 64)
+	return err
+}
+
+var extraDataGas = func(value string, rules *opera.Rules) (err error) {
+	rules.Economy.Gas.ExtraDataGas, err = strconv.ParseUint(value, 10, 64)
+	return err
+}
+
+var blockVotesBaseGas = func(value string, rules *opera.Rules) (err error) {
+	rules.Economy.Gas.BlockVotesBaseGas, err = strconv.ParseUint(value, 10, 64)
+	return err
+}
+
+var blockVoteGas = func(value string, rules *opera.Rules) (err error) {
+	rules.Economy.Gas.BlockVoteGas, err = strconv.ParseUint(value, 10, 64)
+	return err
+}
+
+var epochVoteGas = func(value string, rules *opera.Rules) (err error) {
+	rules.Economy.Gas.EpochVoteGas, err = strconv.ParseUint(value, 10, 64)
+	return err
+}
+
+var misbehaviourProofGas = func(value string, rules *opera.Rules) (err error) {
+	rules.Economy.Gas.MisbehaviourProofGas, err = strconv.ParseUint(value, 10, 64)
+	return err
+}
+
+var shortAllocPerSec = func(value string, rules *opera.Rules) (err error) {
+	rules.Economy.ShortGasPower.AllocPerSec, err = strconv.ParseUint(value, 10, 64)
+	return err
+}
+
+var shortMaxAllocPeriod = func(value string, rules *opera.Rules) (err error) {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return err
+	}
+	rules.Economy.ShortGasPower.MaxAllocPeriod = inter.Timestamp(duration)
+	return nil
+}
+
+var shortStartupAllocPeriod = func(value string, rules *opera.Rules) (err error) {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return err
+	}
+	rules.Economy.ShortGasPower.StartupAllocPeriod = inter.Timestamp(duration)
+	return nil
+}
+
+var shortMinStartupGas = func(value string, rules *opera.Rules) (err error) {
+	rules.Economy.ShortGasPower.MinStartupGas, err = strconv.ParseUint(value, 10, 64)
+	return err
+}
+
+var longAllocPerSec = func(value string, rules *opera.Rules) (err error) {
+	rules.Economy.LongGasPower.AllocPerSec, err = strconv.ParseUint(value, 10, 64)
+	return err
+}
+
+var longMaxAllocPeriod = func(value string, rules *opera.Rules) (err error) {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return err
+	}
+	rules.Economy.LongGasPower.MaxAllocPeriod = inter.Timestamp(duration)
+	return nil
+}
+
+var longStartupAllocPeriod = func(value string, rules *opera.Rules) (err error) {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return err
+	}
+	rules.Economy.LongGasPower.StartupAllocPeriod = inter.Timestamp(duration)
+	return nil
+}
+
+var longMinStartupGas = func(value string, rules *opera.Rules) (err error) {
+	rules.Economy.LongGasPower.MinStartupGas, err = strconv.ParseUint(value, 10, 64)
+	return err
+}
+
+var maxParents = func(value string, rules *opera.Rules) error {
+	number, err := strconv.ParseUint(value, 10, 64)
+	rules.Dag.MaxParents = idx.Event(number)
+	return err
+}
+
+var maxFreeParents = func(value string, rules *opera.Rules) error {
+	number, err := strconv.ParseUint(value, 10, 64)
+	rules.Dag.MaxFreeParents = idx.Event(number)
+	return err
+}
+
+var maxExtraData = func(value string, rules *opera.Rules) error {
+	number, err := strconv.ParseUint(value, 10, 32)
+	rules.Dag.MaxExtraData = uint32(number)
+	return err
+}

--- a/genesis/genesis/rules_config.go
+++ b/genesis/genesis/rules_config.go
@@ -98,7 +98,7 @@ func register(key string, apply ruleUpdater) {
 	}
 }
 
-var naxBlockGas = func(value string, rules *opera.Rules) (err error) {
+var maxBlockGas = func(value string, rules *opera.Rules) (err error) {
 	rules.Blocks.MaxBlockGas, err = strconv.ParseUint(value, 10, 64)
 	return err
 }

--- a/genesis/genesis/rules_config_test.go
+++ b/genesis/genesis/rules_config_test.go
@@ -1,0 +1,405 @@
+package genesis
+
+import (
+	"fmt"
+	"github.com/0xsoniclabs/sonic/opera"
+	"os"
+	"testing"
+)
+
+func TestConfigureNetworkRules_Values_Set(t *testing.T) {
+	defaultRules := opera.MainNetRules()
+
+	tests := []struct {
+		key   string
+		value string
+		match func(rules opera.Rules) (string, bool)
+	}{
+		{
+			key:   "MAX_BLOCK_GAS",
+			value: "2000000",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Blocks.MaxBlockGas), rules.Blocks.MaxBlockGas == 2000000
+			},
+		},
+		{
+			key:   "MAX_EMPTY_BLOCK_SKIP_PERIOD",
+			value: "16ms",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Blocks.MaxEmptyBlockSkipPeriod), rules.Blocks.MaxEmptyBlockSkipPeriod == 16e6
+			},
+		},
+		{
+			key:   "MAX_EPOCH_GAS",
+			value: "30000000",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Epochs.MaxEpochGas), rules.Epochs.MaxEpochGas == 30000000
+			},
+		},
+		{
+			key:   "MAX_EPOCH_DURATION",
+			value: "11s",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Epochs.MaxEpochDuration), rules.Epochs.MaxEpochDuration == 11e9
+			},
+		},
+		{
+			key:   "EMITTER_INTERVAL",
+			value: "5s",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Emitter.Interval), rules.Emitter.Interval == 5e9
+			},
+		},
+		{
+			key:   "EMITTER_STALL_THRESHOLD",
+			value: "2h",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Emitter.StallThreshold), rules.Emitter.StallThreshold == 2*60*60e9
+			},
+		},
+		{
+			key:   "EMITTER_STALLED_INTERVAL",
+			value: "14s",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Emitter.StalledInterval), rules.Emitter.StalledInterval == 14e9
+			},
+		},
+		{
+			key:   "UPGRADES_BERLIN",
+			value: "true",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%t", rules.Upgrades.Berlin), rules.Upgrades.Berlin == true
+			},
+		},
+		{
+			key:   "UPGRADES_LONDON",
+			value: "true",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%t", rules.Upgrades.London), rules.Upgrades.London == true
+			},
+		},
+		{
+			key:   "UPGRADES_LLR",
+			value: "true",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%t", rules.Upgrades.Llr), rules.Upgrades.Llr == true
+			},
+		},
+		{
+			key:   "UPGRADES_SONIC",
+			value: "true",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%t", rules.Upgrades.Sonic), rules.Upgrades.Sonic == true
+			},
+		},
+		{
+			key:   "MIN_GAS_PRICE",
+			value: "1000000001",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.MinGasPrice), rules.Economy.MinGasPrice.Uint64() == 1000000001
+			},
+		},
+		{
+			key:   "MIN_BASE_FEE",
+			value: "1000000002",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.MinBaseFee), rules.Economy.MinBaseFee.Uint64() == 1000000002
+			},
+		},
+		{
+			key:   "BLOCK_MISSED_SLACK",
+			value: "3",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.BlockMissedSlack), rules.Economy.BlockMissedSlack == 3
+			},
+		},
+		{
+			key:   "MAX_EVENT_GAS",
+			value: "1000015",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.Gas.MaxEventGas), rules.Economy.Gas.MaxEventGas == 1000015
+			},
+		},
+		{
+			key:   "EVENT_GAS",
+			value: "1000016",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.Gas.EventGas), rules.Economy.Gas.EventGas == 1000016
+			},
+		},
+		{
+			key:   "PARENT_GAS",
+			value: "1000017",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.Gas.ParentGas), rules.Economy.Gas.ParentGas == 1000017
+			},
+		},
+		{
+			key:   "EXTRA_DATA_GAS",
+			value: "1000018",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.Gas.ExtraDataGas), rules.Economy.Gas.ExtraDataGas == 1000018
+			},
+		},
+		{
+			key:   "BLOCK_VOTES_BASE_GAS",
+			value: "1000019",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.Gas.BlockVotesBaseGas), rules.Economy.Gas.BlockVotesBaseGas == 1000019
+			},
+		},
+		{
+			key:   "BLOCK_VOTE_GAS",
+			value: "1000020",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.Gas.BlockVoteGas), rules.Economy.Gas.BlockVoteGas == 1000020
+			},
+		},
+		{
+			key:   "EPOCH_VOTE_GAS",
+			value: "1000021",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.Gas.EpochVoteGas), rules.Economy.Gas.EpochVoteGas == 1000021
+			},
+		},
+		{
+			key:   "MISBEHAVIOUR_PROOF_GAS",
+			value: "1000022",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.Gas.MisbehaviourProofGas), rules.Economy.Gas.MisbehaviourProofGas == 1000022
+			},
+		},
+		{
+			key:   "SHORT_ALLOC_PER_SEC",
+			value: "1000023",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.ShortGasPower.AllocPerSec), rules.Economy.ShortGasPower.AllocPerSec == 1000023
+			},
+		},
+		{
+			key:   "SHORT_MAX_ALLOC_PERIOD",
+			value: "5s",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.ShortGasPower.MaxAllocPeriod), rules.Economy.ShortGasPower.MaxAllocPeriod == 5e9
+			},
+		},
+		{
+			key:   "SHORT_STARTUP_ALLOC_PERIOD",
+			value: "6s",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.ShortGasPower.StartupAllocPeriod), rules.Economy.ShortGasPower.StartupAllocPeriod == 6e9
+			},
+		},
+		{
+			key:   "SHORT_MIN_STARTUP_GAS",
+			value: "1000026",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.ShortGasPower.MinStartupGas), rules.Economy.ShortGasPower.MinStartupGas == 1000026
+			},
+		},
+		{
+			key:   "LONG_ALLOC_PER_SEC",
+			value: "1000027",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.LongGasPower.AllocPerSec), rules.Economy.LongGasPower.AllocPerSec == 1000027
+			},
+		},
+		{
+			key:   "LONG_MAX_ALLOC_PERIOD",
+			value: "51ms",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.LongGasPower.MaxAllocPeriod), rules.Economy.LongGasPower.MaxAllocPeriod == 51e6
+			},
+		},
+		{
+			key:   "LONG_STARTUP_ALLOC_PERIOD",
+			value: "52ns",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.LongGasPower.StartupAllocPeriod), rules.Economy.LongGasPower.StartupAllocPeriod == 52
+			},
+		},
+		{
+			key:   "LONG_MIN_STARTUP_GAS",
+			value: "1000030",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Economy.LongGasPower.MinStartupGas), rules.Economy.LongGasPower.MinStartupGas == 1000030
+			},
+		},
+		{
+			key:   "MAX_PARENTS",
+			value: "1000031",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Dag.MaxParents), rules.Dag.MaxParents == 1000031
+			},
+		},
+		{
+			key:   "MAX_FREE_PARENTS",
+			value: "1000032",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Dag.MaxFreeParents), rules.Dag.MaxFreeParents == 1000032
+			},
+		},
+		{
+			key:   "MAX_EXTRA_DATA",
+			value: "1000033",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Dag.MaxExtraData), rules.Dag.MaxExtraData == 1000033
+			},
+		},
+		{
+			key:   "MAX_BLOCK_GAS - default",
+			value: "",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Blocks.MaxBlockGas), rules.Blocks.MaxBlockGas == defaultRules.Blocks.MaxBlockGas
+			},
+		},
+		{
+			key:   "MAX_EPOCH_GAS - default",
+			value: "",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%d", rules.Epochs.MaxEpochGas), rules.Epochs.MaxEpochGas == defaultRules.Epochs.MaxEpochGas
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.key, func(t *testing.T) {
+			if err := os.Setenv(test.key, test.value); err != nil {
+				t.Fatalf("failed to set %s: %v", test.key, err)
+			}
+			defer func() {
+				if err := os.Unsetenv(test.key); err != nil {
+					t.Fatalf("failed to unset %s: %v", test.key, err)
+				}
+			}()
+
+			// Create a new Rules object
+			rules := opera.MainNetRules()
+
+			// Call the ConfigureNetworkRules function
+			if err := ConfigureNetworkRules(&rules); err != nil {
+				t.Fatalf("failed to configure network rules: %v", err)
+			}
+
+			// Verify the rules were set correctly
+			if value, ok := test.match(rules); !ok {
+				t.Errorf("unexpected value for %s: got: %s != wanted: %s", test.key, value, test.value)
+			}
+		})
+	}
+}
+
+func TestConfigureNetworkRules_Values_CannotParse(t *testing.T) {
+	tests := []struct {
+		key string
+	}{
+		{
+			key: "MAX_BLOCK_GAS",
+		},
+		{
+			key: "MAX_EPOCH_GAS",
+		},
+		{
+			key: "MAX_EMPTY_BLOCK_SKIP_PERIOD",
+		},
+		{
+			key: "MAX_EPOCH_DURATION",
+		},
+		{
+			key: "EMITTER_INTERVAL",
+		},
+		{
+			key: "EMITTER_STALL_THRESHOLD",
+		},
+		{
+			key: "EMITTER_STALLED_INTERVAL",
+		},
+		{
+			key: "MIN_GAS_PRICE",
+		},
+		{
+			key: "MIN_BASE_FEE",
+		},
+		{
+			key: "BLOCK_MISSED_SLACK",
+		},
+		{
+			key: "MAX_EVENT_GAS",
+		},
+		{
+			key: "EVENT_GAS",
+		},
+		{
+			key: "PARENT_GAS",
+		},
+		{
+			key: "EXTRA_DATA_GAS",
+		},
+		{
+			key: "BLOCK_VOTES_BASE_GAS",
+		},
+		{
+			key: "BLOCK_VOTE_GAS",
+		},
+		{
+			key: "EPOCH_VOTE_GAS",
+		},
+		{
+			key: "MISBEHAVIOUR_PROOF_GAS",
+		},
+		{
+			key: "SHORT_ALLOC_PER_SEC",
+		},
+		{
+			key: "SHORT_MAX_ALLOC_PERIOD",
+		},
+		{
+			key: "SHORT_STARTUP_ALLOC_PERIOD",
+		},
+		{
+			key: "SHORT_MIN_STARTUP_GAS",
+		},
+		{
+			key: "LONG_ALLOC_PER_SEC",
+		},
+		{
+			key: "LONG_MAX_ALLOC_PERIOD",
+		},
+		{
+			key: "LONG_STARTUP_ALLOC_PERIOD",
+		},
+		{
+			key: "LONG_MIN_STARTUP_GAS",
+		},
+		{
+			key: "MAX_PARENTS",
+		},
+		{
+			key: "MAX_FREE_PARENTS",
+		},
+		{
+			key: "MAX_EXTRA_DATA",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.key, func(t *testing.T) {
+			if err := os.Setenv(test.key, "xxx"); err != nil {
+				t.Fatalf("failed to set %s: %v", test.key, err)
+			}
+			defer func() {
+				if err := os.Unsetenv(test.key); err != nil {
+					t.Fatalf("failed to unset %s: %v", test.key, err)
+				}
+			}()
+
+			// Create a new Rules object
+			rules := opera.MainNetRules()
+
+			// Call the ConfigureNetworkRules function
+			if err := ConfigureNetworkRules(&rules); err == nil {
+				t.Errorf("expected an error, got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR allows for customising Network Rules in genesis file.

The rules are read from environment variables and updated in the genesis file generated by the CLI tool. 