### PR TITLE
extends re-try mechanism for getting tx receipt

### DIFF
--- a/driver/rpc/rpc.go
+++ b/driver/rpc/rpc.go
@@ -49,7 +49,7 @@ func WrapRpcClient(rpcClient *rpc.Client) *Impl {
 	return &Impl{
 		ethRpcClient:     ethclient.NewClient(rpcClient),
 		rpcClient:        rpcClient,
-		txReceiptTimeout: 180 * time.Second,
+		txReceiptTimeout: 600 * time.Second,
 	}
 }
 

--- a/driver/rpc/rpc.go
+++ b/driver/rpc/rpc.go
@@ -49,7 +49,7 @@ func WrapRpcClient(rpcClient *rpc.Client) *Impl {
 	return &Impl{
 		ethRpcClient:     ethclient.NewClient(rpcClient),
 		rpcClient:        rpcClient,
-		txReceiptTimeout: 60 * time.Second,
+		txReceiptTimeout: 180 * time.Second,
 	}
 }
 


### PR DESCRIPTION
This PR extends timeout to get transaction receipt. We had recently failing jenkins builds caused by timeouts. The timeout was increased 10times. 