### PR TITLE
introduces scenario to update min base fee

### DIFF
--- a/scenarios/test/min_base_fee_update.yml
+++ b/scenarios/test/min_base_fee_update.yml
@@ -1,0 +1,52 @@
+# This scenario tests update of base fee.
+# It tries this update on a network with
+# pre-Allegro and Allegro nodes.
+# Since this update process has been changed,
+# the network has to split.
+# It is an unwanted behavior that must be avoided
+# in the real network.
+
+# The name of the scenario
+name: Base Fee Network Split
+
+# The duration of the scenario's runtime, in seconds.
+duration: 180
+
+# Initial validator nodes in the network.
+validators:
+  - name: validator-v2.0.4
+    imagename: "sonic:v2.0.3"
+  - name: validator-allegro
+    imagename: "sonic"
+
+# Update the base fee on the network.
+network_rules:
+  genesis:
+    MAX_EPOCH_DURATION: 1h        # there will be only one epoch within the scenario
+    MIN_BASE_FEE: 2000000000
+    UPGRADES_SONIC: true
+    UPGRADES_ALLEGRO: false   # the older client does not support Allegro
+  updates:
+    - time: 60
+      rules:
+        MIN_BASE_FEE: 3000000000
+
+# In the network, there is a few applications producing the load.
+applications:
+  - name: counter
+    type: counter
+    users: 10           # number of users using the app
+    rate:
+      constant: 10    # Tx/s
+
+  - name: erc20
+    type: erc20
+    users: 10           # number of users using the app
+    rate:
+      constant: 10     # Tx/s
+
+  - name: uniswap
+    type: uniswap
+    users: 10           # number of users using the app
+    rate:
+      constant: 10     # Tx/s

--- a/scenarios/test/min_base_fee_update.yml
+++ b/scenarios/test/min_base_fee_update.yml
@@ -14,7 +14,7 @@ duration: 180
 
 # Initial validator nodes in the network.
 validators:
-  - name: validator-v2.0.4
+  - name: validator-v2.0.3
     imagename: "sonic:v2.0.3"
   - name: validator-allegro
     imagename: "sonic"


### PR DESCRIPTION
this PR introduces a new scenario that updates `minBaseFee`.

It is supposed to test if this network rule does not cause network split when applied to old and a new client