### PR TITLE
remove feature configuration from scenario node

### DIFF
--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -74,7 +74,6 @@ type Validator struct {
 // times to create larger, homogenious groups easier.
 type Node struct {
 	Name      string
-	Features  []string
 	Instances *int       `yaml:",omitempty"` // nil is interpreted as 1
 	Start     *float32   `yaml:",omitempty"` // nil is interpreted as 0
 	End       *float32   `yaml:",omitempty"` // nil is interpreted as end-of-scenario
@@ -100,16 +99,6 @@ func (n *Node) IsStaticValidator(s *Scenario) bool {
 	}
 
 	return n.IsValidator() && start == float32(0) && end == s.Duration
-}
-
-// IsCheater returns true if the node is defined as cheater in Features
-func (n *Node) IsCheater() bool {
-	for _, item := range n.Features {
-		if item == "cheater" {
-			return true
-		}
-	}
-	return false
 }
 
 // ClientType is an optional configuration for Node.

--- a/driver/parser/parser_test.go
+++ b/driver/parser/parser_test.go
@@ -73,9 +73,6 @@ validators:
 nodes:
   - name: A
     instances: 10
-    features:
-      - validator
-      - archive
     start: 5
     end: 7.5
 
@@ -116,9 +113,6 @@ validators:
 nodes:
   - name: A
     instances: 10
-    features:
-      - validator
-      - archive
     start: 5
     end: 7.5
     client:

--- a/scenarios/test/client_version_updates.yml
+++ b/scenarios/test/client_version_updates.yml
@@ -23,8 +23,7 @@ nodes:
     start: 60
     client:
       imagename: "sonic:latest"
-    features:
-      - validator
+      type: validator
 
   - name: node-latest-observer
     instances: 2

--- a/scenarios/test/nodes_start_stop.yml
+++ b/scenarios/test/nodes_start_stop.yml
@@ -16,13 +16,15 @@ nodes:
     start: 20
     end: 120
     instances: 2
-    features: [ validator ]
+    client:
+      type: validator
 
   - name: validator-B
     start: 40
     end: 80
     instances: 1
-    features: [ validator ]
+    client:
+      type: validator
 
   - name: observer-A
     start: 80
@@ -43,7 +45,8 @@ nodes:
     start: 140
     end: 200
     instances: 2
-    features: [ validator ]
+    client:
+      type: validator
 
 
 # In the network, there is a single application producing a constant load.


### PR DESCRIPTION
This PR removes the `feature` construct from node configuration. It did nothing and was confusing that it actually does not configure anything. In particular, validator nodes are configured differently. 