### PR TITLE
extends tests to test correct client version has started

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,6 @@ COPY --from=client-src . .
 # Build the client
 RUN --mount=type=cache,target=/root/.cache/go-build make sonicd sonictool
 
-RUN git branch | grep \* | cut -d ' ' -f2 > sonic_git_version.txt
-
 #
 # Stage 1b: Build Norma related tools supporting Client runs.
 #
@@ -67,7 +65,7 @@ FROM debian:bookworm
 RUN apt-get update && \
     apt-get install iproute2 iputils-ping -y
 
-COPY --from=client-build /client/build/sonicd /client/build/sonictool /client/sonic_git_version.txt ./
+COPY --from=client-build /client/build/sonicd /client/build/sonictool ./
 COPY --from=norma-build /genesistools/build/genesistools ./
 
 ENV STATE_DB_IMPL="geth"

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ COPY --from=client-src . .
 # Build the client
 RUN --mount=type=cache,target=/root/.cache/go-build make sonicd sonictool
 
+RUN git branch | grep \* | cut -d ' ' -f2 > sonic_git_version.txt
+
 #
 # Stage 1b: Build Norma related tools supporting Client runs.
 #
@@ -65,7 +67,7 @@ FROM debian:bookworm
 RUN apt-get update && \
     apt-get install iproute2 iputils-ping -y
 
-COPY --from=client-build /client/build/sonicd /client/build/sonictool ./
+COPY --from=client-build /client/build/sonicd /client/build/sonictool /client/sonic_git_version.txt ./
 COPY --from=norma-build /genesistools/build/genesistools ./
 
 ENV STATE_DB_IMPL="geth"

--- a/scripts/run_sonic_privatenet.sh
+++ b/scripts/run_sonic_privatenet.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "Sonic built from git version: $(cat sonic_git_version.txt)"
+echo "Sonic binary checksum: $(sha256sum   /sonicd | cut -d ' ' -f 1 )"
 
 # Get the local node's IP.
 list=`hostname -I`

--- a/scripts/run_sonic_privatenet.sh
+++ b/scripts/run_sonic_privatenet.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo "Sonic built from git version: $(cat sonic_git_version.txt)"
+
 # Get the local node's IP.
 list=`hostname -I`
 array=($list)


### PR DESCRIPTION
This PR extends testing to assess version of Sonic checked out from git. 

The version is stored in a file in the image and printed out when Sonic starts. 