### PR TITLE
PR test now sequential

### DIFF
--- a/PR.jenkinsfile
+++ b/PR.jenkinsfile
@@ -43,8 +43,8 @@ pipeline {
 
 		stage('Test Norma') {
 			steps {
-			    sh 'cd genesis && go test ./...'
-				sh 'go test ./...  -p 2 --parallel 2 --timeout 30m'
+				sh 'cd genesis && go test ./...'
+				sh 'go test ./... -v -p 1 --parallel 1 --timeout 30m'
 			}
 		}
 	}


### PR DESCRIPTION
Currently there's a consistent failure of the following type across multiple tests:
```
failed to create an Opera node on Docker: failed to get node online
```

Local tests suggest that failure happens when multiple tests ran in parallel (and thus the machine ran out of resource to handle simultaneous containers)

This PR checks if this is true on test infrastructure as well.