### PR TITLE
Temporarily Exclude v2.0.3 from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILD_DIR := $(CURDIR)/build
 .PHONY: all test clean
 
 # Define a list of client versions
-CLIENT_VERSIONS := v2.0.3 v2.0.2 v2.0.1 v2.0.0
+CLIENT_VERSIONS := v2.0.2 v2.0.1 v2.0.0
 CLIENT_URL=https://github.com/0xsoniclabs/sonic.git
 
 all: \


### PR DESCRIPTION
This PR removes building of `v2.0.3` temporarily when `make`.

Current image template used to test Norma can hold ~6 sonic images. `make` now produces 7 images and thus results in 
```
17:28:01  197.9 sqlite3-binding.c:257679:1: fatal error: error writing to /tmp/ccj945Bm.s: No space left on device
```

A more permanent solution such as disk increase is being discussed. This is a temporary workaround to make sure that Norma testing pipelines can still function. `v.2.0.3` itself does not indicate concerns, but selected because it's the latest version, and is to be re-added ASAP.

[Test before remove](https://scala.fantom.network/job/Norma/job/RunSingleScenario/100/)
[Test after remove](https://scala.fantom.network/job/Norma/job/RunSingleScenario/101/console)