### PR TITLE
adds scenarios for upgrades with min base fee

### DIFF
--- a/scenarios/test/base_fee_add_new_client.yml
+++ b/scenarios/test/base_fee_add_new_client.yml
@@ -1,0 +1,53 @@
+# This scenario simulates a network with running old client versions from the start.
+# It starts later updated versions of the client to make sure the update succeeds.
+
+# The name of the scenario
+name: Network Updates Base Fee
+
+# The duration of the scenario's runtime, in seconds.
+duration: 180
+
+# There was a min base fee behaviour update between client versions
+network_rules:
+  genesis:
+    UPGRADES_SONIC: true
+    UPGRADES_ALLEGRO: false
+    MIN_BASE_FEE: 1000000000
+  updates:
+    - time: 20
+      rules:
+        MIN_BASE_FEE: 1000000000000
+
+# Initial validator nodes in the network.
+validators:
+  - name: validator-v2.0.2
+    imagename: "sonic:v2.0.2"
+
+# Append updated nodes in the network.
+nodes:
+  - name: node-latest
+    instances: 1
+    start: 60   # will start when the base fee is already updated
+    client:
+      imagename: "sonic"
+      type: validator
+
+# In the network, there is a few applications producing the load.
+applications:
+  - name: counter
+    type: counter
+    users: 10           # number of users using the app
+    rate:
+      constant: 10    # Tx/s
+
+  - name: erc20
+    type: erc20
+    users: 10           # number of users using the app
+    rate:
+      constant: 10     # Tx/s
+
+  - name: uniswap
+    type: uniswap
+    users: 10           # number of users using the app
+    rate:
+      constant: 10     # Tx/s

--- a/scenarios/test/base_fee_add_older_client.yml
+++ b/scenarios/test/base_fee_add_older_client.yml
@@ -1,0 +1,53 @@
+# This scenario simulates a network with running recent client versions from the start.
+# It starts later an older versions of the client to make sure the update succeeds.
+
+# The name of the scenario
+name: Network Updates Base Fee
+
+# The duration of the scenario's runtime, in seconds.
+duration: 180
+
+# There was a min base fee behaviour update between client versions
+network_rules:
+  genesis:
+    UPGRADES_SONIC: true
+    UPGRADES_ALLEGRO: false
+    MIN_BASE_FEE: 1000000000
+  updates:
+    - time: 20
+      rules:
+        MIN_BASE_FEE: 1000000000000
+
+# Initial validator nodes in the network.
+validators:
+  - name: validator-latest
+    imagename: "sonic"
+
+# Append updated nodes in the network.
+nodes:
+  - name: node-v202
+    instances: 1
+    start: 60   # will start when the base fee is already updated
+    client:
+      imagename: "sonic:v2.0.2"
+      type: validator
+
+# In the network, there is a few applications producing the load.
+applications:
+  - name: counter
+    type: counter
+    users: 10           # number of users using the app
+    rate:
+      constant: 10    # Tx/s
+
+  - name: erc20
+    type: erc20
+    users: 10           # number of users using the app
+    rate:
+      constant: 10     # Tx/s
+
+  - name: uniswap
+    type: uniswap
+    users: 10           # number of users using the app
+    rate:
+      constant: 10     # Tx/s


### PR DESCRIPTION
This PR adds two more scenarios:
* update of an client when the base fee was changed 
* adding an older client to a network running a new client when the base fee was changed