### PR TITLE
Move all checker inits to run.go

### DIFF
--- a/driver/checking/block_height.go
+++ b/driver/checking/block_height.go
@@ -25,14 +25,10 @@ import (
 	"strings"
 )
 
-// allow block height to fall short by this amount
-// slack of 5 means that block 95-99 is also accepted when max block height = 100
-const defaultSlack = 5
-
-func init() {
-	RegisterNetworkCheck("block_height", func(net driver.Network, monitor *monitoring.Monitor) Checker {
-		return &blockHeightChecker{net: net, slack: defaultSlack}
-	})
+func NewBlockHeightChecker(slack uint8) Factory {
+	return func(net driver.Network, monitor *monitoring.Monitor) Checker {
+		return &blockHeightChecker{net: net, slack: slack}
+	}
 }
 
 // blockHeightChecker is a Checker checking if all Opera nodes achieved the same block height.

--- a/driver/checking/blocks_hashes.go
+++ b/driver/checking/blocks_hashes.go
@@ -26,10 +26,10 @@ import (
 	"maps"
 )
 
-func init() {
-	RegisterNetworkCheck("blocks_hashes", func(net driver.Network, monitor *monitoring.Monitor) Checker {
+func NewBlockHashesChecker() Factory {
+	return func(net driver.Network, monitor *monitoring.Monitor) Checker {
 		return &blocksHashesChecker{net: net}
-	})
+	}
 }
 
 // blocksHashesChecker is a Checker checking if all Opera nodes provides the same hashes for all blocks/stateRoots.

--- a/driver/checking/blocks_rolling.go
+++ b/driver/checking/blocks_rolling.go
@@ -7,13 +7,13 @@ import (
 	nodemon "github.com/0xsoniclabs/norma/driver/monitoring/node"
 )
 
-func init() {
-	RegisterNetworkCheck("blocks_rolling", func(net driver.Network, monitor *monitoring.Monitor) Checker {
-		return &blocksRollingChecker{monitor: &monitoringDataAdapter{monitor}, toleranceSamples: 10}
-	})
-}
-
 //go:generate mockgen -source blocks_rolling.go -destination blocks_rolling_mock.go -package checking
+
+func NewBlockRollingChecker(toleranceSampleSize uint8) Factory {
+	return func(net driver.Network, monitor *monitoring.Monitor) Checker {
+		return &blocksRollingChecker{monitor: &monitoringDataAdapter{monitor}, toleranceSamples: 10}
+	}
+}
 
 // MonitoringData is an interface that defines a method to get monitoring data related to this checker.
 type MonitoringData interface {

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -244,6 +244,10 @@ func runScenario(path, outputDir, label string, keepPrometheusRunning, skipCheck
 
 	var checks []checking.Checker
 	if !skipChecks {
+		checking.RegisterNetworkCheck("block_height", checking.NewBlockHeightChecker(5))
+		checking.RegisterNetworkCheck("block_hashes", checking.NewBlockHashesChecker())
+		checking.RegisterNetworkCheck("block_rolling", checking.NewBlockRollingChecker(10))
+
 		// Initialize network consistency checks.
 		checks = checking.InitNetworkChecks(net, monitor)
 	}


### PR DESCRIPTION
We now have a need to configure checkers in scenario:
- Specify timing when block rolling must happen (e.g. between time A and B)
- Specify timing when block rolling must not happen (e.g. between time A and B)

Currently, we can set flag to enable/disable checking the following 3 checkers:
- If blocks are rolling (increasing in block height after 10 samples)
- If at the end of the simulation, all nodes are at the same block height. (or at least within 5 blocks away)
- If at the end of the simulation, state root, receipts root and block hash must be valid.
The 3 checkers are fixed.

This PR starts a series of PR to allow the scenario configuration to enable and parameterize checkers as necessary.

This PR focuses on moving the initialization of each checkers from `func init()` in each checkers to `driver/norma/run.go`. 

Incoming PRs will:
- add to scenario configuration a `checker` configurator.
- modify `driver/norma/run.go` so that it defaults to the current 3 checkers but deviate when checkers are specified in scenario.
- convert checkers's `Check()` to `Check(time float32)` so that checkers know to ignore check signal outside its timing window.
- Add new checkers as necessary.