### PR TITLE
updates network rules configuration to split to genesis and updates

### DIFF
--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -172,13 +172,13 @@ func runScenario(path, outputDir, label string, keepPrometheusRunning, skipCheck
 
 	// Startup network.
 	fmt.Printf("Network RoundTripTime: %v\n", scenario.GetRoundTripTime())
-	for k, v := range scenario.NetworkRules {
+	for k, v := range scenario.NetworkRules.Genesis {
 		fmt.Printf("Network Rule: %s: %s\n", k, v)
 	}
 
 	net, err := local.NewLocalNetwork(&driver.NetworkConfig{
 		Validators:    driver.NewValidators(scenario.Validators),
-		RoundTripTime: scenario.GetRoundTripTime(), NetworkRules: maps.Clone(scenario.NetworkRules),
+		RoundTripTime: scenario.GetRoundTripTime(), NetworkRules: maps.Clone(scenario.NetworkRules.Genesis),
 	})
 	if err != nil {
 		return err

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -31,11 +31,11 @@ type Scenario struct {
 	Name          string
 	Duration      float32
 	Validators    []Validator
-	RoundTripTime *time.Duration    `yaml:"round_trip_time,omitempty"` // nil == 0
-	Nodes         []Node            `yaml:",omitempty"`
-	Applications  []Application     `yaml:",omitempty"`
-	Cheats        []Cheat           `yaml:",omitempty"`
-	NetworkRules  map[string]string `yaml:"network_rules,omitempty"`
+	RoundTripTime *time.Duration `yaml:"round_trip_time,omitempty"` // nil == 0
+	Nodes         []Node         `yaml:",omitempty"`
+	Applications  []Application  `yaml:",omitempty"`
+	Cheats        []Cheat        `yaml:",omitempty"`
+	NetworkRules  NetworkRules   `yaml:"network_rules,omitempty"`
 }
 
 func (s *Scenario) GetRoundTripTime() time.Duration {
@@ -43,6 +43,22 @@ func (s *Scenario) GetRoundTripTime() time.Duration {
 		return *s.RoundTripTime
 	}
 	return 0
+}
+
+// networkRules defines a set of network rules as a key value mapping.
+type networkRules map[string]string
+
+// NetworkRules defines a set of network rules that can be applied to the network.
+// It distinguishes between the genesis rules and a set of updates that can be applied at a specific time.
+type NetworkRules struct {
+	Genesis networkRules         `yaml:",omitempty"`
+	Updates []NetworkRulesUpdate `yaml:",omitempty"`
+}
+
+// NetworkRulesUpdate defines a network rule update that can be applied at a specific time.
+type NetworkRulesUpdate struct {
+	Time  float32
+	Rules networkRules
 }
 
 // Validator is a configuration for a group of network start-up validators.

--- a/driver/parser/parser_test.go
+++ b/driver/parser/parser_test.go
@@ -169,24 +169,57 @@ func TestParseExampleWithCheats(t *testing.T) {
 }
 
 func TestNetwork_Rules(t *testing.T) {
-	scenario, err := ParseBytes([]byte(networkRules))
+	scenario, err := ParseBytes([]byte(networkRulesPayload))
 	if err != nil {
 		t.Fatalf("parsing of input failed: %v", err)
 	}
 
-	if val := scenario.NetworkRules["MAX_BLOCK_GAS"]; val != "10_000_000" {
-		t.Errorf("MAX_BLOCK_GAS should be defined")
+	if got, want := scenario.NetworkRules.Genesis["MAX_BLOCK_GAS"], "20500000000"; got != want {
+		t.Errorf("unexpected value: got: %v, want: %v", got, want)
 	}
 
-	if val := scenario.NetworkRules["MAX_EPOCH_GAS"]; val != "100_000_000" {
-		t.Errorf("MAX_EPOCH_GAS should be defined")
+	if got, want := scenario.NetworkRules.Genesis["MAX_EPOCH_GAS"], "1500000000000"; got != want {
+		t.Errorf("unexpected value: got: %v, want: %v", got, want)
+	}
+
+	if got, want := scenario.NetworkRules.Updates[0].Time, float32(10); got != want {
+		t.Errorf("unexpected value: got: %v, want: %v", got, want)
+	}
+
+	if got, want := scenario.NetworkRules.Updates[0].Rules["MAX_BLOCK_GAS"], "20500000001"; got != want {
+		t.Errorf("unexpected value: got: %v, want: %v", got, want)
+	}
+
+	if got, want := scenario.NetworkRules.Updates[1].Time, float32(30); got != want {
+		t.Errorf("unexpected value: got: %v, want: %v", got, want)
+	}
+
+	if got, want := scenario.NetworkRules.Updates[1].Rules["MAX_EPOCH_GAS"], "1500000000002"; got != want {
+		t.Errorf("unexpected value: got: %v, want: %v", got, want)
+	}
+
+	if got, want := scenario.NetworkRules.Updates[1].Rules["MAX_EPOCH_DURATION"], "10s"; got != want {
+		t.Errorf("unexpected value: got: %v, want: %v", got, want)
 	}
 }
 
-var networkRules = `
+var networkRulesPayload = `
 name: Network Rules Example
 
 network_rules:
-     MAX_BLOCK_GAS: 10_000_000
-     MAX_EPOCH_GAS: 100_000_000
+  genesis:
+      MAX_BLOCK_GAS: 20500000000
+      MAX_EPOCH_GAS: 1500000000000
+      YET_ANOTHER_RULE: abcd
+  updates:
+      - time: 10
+        rules:
+          MAX_BLOCK_GAS: 20500000001
+          YET_ANOTHER_RULE: abcde
+      - time: 30
+        rules:
+          MAX_EPOCH_GAS: 1500000000002
+          MAX_EPOCH_DURATION: 10s
+          YET_ANOTHER_RULE: abcdef
+
 `

--- a/scenarios/test/baseline_check.yml
+++ b/scenarios/test/baseline_check.yml
@@ -15,10 +15,23 @@ validators:
 
 # Network rules to be applied to the network.
 # It is an extensible list of key-value pairs.
+# It defines rules for genesis (network bootstrap)
+# and updates of the rules during the network run.
 network_rules:
+  genesis:
     MAX_BLOCK_GAS: 20500000000
     MAX_EPOCH_GAS: 1500000000000
     YET_ANOTHER_RULE: abcd
+  updates:
+    - time: 10
+      rules:
+        MAX_BLOCK_GAS: 20500000001
+        YET_ANOTHER_RULE: abcde
+    - time: 30
+      rules:
+        MAX_EPOCH_GAS: 1500000000002
+        MAX_EPOCH_DURATION: 10s
+        YET_ANOTHER_RULE: abcdef
 
 # In the network there is a single application producing constant load.
 applications:


### PR DESCRIPTION
This PR extends configuration of network rules. 

It splits definition to two sections: `genesis` and `updates`.

Genesis is applied to the genesis file when starting the nodes while updates contain changes in the rules during the network run.