### PR TITLE
Check can now be configured

### DIFF
--- a/driver/checking/block_height.go
+++ b/driver/checking/block_height.go
@@ -41,6 +41,31 @@ type blockHeightChecker struct {
 	slack uint8
 }
 
+// Configure returns a deep copy of the original checker.
+// If the config doesn't provide any replacement value, copy from the value of the original.
+// If the config is invalid, return error instead.
+// If the config is nil, return original checker.
+func (c *blockHeightChecker) Configure(config map[string]string) (Checker, error) {
+	if config == nil {
+		return c, nil
+	}
+
+	slack := c.slack
+	sString, exist := config["slack"]
+	if exist {
+		s, err := strconv.Atoi(sString)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert slack; %v", err)
+		}
+		if s < 0 || s > 255 {
+			return nil, fmt.Errorf("invalid slack; 0 < %d < 255", s)
+		}
+		slack = uint8(s)
+	}
+
+	return &blockHeightChecker{net: c.net, slack: slack}, nil
+}
+
 func (c *blockHeightChecker) Check() error {
 	nodes := c.net.GetActiveNodes()
 	fmt.Printf("checking block heights for %d nodes\n", len(nodes))

--- a/driver/checking/blocks_hashes.go
+++ b/driver/checking/blocks_hashes.go
@@ -37,6 +37,11 @@ type blocksHashesChecker struct {
 	net driver.Network
 }
 
+// Configure returns itself since there is nothing to configure
+func (c *blocksHashesChecker) Configure(map[string]string) (Checker, error) {
+	return c, nil
+}
+
 func (c *blocksHashesChecker) Check() (err error) {
 	nodes := c.net.GetActiveNodes()
 	fmt.Printf("checking hashes for %d nodes\n", len(nodes))

--- a/driver/checking/checker.go
+++ b/driver/checking/checker.go
@@ -35,6 +35,7 @@ var registrations = make(registry)
 // Checker does the consistency check at the end of the scenario.
 type Checker interface {
 	Check() error
+	Configure(map[string]string) (Checker, error)
 }
 
 // Checks is a slice of Checker.

--- a/driver/checking/checker_mock.go
+++ b/driver/checking/checker_mock.go
@@ -52,3 +52,18 @@ func (mr *MockCheckerMockRecorder) Check() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Check", reflect.TypeOf((*MockChecker)(nil).Check))
 }
+
+// Configure mocks base method.
+func (m *MockChecker) Configure(arg0 map[string]string) (Checker, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Configure", arg0)
+	ret0, _ := ret[0].(Checker)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Configure indicates an expected call of Configure.
+func (mr *MockCheckerMockRecorder) Configure(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Configure", reflect.TypeOf((*MockChecker)(nil).Configure), arg0)
+}

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -86,7 +86,12 @@ func Run(clock Clock, network driver.Network, scenario *parser.Scenario, checks 
 			return fmt.Errorf("check '%s' not found", c.Check)
 		}
 
-		scheduleCheckEvents(c.Time, c.Check, checker, queue, network)
+		configured, err := checker.Configure(c.Config)
+		if err != nil {
+			return fmt.Errorf("error configuring checks; %v", err)
+		}
+
+		scheduleCheckEvents(c.Time, c.Check, configured, queue, network)
 	}
 
 	// Register a handler for Ctrl+C events.

--- a/driver/parser/check_test.go
+++ b/driver/parser/check_test.go
@@ -619,6 +619,15 @@ func TestScenario_Checks_Success(t *testing.T) {
 				{Time: 45, Check: "test"},
 			},
 		},
+		{
+			Name:     "Test_Check_Succuss3_TestConfig",
+			Duration: 60,
+			Checks: []Check{
+				{Time: 30, Check: "test", Config: map[string]string{
+					"hello": "world",
+				}},
+			},
+		},
 	}
 
 	for _, scenario := range scenarios {

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -65,8 +65,9 @@ type AdvanceEpoch struct {
 
 // Check defines what timing to perform what check
 type Check struct {
-	Time  float32
-	Check string
+	Time   float32
+	Check  string
+	Config map[string]string
 }
 
 // NetworkRulesUpdate defines a network rule update that can be applied at a specific time.

--- a/driver/parser/parser_test.go
+++ b/driver/parser/parser_test.go
@@ -195,6 +195,10 @@ checks:
     check: block_rolling
   - time: 50 
     check: block_rolling
+    config:
+      this: could
+      be: anything
+      even: 123
 `
 
 func TestParseExampleWithChecks(t *testing.T) {


### PR DESCRIPTION
This PR extends Check such that they can be configured as such: `check.Configure(map[string]string).Check()`
- Parser now allows configuration of checks as follow:
```
checks:
  - time: 25
    check: block_rolling
  - time: 30
    check: block_rolling
    config:                        # this will be pass onto Configure
       tolerance: 5
```
- Checker Interface now requires `Configure(map[string]string) (Checker, error)` which, when necessary, will deep copy the original checker and configure the copied instance. The reason we need to deep copy is because we need multiple instances of the same type of checker.
- Each existing implementation of checker has its `Configure` function implemented and tested.
- Executor now `Configure` each check before scheduling it.