### PR TITLE
Signal removal of node before it is removed

### DIFF
--- a/driver/monitoring/app/app_source.go
+++ b/driver/monitoring/app/app_source.go
@@ -73,7 +73,7 @@ func (s *periodicAppDataSource[T]) AfterNodeCreation(driver.Node) {
 	// ignored
 }
 
-func (s *periodicAppDataSource[T]) AfterNodeRemoval(driver.Node) {
+func (s *periodicAppDataSource[T]) BeforeNodeRemoval(driver.Node) {
 	// ignored
 }
 

--- a/driver/monitoring/node/node_source.go
+++ b/driver/monitoring/node/node_source.go
@@ -79,7 +79,7 @@ func (s *periodicNodeDataSource[T]) AfterNodeCreation(node driver.Node) {
 	s.AddSubject(mon.Node(label), sensor)
 }
 
-func (s *periodicNodeDataSource[T]) AfterNodeRemoval(node driver.Node) {
+func (s *periodicNodeDataSource[T]) BeforeNodeRemoval(node driver.Node) {
 	label := node.GetLabel()
 	s.RemoveSubject(mon.Node(label))
 }

--- a/driver/monitoring/node_log_provider.go
+++ b/driver/monitoring/node_log_provider.go
@@ -124,7 +124,7 @@ func (n *NodeLogDispatcher) AfterNodeCreation(node driver.Node) {
 	n.startDispatcher(Node(nodeId), logStream)
 }
 
-func (n *NodeLogDispatcher) AfterNodeRemoval(_ driver.Node) {
+func (n *NodeLogDispatcher) BeforeNodeRemoval(_ driver.Node) {
 }
 
 func (n *NodeLogDispatcher) AfterApplicationCreation(driver.Application) {

--- a/driver/monitoring/prom_log_provider.go
+++ b/driver/monitoring/prom_log_provider.go
@@ -219,7 +219,7 @@ func (n *PrometheusLogDispatcher) AfterNodeCreation(driverNode driver.Node) {
 	}
 }
 
-func (n *PrometheusLogDispatcher) AfterNodeRemoval(node driver.Node) {
+func (n *PrometheusLogDispatcher) BeforeNodeRemoval(node driver.Node) {
 	n.nodesLock.Lock()
 	defer n.nodesLock.Unlock()
 

--- a/driver/monitoring/prometheus/prometheus.go
+++ b/driver/monitoring/prometheus/prometheus.go
@@ -139,7 +139,7 @@ func (p *Prometheus) AfterNodeCreation(node driver.Node) {
 	}
 }
 
-func (p *Prometheus) AfterNodeRemoval(driver.Node) {
+func (p *Prometheus) BeforeNodeRemoval(driver.Node) {
 	// ignored
 }
 

--- a/driver/monitoring/user/user_source.go
+++ b/driver/monitoring/user/user_source.go
@@ -73,7 +73,7 @@ func (s *periodicUserDataSource[T]) AfterNodeCreation(driver.Node) {
 	// ignored
 }
 
-func (s *periodicUserDataSource[T]) AfterNodeRemoval(driver.Node) {
+func (s *periodicUserDataSource[T]) BeforeNodeRemoval(driver.Node) {
 	// ignored
 }
 

--- a/driver/network.go
+++ b/driver/network.go
@@ -99,8 +99,8 @@ type NetworkRules map[string]string
 type NetworkListener interface {
 	// AfterNodeCreation is called whenever a new node has joined the network.
 	AfterNodeCreation(Node)
-	// AfterNodeRemoval is called whenever a node is removed from the network.
-	AfterNodeRemoval(Node)
+	// BeforeNodeRemoval is called whenever a node is removed from the network.
+	BeforeNodeRemoval(Node)
 	// AfterApplicationCreation is called after a new application has started.
 	AfterApplicationCreation(Application)
 }

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -402,7 +402,7 @@ func TestLocalNetwork_CanRemoveNode(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			listener := driver.NewMockNetworkListener(ctrl)
 			listener.EXPECT().AfterNodeCreation(gomock.Any()).Times(N)
-			listener.EXPECT().AfterNodeRemoval(gomock.Any()).Times(N)
+			listener.EXPECT().BeforeNodeRemoval(gomock.Any()).Times(N)
 			net.RegisterListener(listener)
 
 			if err != nil {

--- a/driver/network/rpc/rpc_pool.go
+++ b/driver/network/rpc/rpc_pool.go
@@ -67,7 +67,7 @@ func (p *RpcWorkerPool) AfterNodeCreation(newNode driver.Node) {
 	}
 }
 
-func (p *RpcWorkerPool) AfterNodeRemoval(node driver.Node) {
+func (p *RpcWorkerPool) BeforeNodeRemoval(node driver.Node) {
 	p.workers[node].close()
 }
 

--- a/driver/network_mock.go
+++ b/driver/network_mock.go
@@ -254,14 +254,14 @@ func (mr *MockNetworkListenerMockRecorder) AfterNodeCreation(arg0 any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterNodeCreation", reflect.TypeOf((*MockNetworkListener)(nil).AfterNodeCreation), arg0)
 }
 
-// AfterNodeRemoval mocks base method.
-func (m *MockNetworkListener) AfterNodeRemoval(arg0 Node) {
+// BeforeNodeRemoval mocks base method.
+func (m *MockNetworkListener) BeforeNodeRemoval(arg0 Node) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AfterNodeRemoval", arg0)
+	m.ctrl.Call(m, "BeforeNodeRemoval", arg0)
 }
 
-// AfterNodeRemoval indicates an expected call of AfterNodeRemoval.
-func (mr *MockNetworkListenerMockRecorder) AfterNodeRemoval(arg0 any) *gomock.Call {
+// BeforeNodeRemoval indicates an expected call of BeforeNodeRemoval.
+func (mr *MockNetworkListenerMockRecorder) BeforeNodeRemoval(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterNodeRemoval", reflect.TypeOf((*MockNetworkListener)(nil).AfterNodeRemoval), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeforeNodeRemoval", reflect.TypeOf((*MockNetworkListener)(nil).BeforeNodeRemoval), arg0)
 }

--- a/driver/norma/progress.go
+++ b/driver/norma/progress.go
@@ -2,16 +2,17 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"sort"
+	"sync"
+	"time"
+
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/monitoring"
 	netmon "github.com/0xsoniclabs/norma/driver/monitoring/network"
 	nodemon "github.com/0xsoniclabs/norma/driver/monitoring/node"
 	"github.com/0xsoniclabs/norma/driver/network/local"
 	"golang.org/x/exp/constraints"
-	"log"
-	"sort"
-	"sync"
-	"time"
 )
 
 // progressLogger is a helper struct that logs the progress of the network.
@@ -66,7 +67,7 @@ func (l *activeNodes) AfterNodeCreation(node driver.Node) {
 	l.data[driver.NodeID(node.GetLabel())] = struct{}{}
 }
 
-func (l *activeNodes) AfterNodeRemoval(node driver.Node) {
+func (l *activeNodes) BeforeNodeRemoval(node driver.Node) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 	delete(l.data, driver.NodeID(node.GetLabel()))

--- a/driver/norma/progress_test.go
+++ b/driver/norma/progress_test.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/0xsoniclabs/norma/driver"
-	"go.uber.org/mock/gomock"
 	"math/rand"
 	"testing"
+
+	"github.com/0xsoniclabs/norma/driver"
+	"go.uber.org/mock/gomock"
 )
 
 func TestActiveNodes_TrackActiveNodes(t *testing.T) {
@@ -32,7 +33,7 @@ func TestActiveNodes_TrackActiveNodes(t *testing.T) {
 			node := driver.NewMockNode(ctrl)
 			node.EXPECT().GetLabel().Return(id)
 			delete(shadow, driver.NodeID(id))
-			nodes.AfterNodeRemoval(node)
+			nodes.BeforeNodeRemoval(node)
 		}
 	}
 


### PR DESCRIPTION
This PR replaces the `AfterNodeRemoval` notification signal with a `BeforeNodeRemoval` signal.

All users of the `AfterNodeRemoval` event notification actually require to be informed about the removal of a node before it is actually removed to avoid attempting accessing its resources while it is removed.

Notifying interested parties only after the removal of a node may contribute to flakiness. Notifying nodes before they are removed may thus increase stability.