### PR TITLE
removes unused nodes list

### DIFF
--- a/driver/monitoring/node_log_provider_test.go
+++ b/driver/monitoring/node_log_provider_test.go
@@ -75,14 +75,6 @@ func TestRegisterLogParser(t *testing.T) {
 		blockEqual(t, node, got, want)
 	}
 
-	if reg.getNumNodes() != 3 {
-		t.Errorf("wrong size")
-	}
-
-	if len(reg.getNodes()) != 3 {
-		t.Errorf("wrong number of iterations")
-	}
-
 	// Check that log got copied to output files.
 	logs := []struct {
 		path, content string


### PR DESCRIPTION
This PR simplifies code of `NodeLogParser`. It removes the internal list of `nodes` registered in this parser, as it was not used for any meaningful purpose. 