### PR TITLE
Register Upgrade.SingleProposerBlockFormation in rules

### DIFF
--- a/genesis/genesis/rules_config.go
+++ b/genesis/genesis/rules_config.go
@@ -46,6 +46,7 @@ func init() {
 	register("UPGRADES_LLR", upgradesLlr)
 	register("UPGRADES_SONIC", upgradesSonic)
 	register("UPGRADES_ALLEGRO", upgradesAllegro)
+	register("UPGRADES_SINGLE_PROPOSER", upgradesSingleProposer)
 
 	// Economy
 	register("MIN_GAS_PRICE", minGasPrice)
@@ -252,6 +253,11 @@ var upgradesSonic = func(value string, rules *opera.Rules) error {
 
 var upgradesAllegro = func(value string, rules *opera.Rules) error {
 	rules.Upgrades.Allegro = value == "true"
+	return nil
+}
+
+var upgradesSingleProposer = func(value string, rules *opera.Rules) error {
+	rules.Upgrades.SingleProposerBlockFormation = value == "true"
 	return nil
 }
 

--- a/genesis/genesis/rules_config_test.go
+++ b/genesis/genesis/rules_config_test.go
@@ -115,6 +115,13 @@ func TestConfigureNetworkRules_Values_Set(t *testing.T) {
 			},
 		},
 		{
+			key:   "UPGRADES_SINGLE_PROPOSER",
+			value: "true",
+			match: func(rules opera.Rules) (string, bool) {
+				return fmt.Sprintf("%t", rules.Upgrades.Sonic), rules.Upgrades.SingleProposerBlockFormation == true
+			},
+		},
+		{
 			key:   "MIN_GAS_PRICE",
 			value: "1000000001",
 			match: func(rules opera.Rules) (string, bool) {
@@ -572,6 +579,15 @@ func TestGenerateJsonNetworkRulesUpdates_Exported_Json_Correct(t *testing.T) {
 			json: map[string]any{
 				"Upgrades": map[string]any{
 					"Sonic": true,
+				},
+			},
+		},
+		{
+			key:   "UPGRADES_SINGLE_PROPOSER",
+			value: "true",
+			json: map[string]any{
+				"Upgrades": map[string]any{
+					"SingleProposerBlockFormation": true,
 				},
 			},
 		},


### PR DESCRIPTION
To facilitate release testing scenarios, the following upgrade flag is required
https://github.com/0xsoniclabs/sonic/blob/3ecd7c5ad326c26fb97001b2bd3adcde5681a859/opera/rules.go#L243

This PR registers the flag into the rules and allow it to be enable/disabled by changing the network rules.