### PR TITLE
Executor and Parser now aware of advance epoch

### DIFF
--- a/driver/executor/executor_test.go
+++ b/driver/executor/executor_test.go
@@ -279,3 +279,32 @@ func (e *is[T]) String() string {
 func newIs[T any](node T) *is[T] {
 	return &is[T]{node}
 }
+
+func TestExecutor_scheduleAdvanceEpochEvents(t *testing.T) {
+	one, three, five, seven := 1, 3, 5, 7
+
+	clock := NewSimClock()
+	scenario := parser.Scenario{
+		Name:     "Test",
+		Duration: 10,
+		AdvanceEpoch: []parser.AdvanceEpoch{
+			parser.AdvanceEpoch{Time: 1, Epochs: &one},
+			parser.AdvanceEpoch{Time: 3, Epochs: &three},
+			parser.AdvanceEpoch{Time: 7, Epochs: &seven},
+			parser.AdvanceEpoch{Time: 5, Epochs: &five},
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	gomock.InOrder(
+		net.EXPECT().AdvanceEpoch(1),
+		net.EXPECT().AdvanceEpoch(3),
+		net.EXPECT().AdvanceEpoch(5),
+		net.EXPECT().AdvanceEpoch(7),
+	)
+
+	if err := Run(clock, net, &scenario, nil); err != nil {
+		t.Errorf("failed to run scenario: %v", err)
+	}
+}

--- a/driver/parser/check.go
+++ b/driver/parser/check.go
@@ -94,6 +94,16 @@ func (s *Scenario) Check() error {
 		}
 	}
 
+	for _, adv := range s.AdvanceEpoch {
+		if adv.Time < 0 || adv.Time > s.Duration {
+			errs = append(errs, fmt.Errorf("invalid timing for advance epoch: %f", adv.Time))
+		}
+
+		if adv.Epochs != nil && *adv.Epochs < 1 {
+			errs = append(errs, fmt.Errorf("minimum epoch to advance must be 1, got: %d", *adv.Epochs))
+		}
+	}
+
 	return errors.Join(errs...)
 }
 

--- a/driver/parser/check_test.go
+++ b/driver/parser/check_test.go
@@ -518,3 +518,74 @@ func TestScenario_NegativeNetworkRuleUpdateTimeIsDetected(t *testing.T) {
 		t.Errorf("negative network rule update time was not detected")
 	}
 }
+
+func TestScenario_AdvanceEpoch_Success(t *testing.T) {
+	one, two, three, four := 1, 2, 3, 4
+
+	scenario := Scenario{
+		Name:     "Test",
+		Duration: 60,
+		AdvanceEpoch: []AdvanceEpoch{
+			AdvanceEpoch{Time: 30, Epochs: &one},
+		},
+	}
+	err := scenario.Check()
+	if err != nil {
+		t.Errorf("AdvanceEpoch valid but this error occured: %v", err)
+	}
+
+	scenario2 := Scenario{
+		Name:     "Test",
+		Duration: 60,
+		AdvanceEpoch: []AdvanceEpoch{
+			AdvanceEpoch{Time: 10, Epochs: &one},
+			AdvanceEpoch{Time: 20, Epochs: &two},
+			AdvanceEpoch{Time: 30, Epochs: &three},
+			AdvanceEpoch{Time: 40, Epochs: &four},
+		},
+	}
+	err = scenario2.Check()
+	if err != nil {
+		t.Errorf("AdvanceEpoch valid but this error occured: %v", err)
+	}
+}
+
+func TestScenario_AdvanceEpoch_Failure(t *testing.T) {
+	three, minusTen := 3, -10
+
+	scenario := Scenario{
+		Name:     "Test",
+		Duration: 60,
+		AdvanceEpoch: []AdvanceEpoch{
+			AdvanceEpoch{Time: 70, Epochs: &three},
+		},
+	}
+	err := scenario.Check()
+	if err == nil || !strings.Contains(err.Error(), "invalid timing for advance epoch") {
+		t.Errorf("invalid timing for advance epoch was not detected")
+	}
+
+	scenario2 := Scenario{
+		Name:     "Test",
+		Duration: 60,
+		AdvanceEpoch: []AdvanceEpoch{
+			AdvanceEpoch{Time: -10, Epochs: &three},
+		},
+	}
+	err = scenario2.Check()
+	if err == nil || !strings.Contains(err.Error(), "invalid timing for advance epoch") {
+		t.Errorf("invalid timing for advance epoch was not detected")
+	}
+
+	scenario3 := Scenario{
+		Name:     "Test",
+		Duration: 60,
+		AdvanceEpoch: []AdvanceEpoch{
+			AdvanceEpoch{Time: 30, Epochs: &minusTen},
+		},
+	}
+	err = scenario3.Check()
+	if err == nil || !strings.Contains(err.Error(), "minimum epoch to advance must be 1") {
+		t.Errorf("backward epoch advancement was not detected")
+	}
+}

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -36,6 +36,7 @@ type Scenario struct {
 	Applications  []Application  `yaml:",omitempty"`
 	Cheats        []Cheat        `yaml:",omitempty"`
 	NetworkRules  NetworkRules   `yaml:"network_rules,omitempty"`
+	AdvanceEpoch  []AdvanceEpoch `yaml:"advance_epoch,omitempty"`
 }
 
 func (s *Scenario) GetRoundTripTime() time.Duration {
@@ -53,6 +54,12 @@ type networkRules map[string]string
 type NetworkRules struct {
 	Genesis networkRules         `yaml:",omitempty"`
 	Updates []NetworkRulesUpdate `yaml:",omitempty"`
+}
+
+// AdvanceEpoch defines how many epoch to advance at what timing
+type AdvanceEpoch struct {
+	Time   float32
+	Epochs *int `yaml:",omitempty"` // nil is interpreted as 1
 }
 
 // NetworkRulesUpdate defines a network rule update that can be applied at a specific time.

--- a/driver/parser/parser_test.go
+++ b/driver/parser/parser_test.go
@@ -173,6 +173,22 @@ func TestParseExampleWithCheats(t *testing.T) {
 	}
 }
 
+// for advance_epoch, epochs can be omitted and will default to 1
+var withAdvanceEpoch = smallExample + `
+
+advance_epoch:
+  - time: 25
+    epochs: 2
+  - time: 50 
+`
+
+func TestParseExampleWithAdvanceEpoch(t *testing.T) {
+	_, err := ParseBytes([]byte(withAdvanceEpoch))
+	if err != nil {
+		t.Fatalf("parsing of input failed: %v", err)
+	}
+}
+
 func TestNetwork_Rules(t *testing.T) {
 	scenario, err := ParseBytes([]byte(networkRulesPayload))
 	if err != nil {

--- a/scenarios/test/advance_epoch.yml
+++ b/scenarios/test/advance_epoch.yml
@@ -1,0 +1,40 @@
+# This scenario demonstrates "advance epoch".
+# 
+# It is a minimal network including two nodes and a single application 
+# producing constant, low-throughput load.
+# 
+# The network is set so that there's only one epoch and will only advance
+# if the advance epoch signal succeeds.
+name: Advance Epoch
+
+# The duration of the scenario's runtime, in seconds.
+duration: 90
+
+# Initial validator nodes in the network.
+validators:
+  - name: validator-latest
+    instances: 2
+    imagename: "sonic"
+
+# Network rules to be applied to the network.
+# It is an extensible list of key-value pairs.
+# It defines rules for genesis (network bootstrap)
+# and updates of the rules during the network run.
+network_rules:
+  genesis:
+    MAX_EPOCH_DURATION: 1h  # only one epoch in this scenario
+
+# advance epoch by 3 mid-scenario (keep in mind 5-6 seconds / epoch advance)
+advance_epoch:
+  - time: 30
+    epochs: 3
+
+# In the network there is a single application producing constant load.
+applications:
+  - name: load
+    type: counter
+    users: 50
+    start: 10          # start time
+    end: 50            # termination time
+    rate:
+      constant: 20    # Tx/s


### PR DESCRIPTION
- Parser now allow field `advance_epoch` of type `float32->int` (timing -> how many epoch to advance)
- Check now checks if timing is valid (not < 0 or > duration of scenario)
- Executor can now schedule Advance Epoch events by calling it on the network.