### PR TITLE
Switch to use dynamic gas price transactions in load generators

### DIFF
--- a/load/app/app.go
+++ b/load/app/app.go
@@ -17,8 +17,6 @@
 package app
 
 import (
-	"math/big"
-
 	"github.com/0xsoniclabs/norma/driver/rpc"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -38,6 +36,6 @@ type Application interface {
 // User produces a stream of transactions to Generate traffic on the chain.
 // Implementations are not required to be thread-safe.
 type User interface {
-	GenerateTx(currentGasPrice *big.Int) (*types.Transaction, error)
+	GenerateTx() (*types.Transaction, error)
 	GetSentTransactions() uint64
 }

--- a/load/app/app_mock.go
+++ b/load/app/app_mock.go
@@ -26,7 +26,6 @@
 package app
 
 import (
-	big "math/big"
 	reflect "reflect"
 
 	rpc "github.com/0xsoniclabs/norma/driver/rpc"
@@ -111,18 +110,18 @@ func (m *MockUser) EXPECT() *MockUserMockRecorder {
 }
 
 // GenerateTx mocks base method.
-func (m *MockUser) GenerateTx(currentGasPrice *big.Int) (*types.Transaction, error) {
+func (m *MockUser) GenerateTx() (*types.Transaction, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateTx", currentGasPrice)
+	ret := m.ctrl.Call(m, "GenerateTx")
 	ret0, _ := ret[0].(*types.Transaction)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GenerateTx indicates an expected call of GenerateTx.
-func (mr *MockUserMockRecorder) GenerateTx(currentGasPrice any) *gomock.Call {
+func (mr *MockUserMockRecorder) GenerateTx() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateTx", reflect.TypeOf((*MockUser)(nil).GenerateTx), currentGasPrice)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateTx", reflect.TypeOf((*MockUser)(nil).GenerateTx))
 }
 
 // GetSentTransactions mocks base method.

--- a/load/app/app_test.go
+++ b/load/app/app_test.go
@@ -94,11 +94,7 @@ func testGenerator(t *testing.T, app app.Application, ctxt app.AppContext) {
 	numTransactions := 10
 	transactions := []*types.Transaction{}
 	for range numTransactions {
-		price, err := rpcClient.SuggestGasPrice(context.Background())
-		if err != nil {
-			return
-		}
-		tx, err := user.GenerateTx(price)
+		tx, err := user.GenerateTx()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/load/app/counter_app.go
+++ b/load/app/counter_app.go
@@ -120,7 +120,7 @@ type CounterUser struct {
 	sentTxs  atomic.Uint64
 }
 
-func (g *CounterUser) GenerateTx(currentGasPrice *big.Int) (*types.Transaction, error) {
+func (g *CounterUser) GenerateTx() (*types.Transaction, error) {
 	// prepare tx data
 	data, err := g.abi.Pack("incrementCounter")
 	if err != nil || data == nil {
@@ -129,7 +129,7 @@ func (g *CounterUser) GenerateTx(currentGasPrice *big.Int) (*types.Transaction, 
 
 	// prepare tx
 	const gasLimit = 28036
-	tx, err := createTx(g.sender, g.contract, big.NewInt(0), data, currentGasPrice, gasLimit)
+	tx, err := createTx(g.sender, g.contract, big.NewInt(0), data, gasLimit)
 	if err == nil {
 		g.sentTxs.Add(1)
 	}

--- a/load/app/erc20_app.go
+++ b/load/app/erc20_app.go
@@ -169,7 +169,7 @@ type ERC20User struct {
 	sentTxs    uint64
 }
 
-func (g *ERC20User) GenerateTx(currentGasPrice *big.Int) (*types.Transaction, error) {
+func (g *ERC20User) GenerateTx() (*types.Transaction, error) {
 	// choose random recipient
 	recipient := g.recipients[rand.Intn(len(g.recipients))]
 
@@ -181,7 +181,7 @@ func (g *ERC20User) GenerateTx(currentGasPrice *big.Int) (*types.Transaction, er
 
 	// prepare tx
 	const gasLimit = 52000 // Transfer method call takes 51349 of gas
-	tx, err := createTx(g.sender, g.contract, big.NewInt(0), data, currentGasPrice, gasLimit)
+	tx, err := createTx(g.sender, g.contract, big.NewInt(0), data, gasLimit)
 	if err == nil {
 		atomic.AddUint64(&g.sentTxs, 1)
 	}

--- a/load/app/store_app.go
+++ b/load/app/store_app.go
@@ -120,7 +120,7 @@ type StoreUser struct {
 	sentTxs  atomic.Uint64
 }
 
-func (g *StoreUser) GenerateTx(currentGasPrice *big.Int) (*types.Transaction, error) {
+func (g *StoreUser) GenerateTx() (*types.Transaction, error) {
 	const updateSize = 260 // ~ 1 GB/minute new netto data at 1000 Tx/s
 
 	// prepare tx data -- since as single put is rather cheap, we use the 'fill' operation
@@ -136,7 +136,7 @@ func (g *StoreUser) GenerateTx(currentGasPrice *big.Int) (*types.Transaction, er
 
 	// prepare tx
 	const gasLimit = 52000 + 25000*updateSize // wild guess ...
-	tx, err := createTx(g.sender, g.contract, big.NewInt(0), data, currentGasPrice, gasLimit)
+	tx, err := createTx(g.sender, g.contract, big.NewInt(0), data, gasLimit)
 	if err == nil {
 		g.sentTxs.Add(1)
 	}

--- a/load/app/uniswap_app.go
+++ b/load/app/uniswap_app.go
@@ -268,7 +268,7 @@ type UniswapUser struct {
 	sentTxs                 uint64
 }
 
-func (g *UniswapUser) GenerateTx(currentGasPrice *big.Int) (*types.Transaction, error) {
+func (g *UniswapUser) GenerateTx() (*types.Transaction, error) {
 	var data []byte
 	var err error
 
@@ -287,7 +287,7 @@ func (g *UniswapUser) GenerateTx(currentGasPrice *big.Int) (*types.Transaction, 
 	// prepare tx
 	// swapExactTokensForTokens consumes 157571 for 2 tokens + cca 94314 for each additional token
 	const gasLimit = 160_000 + (TokensInChain-2)*95000
-	tx, err := createTx(g.sender, g.routerAddress, big.NewInt(0), data, currentGasPrice, gasLimit)
+	tx, err := createTx(g.sender, g.routerAddress, big.NewInt(0), data, gasLimit)
 	if err == nil {
 		atomic.AddUint64(&g.sentTxs, 1)
 	}

--- a/load/controller/controller_test.go
+++ b/load/controller/controller_test.go
@@ -79,7 +79,7 @@ func TestLoadGeneration_CanRealizeConstantTrafficShape(t *testing.T) {
 			application.EXPECT().CreateUsers(gomock.Any(), 100).AnyTimes().Return(users, nil)
 
 			rpcClient.EXPECT().SuggestGasPrice(gomock.Any()).AnyTimes().Return(big.NewInt(0), nil)
-			user.EXPECT().GenerateTx(gomock.Any()).AnyTimes().Return(&transaction, nil)
+			user.EXPECT().GenerateTx().AnyTimes().Return(&transaction, nil)
 
 			clientFactory := app.NewMockRpcClientFactory(ctrl)
 			clientFactory.EXPECT().DialRandomRpc().AnyTimes().Return(rpcClient, nil)

--- a/load/controller/generator.go
+++ b/load/controller/generator.go
@@ -25,20 +25,7 @@ import (
 
 func runGeneratorLoop(user app.User, trigger <-chan struct{}, network driver.Network) {
 	for range trigger {
-		// retrieve gas price for each tx individually as the gasPrice can change by amount of time passed(larger db size),
-		// or by new validator registration, etc.
-		rpcClient, err := network.DialRandomRpc()
-		if err != nil {
-			log.Printf("generator loop; failed to dial random rpc; %v", err)
-			continue
-		}
-		currentRegularGasPrice, err := app.GetGasPrice(rpcClient)
-		if err != nil {
-			log.Printf("generator loop; failed to get gas price; %v", err)
-			continue
-		}
-
-		tx, err := user.GenerateTx(currentRegularGasPrice)
+		tx, err := user.GenerateTx()
 		if err != nil {
 			log.Printf("failed to generate tx; %v", err)
 		} else {

--- a/load/controller/mocked_test.go
+++ b/load/controller/mocked_test.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"math/big"
 	"testing"
 	"time"
 
@@ -40,22 +39,18 @@ func TestMockedTrafficGenerating(t *testing.T) {
 	mockUser := app.NewMockUser(mockCtrl)
 
 	mockedRpcClient := rpc.NewMockRpcClient(mockCtrl)
-	mockedRpcClient.EXPECT().SuggestGasPrice(gomock.Any()).Return(big.NewInt(0), nil)
 	mockedRpcClient.EXPECT().Close()
 
 	appContext := app.NewMockAppContext(mockCtrl)
 	appContext.EXPECT().GetClient().Return(mockedRpcClient).AnyTimes()
 
 	mockedNetwork := driver.NewMockNetwork(mockCtrl)
-	mockedNetwork.EXPECT().DialRandomRpc().Return(mockedRpcClient, nil)
 
 	mockedApp := app.NewMockApplication(mockCtrl)
 	mockedApp.EXPECT().CreateUsers(appContext, numUsers).Return([]app.User{mockUser, mockUser}, nil)
 
 	// app should be called 10-times to generate 10 txs
-	mockedNetwork.EXPECT().DialRandomRpc().Return(mockedRpcClient, nil).MaxTimes(11)
-	mockedRpcClient.EXPECT().SuggestGasPrice(gomock.Any()).Return(big.NewInt(0), nil).MaxTimes(11)
-	mockUser.EXPECT().GenerateTx(gomock.Any()).Return(&demoTx, nil).MinTimes(5).MaxTimes(11)
+	mockUser.EXPECT().GenerateTx().Return(&demoTx, nil).MinTimes(5).MaxTimes(11)
 	// network should be called 10-times to send 10 txs
 	mockedNetwork.EXPECT().SendTransaction(&demoTx).MinTimes(5).MaxTimes(11)
 


### PR DESCRIPTION
This PR replaces the utilization of `LegacyTx` transactions with `DynamicFee` transactions in the load generators. This change eliminates the need for fetching an estimated gas price from the network before sending a transaction. The `DynamicFee` type of transaction will automatically adjust the gas price to the base-fee level at the time of its execution.

This change was motivated by problems encountered during stress tests, in which load generators started to fail producing transactions because the RPC service used to obtain gas-price predictions could not respond fast enough. By eliminating the need for fetching the gas price, this problem could be resolved.

A positive side effect of this is that load-tests are now more accurately representing the load case of validator nodes as the overhead of serving gas-price estimations is eliminated. Before this change, this included the need to create a client connection and to run a RPC request. This is not what a validator node would typically be expected to be confronted with, as validator nodes are recommended not to expose an RPC interface.

