### PR TITLE
Extend block rolling check

### DIFF
--- a/driver/checking/blocks_rolling_test.go
+++ b/driver/checking/blocks_rolling_test.go
@@ -3,6 +3,7 @@ package checking
 import (
 	"github.com/0xsoniclabs/norma/driver/monitoring"
 	"go.uber.org/mock/gomock"
+	"strings"
 	"testing"
 )
 
@@ -32,11 +33,16 @@ func TestBlocksRolling_Blocks_Processed(t *testing.T) {
 			series := createBlockSeries(t, test.series)
 			ctrl := gomock.NewController(t)
 			monitor := NewMockMonitoringData(ctrl)
-			monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
-			monitor.EXPECT().GetData(gomock.Any()).Return(series)
+			monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"}).Times(2)
+			monitor.EXPECT().GetData(gomock.Any()).Return(series).Times(2)
 
-			c := blocksRollingChecker{monitor: monitor, toleranceSamples: 5}
+			c := blocksRollingChecker{monitor: monitor, toleranceSamples: 5, expectNetworkFunctional: true}
 			if err := c.Check(); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			c2 := blocksRollingChecker{monitor: monitor, toleranceSamples: 5, expectNetworkFunctional: false}
+			if err := c2.Check(); err == nil || !strings.Contains(err.Error(), "network is working, nodes still producing blocks") {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})
@@ -75,14 +81,59 @@ func TestBlocksRolling_Blocks_Failure(t *testing.T) {
 			series := createBlockSeries(t, test.series)
 			ctrl := gomock.NewController(t)
 			monitor := NewMockMonitoringData(ctrl)
-			monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
-			monitor.EXPECT().GetData(gomock.Any()).Return(series)
+			monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"}).Times(2)
+			monitor.EXPECT().GetData(gomock.Any()).Return(series).Times(2)
 
-			c := blocksRollingChecker{monitor: monitor, toleranceSamples: 5}
-			if err := c.Check(); err == nil || err.Error() != "network is down, nodes stopped producing blocks" {
+			c := blocksRollingChecker{monitor: monitor, toleranceSamples: 5, expectNetworkFunctional: true}
+			if err := c.Check(); err == nil || !strings.Contains(err.Error(), "network is down, nodes stopped producing blocks") {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			c2 := blocksRollingChecker{monitor: monitor, toleranceSamples: 5, expectNetworkFunctional: false}
+			if err := c2.Check(); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestBlocksRolling_Recent(t *testing.T) {
+	increasingTowardsEnd := []uint64{3, 3, 3, 3, 3, 3, 4, 5, 6, 7, 8}
+	series := createBlockSeries(t, increasingTowardsEnd)
+
+	ctrl := gomock.NewController(t)
+	monitor := NewMockMonitoringData(ctrl)
+	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"}).Times(2)
+	monitor.EXPECT().GetData(gomock.Any()).Return(series).Times(2)
+
+	// recent 6 blocks only, expect network to pass because it see 3,4,5,6,7,8
+	var six monitoring.Time = 6
+	c := blocksRollingChecker{monitor: monitor, toleranceSamples: 5, expectNetworkFunctional: true, recent: &six}
+	if err := c.Check(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// entire range, expect network to fail since it see the entire range
+	c2 := blocksRollingChecker{monitor: monitor, toleranceSamples: 5, expectNetworkFunctional: false}
+	if err := c2.Check(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestBlocksRolling_Recent_Robust(t *testing.T) {
+	small := []uint64{1, 2, 3, 4, 5, 6, 7, 8}
+	series := createBlockSeries(t, small)
+
+	ctrl := gomock.NewController(t)
+	monitor := NewMockMonitoringData(ctrl)
+	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
+	monitor.EXPECT().GetData(gomock.Any()).Return(series)
+
+	// recent set to 30, but it can still function even with 8 data points
+	var thirty monitoring.Time = 30
+	c := blocksRollingChecker{monitor: monitor, toleranceSamples: 5, expectNetworkFunctional: true, recent: &thirty}
+	if err := c.Check(); err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
This PR extends block rolling check with the following 2 configurations:
- `recent`: if configure, only pull the most X recent data point from the series. Otherwise, pull the entire series.
- `expectNetworkFunctional`: allow to check for expected network failures.

Additionally, registers the following network checks (default recent = 30 data points)
- `recent_blocks_rolling`: check if at least one node has increasing block heights throughout recent data points
- `recent_blocks_not_rolling`: check if none of the node has increasing block heights throughout recent data points