### PR TITLE
creates scenario for hardfork

### DIFF
--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -317,7 +317,7 @@ func scheduleCheatEvents(cheat *parser.Cheat, queue *eventQueue, net driver.Netw
 
 // scheduleNetworkRulesEvents schedules an event to apply network rules at a given time.
 func scheduleNetworkRulesEvents(rule parser.NetworkRulesUpdate, queue *eventQueue, network driver.Network) {
-	queue.add(toSingleEvent(Seconds(rule.Time), "Applying network rules", func() error {
+	queue.add(toSingleEvent(Seconds(rule.Time), fmt.Sprintf("Applying network rules: %v", rule.Rules), func() error {
 		return network.ApplyNetworkRules(driver.NetworkRules(rule.Rules))
 	}))
 }

--- a/genesis/genesis/rules_config.go
+++ b/genesis/genesis/rules_config.go
@@ -45,6 +45,7 @@ func init() {
 	register("UPGRADES_LONDON", upgradesLondon)
 	register("UPGRADES_LLR", upgradesLlr)
 	register("UPGRADES_SONIC", upgradesSonic)
+	register("UPGRADES_ALLEGRO", upgradesAllegro)
 
 	// Economy
 	register("MIN_GAS_PRICE", minGasPrice)
@@ -254,6 +255,11 @@ var upgradesLlr = func(value string, rules *opera.Rules) error {
 
 var upgradesSonic = func(value string, rules *opera.Rules) error {
 	rules.Upgrades.Sonic = value == "true"
+	return nil
+}
+
+var upgradesAllegro = func(value string, rules *opera.Rules) error {
+	rules.Upgrades.Allegro = value == "true"
 	return nil
 }
 

--- a/scenarios/test/network_hardfork.yml
+++ b/scenarios/test/network_hardfork.yml
@@ -1,0 +1,48 @@
+# This scenario simulates a network with running recent client versions from the start.
+# At some point it enables hardfork verifying that the clients are able to handle the hardfork.
+
+# The name of the scenario
+name: Network Hardfork
+
+# The duration of the scenario's runtime, in seconds.
+duration: 180
+
+# Initial validator nodes in the network.
+validators:
+  - name: validators
+    instances: 3
+    imagename: "sonic:latest"
+#  - name: validator-v2.0.2
+#    imagename: "sonic:v2.0.2"   # this node should stop working after the hardfork - not supported to check this in Norma
+
+# Start with the hardfork disabled
+# while enabling the hardfork later
+network_rules:
+  genesis:
+    UPGRADES_SONIC: true
+    UPGRADES_ALLEGRO: false
+    MAX_EPOCH_DURATION: 3s
+  updates:
+    - time: 60
+      rules:
+        UPGRADES_ALLEGRO: true  # hardfork enabled
+
+# In the network, there is a few applications producing the load.
+applications:
+  - name: counter
+    type: counter
+    users: 10           # number of users using the app
+    rate:
+      constant: 1    # Tx/s
+
+  - name: erc20
+    type: erc20
+    users: 10           # number of users using the app
+    rate:
+      constant: 1     # Tx/s
+
+  - name: uniswap
+    type: uniswap
+    users: 10           # number of users using the app
+    rate:
+      constant: 1     # Tx/s


### PR DESCRIPTION
This PR adds a new scenario that simulates a hardfork.
It updates network rules to enable Allegro in the network of running nodes and verifies that the nodes keep running. 

This PR also extends supported network rule changes. 

There is also an idea to show that an older node fails after network update, but it is not available in Norma at the moment. 