### PR TITLE
Add default checker behavior

### DIFF
--- a/driver/checking/block_height.go
+++ b/driver/checking/block_height.go
@@ -25,6 +25,10 @@ import (
 	"strings"
 )
 
+// allow block height to fall short by this amount
+// slack of 5 means that block 95-99 is also accepted when max block height = 100
+const defaultSlack = 5
+
 func NewBlockHeightChecker(slack uint8) Factory {
 	return func(net driver.Network, monitor *monitoring.Monitor) Checker {
 		return &blockHeightChecker{net: net, slack: slack}

--- a/driver/checking/blocks_rolling.go
+++ b/driver/checking/blocks_rolling.go
@@ -7,6 +7,9 @@ import (
 	nodemon "github.com/0xsoniclabs/norma/driver/monitoring/node"
 )
 
+// the longest amount of sampling before considering stagnation
+const defaultTolerance = 10
+
 //go:generate mockgen -source blocks_rolling.go -destination blocks_rolling_mock.go -package checking
 
 func NewBlockRollingChecker(toleranceSampleSize uint8) Factory {

--- a/driver/checking/checker_config.go
+++ b/driver/checking/checker_config.go
@@ -1,0 +1,97 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package checking
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// init registers all currently supported checkers
+func init() {
+	registerCheckerType("block_height_checker", blockHeightCheckerFactory)
+	registerCheckerType("blocks_hashes_checker", blocksHashesCheckerFactory)
+	registerCheckerType("blocks_rolling_checker", blocksRollingCheckerFactory)
+
+	registerDefaultNetworkCheck("default_block_height", "block_height_checker",
+		map[string]string{"slack": strconv.Itoa(defaultSlack)},
+	)
+	registerDefaultNetworkCheck("default_blocks_hashes", "blocks_hashes_checker",
+		map[string]string{},
+	)
+	registerDefaultNetworkCheck("default_blocks_rolling", "blocks_rolling_checker",
+		map[string]string{"tolerance": strconv.Itoa(defaultTolerance)},
+	)
+}
+
+// these support adding custom configurations into each Checker Factory
+type configuredFactory func(config map[string]string) (Factory, error)
+type configuredFactoryRegistry map[string]configuredFactory
+
+// supportedChecker is a map of currently supported checkers
+var supportedChecker = make(configuredFactoryRegistry)
+
+// IsSupportedChecker returns true if the given key is a supported checker
+func IsSupportedChecker(key string) bool {
+	_, ok := supportedChecker[key]
+	return ok
+}
+
+// registerCheckerType registers a new supported checker
+func registerCheckerType(typ string, factory configuredFactory) {
+	supportedChecker[typ] = factory
+}
+
+var blockHeightCheckerFactory = func(config map[string]string) (Factory, error) {
+	var slack uint8 = defaultSlack
+
+	// if not configured, simply use default value - else overwrite it
+	val, exist := config["slack"]
+	if exist {
+		s, err := strconv.ParseUint(val, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing slack; %v", err)
+		}
+		slack = uint8(s)
+	}
+
+	return NewBlockHeightChecker(slack), nil
+}
+
+var blocksHashesCheckerFactory = func(config map[string]string) (Factory, error) {
+	return NewBlockHashesChecker(), nil
+}
+
+var blocksRollingCheckerFactory = func(config map[string]string) (Factory, error) {
+	var tolerance uint8 = defaultTolerance
+
+	// if not configured, simply use default value - else overwrite it
+	val, exist := config["tolerance"]
+	if exist {
+		t, err := strconv.ParseUint(val, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing slack; %v", err)
+		}
+		tolerance = uint8(t)
+	}
+
+	if tolerance < 5 {
+		return nil, fmt.Errorf("minimum tolerance sample size is 5")
+	}
+
+	return NewBlockRollingChecker(tolerance), nil
+}

--- a/driver/checking/checker_config_test.go
+++ b/driver/checking/checker_config_test.go
@@ -1,0 +1,82 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package checking
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckerConfig_IsSupportedChecker(t *testing.T) {
+	tests := []struct {
+		typ      string
+		expected bool
+	}{
+		{"block_height_checker", true},
+		{"blocks_height_checker", false},
+		{"block_hashes_checker", false},
+		{"blocks_hashes_checker", true},
+		{"block_rolling_checker", false},
+		{"blocks_rolling_checker", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.typ, func(t *testing.T) {
+			res := IsSupportedChecker(test.typ)
+			if res != test.expected {
+				t.Errorf("IsSupportedChecker(%s) = %v, want %v", test.typ, res, test.expected)
+			}
+		})
+	}
+}
+
+func TestCheckerConfig_IsCorrectlyConfigured(t *testing.T) {
+	tests := []struct {
+		typ      string
+		config   map[string]string
+		expected bool
+		err      string
+	}{
+		{"block_height_checker", map[string]string{}, true, ""},
+		{"block_height_checker", map[string]string{"slack": "5"}, true, ""},
+		{"block_height_checker", map[string]string{"slack": "-1"}, false, "error parsing slack"},
+		{"block_height_checker", map[string]string{"slack": "abcd"}, false, "error parsing slack"},
+		{"blocks_hashes_checker", map[string]string{}, true, ""},
+		{"blocks_hashes_checker", map[string]string{"random": "config"}, true, ""},
+		{"blocks_rolling_checker", map[string]string{}, true, ""},
+		{"blocks_rolling_checker", map[string]string{"tolerance": "10"}, true, ""},
+		{"blocks_rolling_checker", map[string]string{"tolerance": "0"}, false, "minimum tolerance sample size is 5"},
+		{"blocks_rolling_checker", map[string]string{"tolerance": "abcd"}, false, "error parsing slack"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.typ, func(t *testing.T) {
+			if !IsSupportedChecker(test.typ) {
+				t.Errorf("%s not supported", test.typ)
+			}
+
+			err := RegisterNetworkCheck("test", test.typ, test.config)
+			if test.expected && err != nil {
+				t.Errorf("%s should pass when configured with %v; got %v", test.typ, test.config, err)
+			}
+			if !test.expected && (err == nil || !strings.Contains(err.Error(), test.err)) {
+				t.Errorf("expected error of type %s, got: %v", test.err, err)
+			}
+
+		})
+	}
+}

--- a/driver/checking/checker_test.go
+++ b/driver/checking/checker_test.go
@@ -1,0 +1,115 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package checking
+
+import (
+	"testing"
+
+	"github.com/0xsoniclabs/norma/driver"
+	"github.com/0xsoniclabs/norma/driver/monitoring"
+	"go.uber.org/mock/gomock"
+)
+
+func TestChecker_DefaultChecker_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
+	net.EXPECT().GetActiveNodes().AnyTimes()
+	monitor, err := monitoring.NewMonitor(net, monitoring.MonitorConfig{
+		EvaluationLabel: "test",
+		OutputDir:       tmpDir,
+	})
+	if err != nil {
+		t.Errorf("failed to start monitor; %v", err)
+	}
+	t.Cleanup(func() {
+		_ = monitor.Shutdown()
+	})
+
+	registrations = make(registry)
+	checkers := InitNetworkChecks(net, monitor)
+
+	if len(checkers) != len(defaultRegistrations) {
+		t.Errorf("Expected %d checkers, got %d", len(defaultRegistrations), len(checkers))
+	}
+}
+
+func TestChecker_CustomChecker_Success(t *testing.T) {
+	type check struct {
+		name   string
+		typ    string
+		config map[string]string
+	}
+	type testcase struct {
+		checks []check
+	}
+	tests := []testcase{
+		{[]check{
+			{"test1", "block_height_checker", map[string]string{"slack": "5"}},
+		}},
+		{[]check{
+			{"test2", "blocks_hashes_checker", map[string]string{}},
+		}},
+		{[]check{
+			{"test3", "blocks_hashes_checker", map[string]string{"random": "ignored"}},
+		}},
+		{[]check{
+			{"test4", "blocks_rolling_checker", map[string]string{"tolerance": "10"}},
+		}},
+		{[]check{
+			{"test5", "block_height_checker", map[string]string{"slack": "5"}},
+			{"test6", "blocks_hashes_checker", map[string]string{}},
+			{"test7", "blocks_rolling_checker", map[string]string{"tolerance": "10"}},
+		}},
+	}
+
+	for _, test := range tests {
+		tmpDir := t.TempDir()
+
+		ctrl := gomock.NewController(t)
+		net := driver.NewMockNetwork(ctrl)
+		net.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
+		net.EXPECT().GetActiveNodes().AnyTimes()
+
+		monitor, err := monitoring.NewMonitor(net, monitoring.MonitorConfig{
+			EvaluationLabel: "test",
+			OutputDir:       tmpDir,
+		})
+		if err != nil {
+			t.Errorf("failed to start monitor; %v", err)
+		}
+		t.Cleanup(func() {
+			_ = monitor.Shutdown()
+		})
+
+		registrations = make(registry)
+		for _, chk := range test.checks {
+			err := RegisterNetworkCheck(chk.name, chk.typ, chk.config)
+			if err != nil {
+				t.Errorf("Should succeed when registering %+v; got %v", chk, err)
+			}
+		}
+
+		checkers := InitNetworkChecks(net, monitor)
+		if len(checkers) != len(test.checks) {
+			t.Errorf("Expected %d checkers, got %d", len(test.checks), len(checkers))
+		}
+
+	}
+}

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -244,9 +244,13 @@ func runScenario(path, outputDir, label string, keepPrometheusRunning, skipCheck
 
 	var checks []checking.Checker
 	if !skipChecks {
-		checking.RegisterNetworkCheck("block_height", checking.NewBlockHeightChecker(5))
-		checking.RegisterNetworkCheck("block_hashes", checking.NewBlockHashesChecker())
-		checking.RegisterNetworkCheck("block_rolling", checking.NewBlockRollingChecker(10))
+		for _, chk := range scenario.Checkers {
+			err := checking.RegisterNetworkCheck(chk.Name, chk.Type, chk.Config)
+			if err != nil {
+				fmt.Printf("Failed to register check %s of type %s with config %+v; %v\n", chk.Name, chk.Type, chk.Config, err)
+				return err
+			}
+		}
 
 		// Initialize network consistency checks.
 		checks = checking.InitNetworkChecks(net, monitor)


### PR DESCRIPTION
This PR do the following:
- Add a separate registration layer so one can register supported type of checks.
- using `init()`, the 3 default behaviors are now registered as before. This is done in after each check types have been registered.
- The factory can also take on a `map[string]string` so that the yml configuration can be configured generically. Example:
```
checkers:
  - name: block_rolling
    type: block_rolling_checker
    config:                              ### this can be parsed and passed on to the factory
      tolerance: 10        
```
- This feels overly complicated, I will have to go through this again when I'm more fresh. Any feedback is welcome.

Note: This PR still uses the old name checkers. This is to be clean up and a new name of checks should be adopted.

Incoming PRs will:

- Implement a way to repeatedly send `Check` signal to checker by name between `Start` and `End`.
- Add new checkers as necessary.
