### PR TITLE
Make epoch advancement block until new epoch has been reached

### DIFF
--- a/driver/network/backend.go
+++ b/driver/network/backend.go
@@ -18,10 +18,11 @@ package network
 
 import (
 	"encoding/hex"
+	"strings"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"strings"
 )
 
 //go:generate mockgen -source backend.go -destination backend_mock.go -package network
@@ -36,9 +37,7 @@ type ContractBackend interface {
 
 // convertContractBytecode converts a contract hex string to bytecode.
 func convertContractBytecode(contractHex string) ([]byte, error) {
-	if strings.HasPrefix(contractHex, "0x") {
-		contractHex = strings.TrimPrefix(contractHex, "0x")
-	}
+	contractHex = strings.TrimPrefix(contractHex, "0x")
 
 	bytecode, err := hex.DecodeString(contractHex)
 	if err != nil {

--- a/driver/network/epoch.go
+++ b/driver/network/epoch.go
@@ -26,7 +26,7 @@ func AdvanceEpoch(client rpc.Client, epochIncrement int) error {
 		return fmt.Errorf("failed to get driver auth contract representation; %v", err)
 	}
 
-	currentEpoch, err := getCurrentEpoch(client)
+	currentEpoch, err := GetCurrentEpoch(client)
 	if err != nil {
 		return fmt.Errorf("failed to get current epoch: %w", err)
 	}
@@ -56,8 +56,8 @@ func AdvanceEpoch(client rpc.Client, epochIncrement int) error {
 
 	// wait until the new epoch has actually started
 	start := time.Now()
-	for time.Since(start) < 10*time.Second {
-		newEpoch, err := getCurrentEpoch(client)
+	for time.Since(start) < 60*time.Second {
+		newEpoch, err := GetCurrentEpoch(client)
 		if err != nil {
 			return fmt.Errorf("failed to get current epoch after advancing: %w", err)
 		}
@@ -71,7 +71,7 @@ func AdvanceEpoch(client rpc.Client, epochIncrement int) error {
 	return fmt.Errorf("failed to advance epoch: waited too long for the epoch to be advanced")
 }
 
-func getCurrentEpoch(client rpc.Client) (hexutil.Uint64, error) {
+func GetCurrentEpoch(client rpc.Client) (hexutil.Uint64, error) {
 	var currentEpoch hexutil.Uint64
 	if err := client.Call(&currentEpoch, "eth_currentEpoch"); err != nil {
 		return 0, fmt.Errorf("failed to get current epoch: %w", err)

--- a/driver/network/epoch.go
+++ b/driver/network/epoch.go
@@ -1,0 +1,111 @@
+package network
+
+import (
+	"fmt"
+	"log/slog"
+	big "math/big"
+	"time"
+
+	"github.com/0xsoniclabs/norma/driver/rpc"
+	"github.com/0xsoniclabs/sonic/evmcore"
+	"github.com/0xsoniclabs/sonic/gossip/contract/driverauth100"
+	"github.com/0xsoniclabs/sonic/gossip/contract/sfc100"
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/opera/contracts/driverauth"
+	"github.com/0xsoniclabs/sonic/opera/contracts/sfc"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// AdvanceEpoch triggers the sealing of an epoch advancing it by the given number.
+// The function blocks until the final epoch has been reached
+func AdvanceEpoch(client rpc.Client, epochIncrement int) error {
+	contract, err := driverauth100.NewContract(driverauth.ContractAddress, client)
+	if err != nil {
+		return fmt.Errorf("failed to get driver auth contract representation; %v", err)
+	}
+
+	currentEpoch, err := getCurrentEpoch(client)
+	if err != nil {
+		return fmt.Errorf("failed to get current epoch: %w", err)
+	}
+
+	originalRules := opera.FakeNetRules(opera.GetSonicUpgrades())
+
+	// Use Fake ID for the network
+	// Driver owner is the first validator from the list i.e., index 1 (defined in genesis export in genesis.GenerateJsonGenesis)
+	txOpts, err := bind.NewKeyedTransactorWithChainID(evmcore.FakeKey(1), big.NewInt(int64(originalRules.NetworkID)))
+	if err != nil {
+		return fmt.Errorf("failed to create txOpts; %v", err)
+	}
+
+	tx, err := contract.AdvanceEpochs(txOpts, big.NewInt(int64(epochIncrement)))
+	if err != nil {
+		return fmt.Errorf("failed to advance epoch; %v", err)
+	}
+
+	rec, err := client.WaitTransactionReceipt(tx.Hash())
+	if err != nil {
+		return fmt.Errorf("failed to get receipt; %v", err)
+	}
+
+	if rec.Status != types.ReceiptStatusSuccessful {
+		return fmt.Errorf("failed to advance epoch; receipt status: %v", rec.Status)
+	}
+
+	// wait until the new epoch has actually started
+	start := time.Now()
+	for time.Since(start) < 10*time.Second {
+		newEpoch, err := getCurrentEpoch(client)
+		if err != nil {
+			return fmt.Errorf("failed to get current epoch after advancing: %w", err)
+		}
+		if newEpoch >= currentEpoch+hexutil.Uint64(epochIncrement) {
+			logEpochSummary(client)
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return fmt.Errorf("failed to advance epoch: waited too long for the epoch to be advanced")
+}
+
+func getCurrentEpoch(client rpc.Client) (hexutil.Uint64, error) {
+	var currentEpoch hexutil.Uint64
+	if err := client.Call(&currentEpoch, "eth_currentEpoch"); err != nil {
+		return 0, fmt.Errorf("failed to get current epoch: %w", err)
+	}
+	return currentEpoch, nil
+}
+
+func logEpochSummary(client rpc.Client) {
+	// get a representation of the deployed contract
+	sfc, err := sfc100.NewContract(sfc.ContractAddress, client)
+	if err != nil {
+		slog.Error("Failed to get SFC contract representation", "error", err)
+		return
+	}
+
+	epoch, err := sfc.CurrentEpoch(nil)
+	if err != nil {
+		slog.Error("Failed to get current epoch", "error", err)
+		return
+	}
+
+	validators, err := sfc.GetEpochValidatorIDs(nil, epoch)
+	if err != nil {
+		slog.Error("Failed to get epoch validator IDs", "epoch", epoch, "error", err)
+		return
+	}
+
+	validatorIds := []int{}
+	for _, id := range validators {
+		validatorIds = append(validatorIds, int(id.Int64()))
+	}
+
+	slog.Info("Epoch summary",
+		"current_epoch", epoch,
+		"active_validators", validatorIds,
+	)
+}

--- a/driver/network/epoch_test.go
+++ b/driver/network/epoch_test.go
@@ -1,0 +1,61 @@
+package network
+
+import (
+	big "math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/norma/driver/rpc"
+	"github.com/0xsoniclabs/sonic/gossip/contract/driverauth100"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	gomock "go.uber.org/mock/gomock"
+)
+
+func TestAdvanceEpoch_Success(t *testing.T) {
+	t.Parallel()
+
+	baseFee := big.Int{}
+	baseFee.SetInt64(123)
+	header := types.Header{BaseFee: &baseFee}
+
+	bytecode, err := convertContractBytecode(driverauth100.ContractMetaData.Bin)
+	if err != nil {
+		t.Fatalf("failed to decode contract bytecode: %v", err)
+	}
+
+	ctrl := gomock.NewController(t)
+	client := rpc.NewMockClient(ctrl)
+
+	// Obtaining the current epoch before advancing.
+	client.EXPECT().Call(gomock.Any(), "eth_currentEpoch").DoAndReturn(
+		func(result *hexutil.Uint64, _ string, _ ...any) error {
+			*result = hexutil.Uint64(1)
+			return nil
+		},
+	)
+
+	client.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).Return(&header, nil)
+	client.EXPECT().SuggestGasTipCap(gomock.Any()).Return(&baseFee, nil)
+	client.EXPECT().PendingCodeAt(gomock.Any(), gomock.Any()).Return(bytecode, nil)
+	client.EXPECT().EstimateGas(gomock.Any(), gomock.Any()).Return(uint64(123), nil)
+	client.EXPECT().PendingNonceAt(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
+	client.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return(nil)
+	client.EXPECT().WaitTransactionReceipt(gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusSuccessful}, nil)
+
+	// Report the updated epoch after advancing.
+	client.EXPECT().Call(gomock.Any(), "eth_currentEpoch").DoAndReturn(
+		func(result *hexutil.Uint64, _ string, _ ...any) error {
+			*result = hexutil.Uint64(2)
+			return nil
+		},
+	)
+
+	// The epoch state log reporting.
+	any := gomock.Any()
+	client.EXPECT().CallContract(any, any, any).Return(nil, nil)
+	client.EXPECT().CodeAt(any, any, any).Return(bytecode, nil)
+
+	if err := AdvanceEpoch(client, 1); err != nil {
+		t.Errorf("failed to advance epoch: %v", err)
+	}
+}

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -19,13 +19,15 @@ package local
 import (
 	"bufio"
 	"fmt"
-	"github.com/0xsoniclabs/norma/driver/parser"
 	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/0xsoniclabs/norma/driver/network"
+	"github.com/0xsoniclabs/norma/driver/parser"
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/node"
@@ -659,8 +661,8 @@ func TestLocalNetworkAdvanceEpoch_Success(t *testing.T) {
 	defer client.Close()
 
 	// get original epoch
-	var currentEpoch hexutil.Uint64
-	if err := client.Call(&currentEpoch, "eth_currentEpoch"); err != nil {
+	originalEpoch, err := network.GetCurrentEpoch(client)
+	if err != nil {
 		t.Fatalf("failed to get current epoch: %v", err)
 	}
 
@@ -669,24 +671,13 @@ func TestLocalNetworkAdvanceEpoch_Success(t *testing.T) {
 		t.Errorf("failed to advance epoch: %v", err)
 	}
 
-	advanced := make(chan bool)
+	newEpoch, err := network.GetCurrentEpoch(client)
+	if err != nil {
+		t.Fatalf("failed to get new epoch: %v", err)
+	}
 
-	go func() {
-		var newEpoch hexutil.Uint64 = 0
-		var targetEpoch = currentEpoch + hexutil.Uint64(epochIncrement)
-		for newEpoch < targetEpoch {
-			if err := client.Call(&newEpoch, "eth_currentEpoch"); err != nil {
-				t.Errorf("failed to get current epoch: %v", err)
-			}
-		}
-		advanced <- true
-	}()
-
-	select {
-	case <-advanced:
-		// epoch advanced sucessfully
-	case <-time.After(60 * time.Second):
-		t.Errorf("epoch did not advanced successfully")
+	if got, want := newEpoch, originalEpoch+hexutil.Uint64(epochIncrement); got < want {
+		t.Errorf("epoch did not advance correctly, got %d, want %d", got, want)
 	}
 }
 

--- a/driver/network/rules.go
+++ b/driver/network/rules.go
@@ -49,37 +49,3 @@ func ApplyNetworkRules(backend ContractBackend, rules genesis.NetworkRules) erro
 
 	return nil
 }
-
-// AdvanceEpoch triggers the sealing of an epoch advancing it by the given number.
-// The function blocks until the final epoch has been reached
-func AdvanceEpoch(backend ContractBackend, epochIncrement int) error {
-	contract, err := driverauth100.NewContract(driverauth.ContractAddress, backend)
-	if err != nil {
-		return fmt.Errorf("failed to get driver auth contract representation; %v", err)
-	}
-
-	originalRules := opera.FakeNetRules(opera.GetSonicUpgrades())
-
-	// Use Fake ID for the network
-	// Driver owner is the first validator from the list i.e., index 1 (defined in genesis export in genesis.GenerateJsonGenesis)
-	txOpts, err := bind.NewKeyedTransactorWithChainID(evmcore.FakeKey(1), big.NewInt(int64(originalRules.NetworkID)))
-	if err != nil {
-		return fmt.Errorf("failed to create txOpts; %v", err)
-	}
-
-	tx, err := contract.AdvanceEpochs(txOpts, big.NewInt(int64(epochIncrement)))
-	if err != nil {
-		return fmt.Errorf("failed to advance epoch; %v", err)
-	}
-
-	rec, err := backend.WaitTransactionReceipt(tx.Hash())
-	if err != nil {
-		return fmt.Errorf("failed to get receipt; %v", err)
-	}
-
-	if rec.Status != types.ReceiptStatusSuccessful {
-		return fmt.Errorf("failed to advance epoch; receipt status: %v", rec.Status)
-	}
-
-	return nil
-}

--- a/driver/network/rules_test.go
+++ b/driver/network/rules_test.go
@@ -2,15 +2,16 @@ package network
 
 import (
 	"fmt"
+	"math/big"
+	"testing"
+
 	"github.com/0xsoniclabs/norma/genesistools/genesis"
 	"github.com/0xsoniclabs/sonic/gossip/contract/driverauth100"
 	"github.com/ethereum/go-ethereum/core/types"
 	"go.uber.org/mock/gomock"
-	"math/big"
-	"testing"
 )
 
-func TestLocalNetworkApplyNetworkRules_Success(t *testing.T) {
+func TestApplyNetworkRules_Success(t *testing.T) {
 	t.Parallel()
 
 	baseFee := big.Int{}
@@ -38,33 +39,5 @@ func TestLocalNetworkApplyNetworkRules_Success(t *testing.T) {
 
 	if err := ApplyNetworkRules(backend, rules); err != nil {
 		t.Errorf("failed to apply network rules: %v", err)
-	}
-}
-
-func TestLocalNetworkAdvanceEpoch_Success(t *testing.T) {
-	t.Parallel()
-
-	baseFee := big.Int{}
-	baseFee.SetInt64(123)
-	header := types.Header{BaseFee: &baseFee}
-
-	bytecode, err := convertContractBytecode(driverauth100.ContractMetaData.Bin)
-	if err != nil {
-		t.Fatalf("failed to decode contract bytecode: %v", err)
-	}
-
-	ctrl := gomock.NewController(t)
-	backend := NewMockContractBackend(ctrl)
-	backend.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).Return(&header, nil)
-	backend.EXPECT().SuggestGasTipCap(gomock.Any()).Return(&baseFee, nil)
-	backend.EXPECT().PendingCodeAt(gomock.Any(), gomock.Any()).Return(bytecode, nil)
-	backend.EXPECT().EstimateGas(gomock.Any(), gomock.Any()).Return(uint64(123), nil)
-	backend.EXPECT().PendingNonceAt(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
-	backend.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return(nil)
-	backend.EXPECT().WaitTransactionReceipt(gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusSuccessful}, nil)
-
-	const epochIncrement = 4
-	if err := AdvanceEpoch(backend, epochIncrement); err != nil {
-		t.Errorf("failed to advance epoch: %v", err)
 	}
 }

--- a/driver/rpc/rpc.go
+++ b/driver/rpc/rpc.go
@@ -20,10 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum"
 	"math/big"
 	"time"
-
-	"github.com/ethereum/go-ethereum"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -50,7 +49,7 @@ func WrapRpcClient(rpcClient *rpc.Client) *Impl {
 	return &Impl{
 		ethRpcClient:     ethclient.NewClient(rpcClient),
 		rpcClient:        rpcClient,
-		txReceiptTimeout: 10 * time.Second,
+		txReceiptTimeout: 600 * time.Second,
 	}
 }
 

--- a/driver/rpc/rpc.go
+++ b/driver/rpc/rpc.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum"
 	"math/big"
 	"time"
+
+	"github.com/ethereum/go-ethereum"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -49,7 +50,7 @@ func WrapRpcClient(rpcClient *rpc.Client) *Impl {
 	return &Impl{
 		ethRpcClient:     ethclient.NewClient(rpcClient),
 		rpcClient:        rpcClient,
-		txReceiptTimeout: 600 * time.Second,
+		txReceiptTimeout: 10 * time.Second,
 	}
 }
 


### PR DESCRIPTION
This PR updates the advance-epoch operation to block until the required epoch change has actually happened on the network.

The changes comprise the following steps:
- moved the `AdvanceEpoch` function from the `rules.go` file into its own `epochs.go` file
- extended `AdvanceEpoch` to wait for the network to have reached the new epoch
- added a log message after the epoch change listing the active validators for the new epoch