### PR TITLE
Add a memory limit to Sonic instances

### DIFF
--- a/scripts/run_sonic_privatenet.sh
+++ b/scripts/run_sonic_privatenet.sh
@@ -73,6 +73,7 @@ fi
 
 
 # Start sonic as part of a fake net with RPC service.
+export GOMEMLIMIT="1GiB"
 ./sonicd \
     --datadir=${datadir} \
     ${val_flag} \


### PR DESCRIPTION
This PR adds a soft memory limit to `sonicd` instances of 1 GiB per instance. This should help making resources requirements of clients more predictable.