### PR TITLE
Kjezek/enable local client build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sonic"]
+	path = sonic
+	url = git@github.com:0xsoniclabs/sonic.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sonic"]
 	path = sonic
-	url = git@github.com:0xsoniclabs/sonic.git
+	url = https://github.com/0xsoniclabs/sonic.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,20 +19,21 @@
 #
 # It checks out the required version of the client, and builds it.
 #
-FROM golang:1.22 AS client-build
+FROM golang:1.24 AS client-build
 
-# Download Sonic dependencies from the default branch first to cache them.
-# We assume tags/branches do not change majority of dependencies.
-RUN git clone https://github.com/0xsoniclabs/sonic.git /client
-
-# Download Client dependencies from the default bracnch
 WORKDIR /client
+
+# Download expected Client version from the outside defined location.
+# The 'client-src' parameter is passed as '--build-context' to the docker build command.
+
+# Download Sonic dependencies first to cache them.
+COPY --from=client-src go.mod .
 RUN go mod download
 
-# Checkout required Client version and build it
-ARG CLIENT_VERSION=main
-WORKDIR /client
-RUN git checkout ${CLIENT_VERSION}
+# Copy the rest of the client source code to build it.
+COPY --from=client-src . .
+
+# Build the client
 RUN --mount=type=cache,target=/root/.cache/go-build make sonicd sonictool
 
 #
@@ -43,7 +44,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build make sonicd sonictool
 #
 # It checks out the local version of the norma, and builds it.
 #
-FROM golang:1.22 AS norma-build
+FROM golang:1.24 AS norma-build
 
 # Download dependencies supporting Sonic run first to cache them for faster build when Norma changes.
 WORKDIR /

--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,16 @@ BUILD_DIR := $(CURDIR)/build
 .PHONY: all test clean
 
 # Define a list of client versions
-CLIENT_VERSIONS := v2.0.2 v2.0.1 v2.0.0
+CLIENT_VERSIONS := v2.0.3 v2.0.2 v2.0.1 v2.0.0
+CLIENT_URL=https://github.com/0xsoniclabs/sonic.git
 
 all: \
     norma \
     pull-hello-world-image \
     pull-alpine-image \
     pull-prometheus-image \
-    build-sonic-docker-image \
+    build-sonic-docker-image-main \
+    build-sonic-docker-image-local \
     $(foreach version, $(CLIENT_VERSIONS), build-sonic-docker-image-$(version)) \
 
 pull-hello-world-image:
@@ -38,12 +40,15 @@ pull-alpine-image:
 pull-prometheus-image:
 	DOCKER_BUILDKIT=1 docker image pull prom/prometheus:v2.44.0
 
-build-sonic-docker-image:
-	DOCKER_BUILDKIT=1 docker build . -t sonic
+build-sonic-docker-image-main:
+	DOCKER_BUILDKIT=1 docker build --build-context client-src=$(CLIENT_URL) . -t sonic
+
+build-sonic-docker-image-local:
+	DOCKER_BUILDKIT=1 docker build --build-context client-src=/Users/kjezek/sonic/sonic . -t sonic:local
 
 # Build various client versions
 $(foreach version, $(CLIENT_VERSIONS), build-sonic-docker-image-$(version)):
-	DOCKER_BUILDKIT=1 docker build --build-arg CLIENT_VERSION=$($(subst build-sonic-docker-image-,,$@)) . -t sonic:$(subst build-sonic-docker-image-,,$@)
+	DOCKER_BUILDKIT=1 docker build --build-context client-src=$(CLIENT_URL)\#$(subst build-sonic-docker-image-,,$@) . -t sonic:$(subst build-sonic-docker-image-,,$@)
 
 generate-abi: load/contracts/abi/Counter.abi load/contracts/abi/ERC20.abi load/contracts/abi/Store.abi load/contracts/abi/UniswapV2Pair.abi load/contracts/abi/UniswapRouter.abi load/contracts/abi/Helper.abi # requires installed solc and Ethereum abigen - check README.md
 
@@ -74,10 +79,10 @@ load/contracts/abi/Helper.abi: load/contracts/Helper.sol
 generate-mocks: # requires installed mockgen
 	go generate ./...
 
-norma: pull-prometheus-image build-sonic-docker-image
+norma: pull-prometheus-image build-sonic-docker-image-main
 	go build -o $(BUILD_DIR)/norma ./driver/norma
 
-test: pull-hello-world-image pull-alpine-image pull-prometheus-image build-sonic-docker-image
+test: pull-hello-world-image pull-alpine-image pull-prometheus-image build-sonic-docker-image-main
 	go test ./... -v
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ build-sonic-docker-image-main:
 	DOCKER_BUILDKIT=1 docker build --build-context client-src=$(CLIENT_URL) . -t sonic
 
 build-sonic-docker-image-local:
-	DOCKER_BUILDKIT=1 docker build --build-context client-src=/Users/kjezek/sonic/sonic . -t sonic:local
+	DOCKER_BUILDKIT=1 docker build --build-context client-src=sonic . -t sonic:local
 
 # Build various client versions
 $(foreach version, $(CLIENT_VERSIONS), build-sonic-docker-image-$(version)):


### PR DESCRIPTION
This PR extends the set of docker images build for the clients of the local one. 

This local instance is added to the project as a git submodule and built as an additional image tagged as `local` .

This image is useful for local development, when the client can be modified, and immediately tested in the Norma network. 