### PR TITLE
Add support for removing stake for validators when being stopped 

### DIFF
--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -18,11 +18,13 @@ package executor
 
 import (
 	"fmt"
-	"github.com/0xsoniclabs/norma/driver/checking"
 	"log"
 	"os"
 	"os/signal"
 	"time"
+
+	"github.com/0xsoniclabs/norma/driver/checking"
+	"github.com/0xsoniclabs/norma/driver/network"
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/parser"
@@ -253,6 +255,14 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 					return nil
 				}
 
+				// Validators only need to be unregistered if they are stopped
+				// before the end of the scenario. At the end of the scenario,
+				// validators can no longer be unregistered since the network
+				// is being shut down, losing the ability to run transactions.
+				if endTime != end && nodeIsValidator {
+					unregisterValidator(net, *instance)
+				}
+
 				if err := net.RemoveNode(*instance); err != nil {
 					return err
 				}
@@ -266,6 +276,23 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 			},
 		))
 	}
+}
+
+func unregisterValidator(net driver.Network, node driver.Node) error {
+	validatorId := node.GetValidatorId()
+	if validatorId == nil {
+		return nil
+	}
+	rpcClient, err := net.DialRandomRpc()
+	if err != nil {
+		return fmt.Errorf("failed to connect to RPC; %v", err)
+	}
+	defer rpcClient.Close()
+	err = network.UnregisterValidatorNode(rpcClient, *validatorId)
+	if err != nil {
+		return fmt.Errorf("failed to unregister validator node; %v", err)
+	}
+	return nil
 }
 
 // scheduleApplicationEvents schedules a number of events covering the life-cycle of a class of

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -203,7 +203,7 @@ func (n *LocalNetwork) createNode(nodeConfig *node.OperaNodeConfig) (*node.Opera
 
 // CreateNode creates nodes in the network during run.
 func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error) {
-	newValId := 0
+	var newValId *int
 	if config.Validator {
 		var err error
 		rpcClient, err := n.DialRandomRpc()
@@ -212,10 +212,11 @@ func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error
 		}
 		defer rpcClient.Close()
 
-		newValId, err = network.RegisterValidatorNode(rpcClient)
+		id, err := network.RegisterValidatorNode(rpcClient)
 		if err != nil {
 			return nil, err
 		}
+		newValId = &id
 	}
 
 	if config.Cheater {
@@ -224,7 +225,7 @@ func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error
 			Failing:       config.Failing,
 			Image:         config.Image,
 			NetworkConfig: &n.config,
-			ValidatorId:   &newValId,
+			ValidatorId:   newValId,
 		})
 		if err != nil {
 			return nil, err
@@ -242,7 +243,7 @@ func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error
 		Failing:       config.Failing,
 		Image:         config.Image,
 		NetworkConfig: &n.config,
-		ValidatorId:   &newValId,
+		ValidatorId:   newValId,
 		MountDataDir:  datadir,
 	})
 }

--- a/driver/network/validator.go
+++ b/driver/network/validator.go
@@ -2,6 +2,11 @@ package network
 
 import (
 	"fmt"
+	"log/slog"
+	"math/big"
+	"time"
+
+	"github.com/0xsoniclabs/norma/driver/rpc"
 	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip/contract/sfc100"
 	"github.com/0xsoniclabs/sonic/inter/validatorpk"
@@ -10,7 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"math/big"
 )
 
 // RegisterValidatorNode registers a validator in the SFC contract.
@@ -37,7 +41,7 @@ func RegisterValidatorNode(backend ContractBackend) (int, error) {
 		return 0, fmt.Errorf("failed to create txOpts; %v", err)
 	}
 
-	txOpts.Value = big.NewInt(0).Mul(big.NewInt(5_000_000), big.NewInt(1_000_000_000_000_000_000)) // 5_000_000 FTM
+	txOpts.Value = getStakePerValidator()
 
 	validatorPubKey := validatorpk.PubKey{
 		Raw:  crypto.FromECDSAPub(&privateKeyECDSA.PublicKey),
@@ -58,5 +62,56 @@ func RegisterValidatorNode(backend ContractBackend) (int, error) {
 		return 0, fmt.Errorf("failed to deploy helper contract: transaction reverted")
 	}
 
+	slog.Info(
+		"Completed registration of new validator node",
+		"validator_id", newValId,
+	)
+
 	return newValId, nil
+}
+
+func UnregisterValidatorNode(client rpc.Client, validatorId int) error {
+	slog.Info("Start unregistering validator node", "validator_id", validatorId)
+
+	// get a representation of the deployed contract
+	sfc, err := sfc100.NewContract(sfc.ContractAddress, client)
+	if err != nil {
+		return fmt.Errorf("failed to get SFC contract representation; %v", err)
+	}
+
+	key := evmcore.FakeKey(uint32(validatorId))
+	txOpts, err := bind.NewKeyedTransactorWithChainID(key, big.NewInt(int64(opera.FakeNetRules(opera.GetSonicUpgrades()).NetworkID)))
+	if err != nil {
+		return fmt.Errorf("failed to create txOpts; %v", err)
+	}
+
+	stake := getStakePerValidator()
+
+	// withdraw ID must be unique, so we use the current time in nanoseconds
+	withdrawId := big.NewInt(time.Now().UnixNano())
+	tx, err := sfc.Undelegate(txOpts, big.NewInt(int64(validatorId)), withdrawId, stake)
+	if err != nil {
+		return fmt.Errorf("failed to undelegate validator stake; %v", err)
+	}
+
+	receipt, err := client.WaitTransactionReceipt(tx.Hash())
+	if err != nil {
+		return fmt.Errorf("failed to unregister validator, receipt error: %v", err)
+	}
+
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		return fmt.Errorf("failed to unregister validator: transaction reverted")
+	}
+
+	slog.Info(
+		"Completed unregistering validator node",
+		"validator_id", validatorId,
+	)
+
+	return nil
+}
+
+func getStakePerValidator() *big.Int {
+	// 5_000_000 S
+	return new(big.Int).Mul(big.NewInt(5_000_000), big.NewInt(1e18))
 }

--- a/driver/node.go
+++ b/driver/node.go
@@ -29,7 +29,7 @@ import (
 // control of a node, allowing it to be started (through an Environment),
 // interact with the node, and shut it down.
 type Node interface {
-	// GetLabel returns a human-readable identifer for this node. Is is intended
+	// GetLabel returns a human-readable identifier for this node. Is is intended
 	// to label data and should be unique within a single scenario run.
 	GetLabel() string
 
@@ -48,6 +48,10 @@ type Node interface {
 	// GetNodeID returns an enode identifying this node within the Norma network.
 	// An error shall be produced if no valid node ID could be obtained.
 	GetNodeID() (NodeID, error)
+
+	// GetValidatorId returns the validator ID used by this node, if it is a
+	// validator node. If the node is not a validator, it returns nil.
+	GetValidatorId() *int
 
 	// GetServiceUrl returns the URL of a service running on the
 	// represented node. May be nil if no such service is offered.

--- a/driver/node_mock.go
+++ b/driver/node_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -source node.go -destination node_mock.go -package driver
 //
+
 // Package driver is a generated GoMock package.
 package driver
 
@@ -21,6 +22,7 @@ import (
 type MockNode struct {
 	ctrl     *gomock.Controller
 	recorder *MockNodeMockRecorder
+	isgomock struct{}
 }
 
 // MockNodeMockRecorder is the mock recorder for MockNode.
@@ -110,6 +112,20 @@ func (m *MockNode) GetServiceUrl(arg0 *network.ServiceDescription) *URL {
 func (mr *MockNodeMockRecorder) GetServiceUrl(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceUrl", reflect.TypeOf((*MockNode)(nil).GetServiceUrl), arg0)
+}
+
+// GetValidatorId mocks base method.
+func (m *MockNode) GetValidatorId() *int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetValidatorId")
+	ret0, _ := ret[0].(*int)
+	return ret0
+}
+
+// GetValidatorId indicates an expected call of GetValidatorId.
+func (mr *MockNodeMockRecorder) GetValidatorId() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidatorId", reflect.TypeOf((*MockNode)(nil).GetValidatorId))
 }
 
 // Hostname mocks base method.

--- a/scenarios/test/joining_and_leaving_validator.yml
+++ b/scenarios/test/joining_and_leaving_validator.yml
@@ -1,0 +1,40 @@
+# This scenario covers the joining and leaving of a validator.
+name: Joining and Leaving Validator
+
+# The duration of the scenario's runtime, in seconds.
+duration: 110
+
+# Initial validator nodes in the network. We need 3 validators, such that when
+# the 4th validator is departing, the voting power is not dropping below 2/3
+# of the total voting power.
+validators:
+  - name: validator-init
+    instances: 3
+
+
+# Make sure epochs are only transitioned on demand.
+network_rules:
+  genesis:
+    MAX_EPOCH_DURATION: 600s
+
+
+advance_epoch:
+  - time: 50   # val-extra has joined
+  - time: 90   # val-extra has left
+
+nodes:
+  # the validator joining and leaving the network
+  - name: val-extra
+    start: 30
+    end: 70
+    client:
+      type: validator
+
+
+# Some constant background load to keep the network busy.
+applications:
+  - name: load
+    type: counter
+    users: 50
+    rate:
+      constant: 20    # Tx/s


### PR DESCRIPTION
This PR adds support for undelegating the stake of validators before removing their nodes. This is required to run scenarios with a high validator turn-over rate.

The PR includes a test scenario running a network with initially 3 validators, temporarily extended by a 4th validator. When following the events, it can be observed that the set of validators in the respective epoch are adjusted accordingly. However, there is no automated verification of this yet.

More extensive scenarios testing the full replacement of an initial set of validators are in preparation as part of Sonic's version 2.1 release testing campaign.