### PR TITLE
Parser can now parse checkers

### DIFF
--- a/driver/parser/check.go
+++ b/driver/parser/check.go
@@ -104,6 +104,12 @@ func (s *Scenario) Check() error {
 		}
 	}
 
+	for _, checker := range s.Checkers {
+		if err := checkTimeInterval(checker.Start, checker.End, s.Duration); err != nil {
+			errs = append(errs, fmt.Errorf("invalid timing for checker; %v", err))
+		}
+	}
+
 	return errors.Join(errs...)
 }
 

--- a/driver/parser/check_test.go
+++ b/driver/parser/check_test.go
@@ -589,3 +589,107 @@ func TestScenario_AdvanceEpoch_Failure(t *testing.T) {
 		t.Errorf("backward epoch advancement was not detected")
 	}
 }
+
+func TestScenario_Checker_Success(t *testing.T) {
+	var zero, sixty float32 = 0, 60
+
+	scenarios := []Scenario{
+		// blanks
+		Scenario{
+			Name:     "Test",
+			Duration: 60,
+		},
+		Scenario{
+			Name:     "Test",
+			Duration: 60,
+			Checkers: []Checker{},
+		},
+		// default checkers
+		Scenario{
+			Name:     "Test",
+			Duration: 60,
+			Checkers: []Checker{
+				Checker{Name: "block_height", Type: "block_height_checker", Start: &zero, End: &sixty, Config: map[string]string{"slack": "5"}},
+				Checker{Name: "blocks_hashes", Type: "blocks_hashes_checker", Start: &zero, End: &sixty, Config: map[string]string{}},
+				Checker{Name: "blocks_rolling", Type: "blocks_rolling_checker", Start: &zero, End: &sixty, Config: map[string]string{"tolerance": "10"}},
+			},
+		},
+		Scenario{
+			Name:     "Test",
+			Duration: 60,
+			Checkers: []Checker{
+				Checker{Name: "block_height", Type: "block_height_checker", Config: map[string]string{"slack": "5"}},
+				Checker{Name: "blocks_hashes", Type: "blocks_hashes_checker", Config: map[string]string{}},
+				Checker{Name: "blocks_rolling", Type: "blocks_rolling_checker", Config: map[string]string{"tolerance": "10"}},
+			},
+		},
+		Scenario{
+			Name:     "Test",
+			Duration: 60,
+			Checkers: []Checker{
+				Checker{Name: "block_height", Type: "block_height_checker", Config: map[string]string{}},
+				Checker{Name: "blocks_hashes", Type: "blocks_hashes_checker", Config: map[string]string{}},
+				Checker{Name: "blocks_rolling", Type: "blocks_rolling_checker", Config: map[string]string{}},
+			},
+		},
+		Scenario{
+			Name:     "Test",
+			Duration: 60,
+			Checkers: []Checker{
+				Checker{Name: "block_height", Type: "block_height_checker"},
+				Checker{Name: "blocks_hashes", Type: "blocks_hashes_checker"},
+				Checker{Name: "blocks_rolling", Type: "blocks_rolling_checker"},
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		err := scenario.Check()
+		if err != nil {
+			t.Errorf("scenario valid but error occured: %v", err)
+		}
+	}
+}
+
+func TestScenario_Checker_Failure(t *testing.T) {
+	var fm1, f5555, f10, f5 float32 = -1, 5555, 10, 5
+
+	scenarios := []Scenario{
+		// default checkers
+		Scenario{
+			Name:     "Test",
+			Duration: 60,
+			Checkers: []Checker{
+				Checker{Name: "block_height", Type: "block_height_checker", Start: &fm1, Config: map[string]string{"slack": "5"}},
+			},
+		},
+		Scenario{
+			Name:     "Test",
+			Duration: 60,
+			Checkers: []Checker{
+				Checker{Name: "block_height", Type: "block_height_checker", End: &fm1, Config: map[string]string{"slack": "5"}},
+			},
+		},
+		Scenario{
+			Name:     "Test",
+			Duration: 60,
+			Checkers: []Checker{
+				Checker{Name: "block_height", Type: "block_height_checker", End: &f5555, Config: map[string]string{"slack": "5"}},
+			},
+		},
+		Scenario{
+			Name:     "Test",
+			Duration: 60,
+			Checkers: []Checker{
+				Checker{Name: "block_height", Type: "block_height_checker", Start: &f10, End: &f5, Config: map[string]string{"slack": "5"}},
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		err := scenario.Check()
+		if err == nil || !strings.Contains(err.Error(), "invalid timing for checker") {
+			t.Errorf("scenario valid but error occured: %v", err)
+		}
+	}
+}

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -37,6 +37,7 @@ type Scenario struct {
 	Cheats        []Cheat        `yaml:",omitempty"`
 	NetworkRules  NetworkRules   `yaml:"network_rules,omitempty"`
 	AdvanceEpoch  []AdvanceEpoch `yaml:"advance_epoch,omitempty"`
+	Checkers      []Checker      `yaml:"checker,omitempty"`
 }
 
 func (s *Scenario) GetRoundTripTime() time.Duration {
@@ -66,6 +67,18 @@ type AdvanceEpoch struct {
 type NetworkRulesUpdate struct {
 	Time  float32
 	Rules networkRules
+}
+
+// checkerConfig is a way to pass generic config to the respective checker
+type checkerConfig map[string]string
+
+// Checker is a configuration for the checker to apply to this specific scenario.
+type Checker struct {
+	Name   string
+	Type   string
+	Start  *float32      `yaml:"start,omitempty"`  // nil is intepreted as 0
+	End    *float32      `yaml:"end,omitempty"`    // nil is intepreted as scenario duration
+	Config checkerConfig `yaml:"config,omitempty"` // nil is intepreted as empty map
 }
 
 // Validator is a configuration for a group of network start-up validators.

--- a/driver/parser/parser_test.go
+++ b/driver/parser/parser_test.go
@@ -189,6 +189,29 @@ func TestParseExampleWithAdvanceEpoch(t *testing.T) {
 	}
 }
 
+// these describe the default checkers
+var withDefaultCheckers = smallExample + `
+
+checker:
+  - name: block_height
+    type: block_height_checker
+    config:
+      slack: 5
+  - name: block_hashes
+    type: block_hashes_checker
+  - name: block_rolling
+    type: block_rolling_checker
+    config:
+      tolerance: 10
+`
+
+func TestParseExampleWithDefaultCheckers(t *testing.T) {
+	_, err := ParseBytes([]byte(withDefaultCheckers))
+	if err != nil {
+		t.Fatalf("parsing of input failed: %v", err)
+	}
+}
+
 func TestNetwork_Rules(t *testing.T) {
 	scenario, err := ParseBytes([]byte(networkRulesPayload))
 	if err != nil {


### PR DESCRIPTION
This PR add to scenario parser a checker configurator.

Incoming PRs will:

- modify driver/norma/run.go so that it defaults to the current 3 checkers but deviate when checkers are specified in scenario.
- convert checkers's Check() to Check(time float32) so that checkers know to ignore check signal outside its timing window.
- Add new checkers as necessary.

-----

Context:
We now have a need to configure checkers in scenario:
- Specify timing when block rolling must happen (e.g. between time A and B)
- Specify timing when block rolling must not happen (e.g. between time A and B)

Currently, we can set flag to enable/disable checking the following 3 checkers:
- If blocks are rolling (increasing in block height after 10 samples)
- If at the end of the simulation, all nodes are at the same block height. (or at least within 5 blocks away)
- If at the end of the simulation, state root, receipts root and block hash must be valid.
The 3 checkers are fixed.