### PR TITLE
updates dependencies to recent sonic main

### DIFF
--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -23,7 +23,6 @@ import (
 	"github.com/0xsoniclabs/norma/genesistools/genesis"
 	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip/contract/driverauth100"
-	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/opera/contracts/driverauth"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"log"
@@ -286,15 +285,14 @@ func (n *LocalNetwork) ApplyNetworkRules(rules driver.NetworkRules) error {
 		return fmt.Errorf("failed to get driver auth contract representation; %v", err)
 	}
 
-	originalRules := opera.FakeNetRules()
-	diff, err := genesis.GenerateJsonNetworkRulesUpdates(originalRules, genesis.NetworkRules(rules))
+	diff, err := genesis.GenerateJsonFakeNetNetworkRulesUpdates(genesis.NetworkRules(rules))
 	if err != nil {
 		return fmt.Errorf("failed to generate network rules updates; %v", err)
 	}
 
 	// Use Fake ID for the network
 	// Driver owner is the first validator from the list i.e., index 1 (defined in genesis export in genesis.GenerateJsonGenesis)
-	txOpts, err := bind.NewKeyedTransactorWithChainID(evmcore.FakeKey(1), big.NewInt(int64(originalRules.NetworkID)))
+	txOpts, err := bind.NewKeyedTransactorWithChainID(evmcore.FakeKey(1), big.NewInt(int64(fakeNetworkID)))
 	if err != nil {
 		return fmt.Errorf("failed to create txOpts; %v", err)
 	}

--- a/genesis/app/genesis.go
+++ b/genesis/app/genesis.go
@@ -31,7 +31,7 @@ func exportGenesis(ctx *cli.Context) error {
 
 	filePath := ctx.Args().Get(0)
 
-	rules := opera.FakeNetRules()
+	rules := opera.FakeNetRules(opera.SonicFeatures)
 
 	// apply the rules configuration
 	if err := genesis.ConfigureNetworkRulesEnv(&rules); err != nil {

--- a/genesis/genesis/rules_config.go
+++ b/genesis/genesis/rules_config.go
@@ -103,6 +103,14 @@ func ConfigureNetworkRulesMap(rules *opera.Rules, updates map[string]string) err
 	return errors.Join(errs...)
 }
 
+// GenerateJsonFakeNetNetworkRulesUpdates generates a JSON string with the differences between the original network rules
+// and the updated network rules configuration, provided on the input.
+// This function uses the default fake network rules as the original configuration.
+func GenerateJsonFakeNetNetworkRulesUpdates(updates NetworkRules) (string, error) {
+	originalRules := opera.FakeNetRules(opera.SonicFeatures)
+	return GenerateJsonNetworkRulesUpdates(originalRules, updates)
+}
+
 // GenerateJsonNetworkRulesUpdates generates a JSON string with the differences between the original network rules
 // and the updated network rules configuration, provided on the input.
 func GenerateJsonNetworkRulesUpdates(rules opera.Rules, updates NetworkRules) (string, error) {

--- a/genesis/genesis/rules_config_test.go
+++ b/genesis/genesis/rules_config_test.go
@@ -812,6 +812,28 @@ func TestGenerateJsonNetworkRulesUpdates_Exported_Json_Correct(t *testing.T) {
 		}
 	})
 
+	t.Run("single - fakenet rules", func(t *testing.T) {
+		for _, test := range tests {
+			t.Run(test.key, func(t *testing.T) {
+				updates := make(NetworkRules)
+				updates[test.key] = test.value
+				gotJson, err := GenerateJsonFakeNetNetworkRulesUpdates(updates)
+				if err != nil {
+					t.Fatalf("failed to generate json: %v", err)
+				}
+
+				b, err := json.Marshal(test.json)
+				if err != nil {
+					t.Fatalf("failed to marshal json: %v", err)
+				}
+
+				if got, want := gotJson, string(b); got != want {
+					t.Errorf("unexpected json: got: %s != want: %s", got, want)
+				}
+			})
+		}
+	})
+
 	t.Run("multiple", func(t *testing.T) {
 		// collect changes from all tests and merge them all to one update set
 		updates := make(NetworkRules)

--- a/genesis/go.mod
+++ b/genesis/go.mod
@@ -3,7 +3,7 @@ module github.com/0xsoniclabs/norma/genesistools
 go 1.24.0
 
 require (
-	github.com/0xsoniclabs/sonic v0.0.0-20250307103210-6c3036738d08
+	github.com/0xsoniclabs/sonic v0.0.0-20250312080804-b5d41c48e0a1
 	github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00
 	github.com/ethereum/go-ethereum v1.15.0
 	github.com/stretchr/testify v1.9.0

--- a/genesis/go.sum
+++ b/genesis/go.sum
@@ -4,6 +4,8 @@ github.com/0xsoniclabs/go-ethereum v0.0.0-20250210213022-86eca3554809 h1:MtKV0hC
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250210213022-86eca3554809/go.mod h1:9SAhGia6ukqZnvwJ3npNEmQDFjusZ/vXgbU1Z7J1vhw=
 github.com/0xsoniclabs/sonic v0.0.0-20250307103210-6c3036738d08 h1:EXlNbD+K1zu4JuDy8c4YXF0hthEjLRlMMWDPWKsh97w=
 github.com/0xsoniclabs/sonic v0.0.0-20250307103210-6c3036738d08/go.mod h1:q3YvXU/c4nUzDEANwtFi+xr9rluIgmfNDDfanMzfpSg=
+github.com/0xsoniclabs/sonic v0.0.0-20250312080804-b5d41c48e0a1 h1:bOHX3BKRdRil3nM4TMjR9x8xKx0ayyM2kd/+J61Ox1I=
+github.com/0xsoniclabs/sonic v0.0.0-20250312080804-b5d41c48e0a1/go.mod h1:q3YvXU/c4nUzDEANwtFi+xr9rluIgmfNDDfanMzfpSg=
 github.com/0xsoniclabs/tosca v0.0.0-20250221124739-3aac4e7427dc h1:3JvCgp/G+0VQCz74vXKjH475/JvCM7r1Kny0wzUN7TI=
 github.com/0xsoniclabs/tosca v0.0.0-20250221124739-3aac4e7427dc/go.mod h1:vc9gDLnHywVth6uaAt1G4GarSy1tYZpVMvgsG/qhjgU=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/0xsoniclabs/norma/genesistools v0.0.0-20250218144827-28263a9a85f9
-	github.com/0xsoniclabs/sonic v0.0.0-20250307103210-6c3036738d08
+	github.com/0xsoniclabs/sonic v0.0.0-20250312080804-b5d41c48e0a1
 	github.com/docker/docker v27.3.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/ethereum/go-ethereum v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/0xsoniclabs/go-ethereum v0.0.0-20250210213022-86eca3554809 h1:MtKV0hC
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250210213022-86eca3554809/go.mod h1:9SAhGia6ukqZnvwJ3npNEmQDFjusZ/vXgbU1Z7J1vhw=
 github.com/0xsoniclabs/sonic v0.0.0-20250307103210-6c3036738d08 h1:EXlNbD+K1zu4JuDy8c4YXF0hthEjLRlMMWDPWKsh97w=
 github.com/0xsoniclabs/sonic v0.0.0-20250307103210-6c3036738d08/go.mod h1:q3YvXU/c4nUzDEANwtFi+xr9rluIgmfNDDfanMzfpSg=
+github.com/0xsoniclabs/sonic v0.0.0-20250312080804-b5d41c48e0a1 h1:bOHX3BKRdRil3nM4TMjR9x8xKx0ayyM2kd/+J61Ox1I=
+github.com/0xsoniclabs/sonic v0.0.0-20250312080804-b5d41c48e0a1/go.mod h1:q3YvXU/c4nUzDEANwtFi+xr9rluIgmfNDDfanMzfpSg=
 github.com/0xsoniclabs/tosca v0.0.0-20250221124739-3aac4e7427dc h1:3JvCgp/G+0VQCz74vXKjH475/JvCM7r1Kny0wzUN7TI=
 github.com/0xsoniclabs/tosca v0.0.0-20250221124739-3aac4e7427dc/go.mod h1:vc9gDLnHywVth6uaAt1G4GarSy1tYZpVMvgsG/qhjgU=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=


### PR DESCRIPTION
This PR updates dependencies to Sonic client to the recent main. 

It also removes the dependency to `opera.FakeNetRules` from the Norma main module. 