### PR TITLE
Introduce CheckerConfig

### DIFF
--- a/driver/checking/block_height.go
+++ b/driver/checking/block_height.go
@@ -45,17 +45,17 @@ type blockHeightChecker struct {
 // If the config doesn't provide any replacement value, copy from the value of the original.
 // If the config is invalid, return error instead.
 // If the config is nil, return original checker.
-func (c *blockHeightChecker) Configure(config map[string]string) (Checker, error) {
+func (c *blockHeightChecker) Configure(config CheckerConfig) (Checker, error) {
 	if config == nil {
 		return c, nil
 	}
 
 	slack := c.slack
-	sString, exist := config["slack"]
+	val, exist := config["slack"]
 	if exist {
-		s, err := strconv.Atoi(sString)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert slack; %v", err)
+		s, ok := val.(int)
+		if !ok {
+			return nil, fmt.Errorf("failed to convert slack; %v", val)
 		}
 		if s < 0 || s > 255 {
 			return nil, fmt.Errorf("invalid slack; 0 < %d < 255", s)

--- a/driver/checking/block_height_test.go
+++ b/driver/checking/block_height_test.go
@@ -31,15 +31,15 @@ func TestBlockHeightCheckerValid(t *testing.T) {
 		blockHeight1 string
 		blockHeight2 string
 		slack        uint8
-		config       map[string]string
+		config       CheckerConfig
 	}{
 		{name: "within-tolerance-big-asc", blockHeight1: "0x42", blockHeight2: "0x52", slack: 16},
 		{name: "within-tolerance-big-desc", blockHeight1: "0x52", blockHeight2: "0x42", slack: 16},
 		{name: "within-tolerance", blockHeight1: "0x42", blockHeight2: "0x43", slack: 1},
 		{name: "constant", blockHeight1: "0x42", blockHeight2: "0x42", slack: 0},
-		{name: "within-tolerance-big-asc-configured", blockHeight1: "0x42", blockHeight2: "0x52", slack: 1, config: map[string]string{"slack": "16"}},
-		{name: "within-tolerance-big-desc-configured", blockHeight1: "0x52", blockHeight2: "0x42", slack: 1, config: map[string]string{"slack": "16"}},
-		{name: "empty-config", blockHeight1: "0x52", blockHeight2: "0x42", slack: 16, config: map[string]string{}},
+		{name: "within-tolerance-big-asc-configured", blockHeight1: "0x42", blockHeight2: "0x52", slack: 1, config: CheckerConfig{"slack": 16}},
+		{name: "within-tolerance-big-desc-configured", blockHeight1: "0x52", blockHeight2: "0x42", slack: 1, config: CheckerConfig{"slack": 16}},
+		{name: "empty-config", blockHeight1: "0x52", blockHeight2: "0x42", slack: 16, config: CheckerConfig{}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -80,15 +80,15 @@ func TestBlockHeightCheckerInvalid_WithSlack(t *testing.T) {
 		blockHeight1 string
 		blockHeight2 string
 		slack        uint8
-		config       map[string]string
+		config       CheckerConfig
 	}{
 		{name: "should-reject-asc", blockHeight1: "0x42", blockHeight2: "0x1234", slack: 5},
 		{name: "should-reject-desc", blockHeight1: "0x1234", blockHeight2: "0x42", slack: 5},
 		{name: "no-slack", blockHeight1: "0x42", blockHeight2: "0x43", slack: 0},
-		{name: "should-reject-asc", blockHeight1: "0x42", blockHeight2: "0x52", slack: 255, config: map[string]string{"slack": "5"}},
-		{name: "should-reject-desc", blockHeight1: "0x52", blockHeight2: "0x42", slack: 255, config: map[string]string{"slack": "5"}},
-		{name: "no-slack", blockHeight1: "0x42", blockHeight2: "0x43", slack: 255, config: map[string]string{"slack": "0"}},
-		{name: "empty-config", blockHeight1: "0x42", blockHeight2: "0x1234", slack: 5, config: map[string]string{}},
+		{name: "should-reject-asc-configured", blockHeight1: "0x42", blockHeight2: "0x52", slack: 255, config: CheckerConfig{"slack": 5}},
+		{name: "should-reject-desc-configured", blockHeight1: "0x52", blockHeight2: "0x42", slack: 255, config: CheckerConfig{"slack": 5}},
+		{name: "no-slack-configured", blockHeight1: "0x42", blockHeight2: "0x43", slack: 255, config: CheckerConfig{"slack": 0}},
+		{name: "empty-config", blockHeight1: "0x42", blockHeight2: "0x1234", slack: 5, config: CheckerConfig{}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -127,12 +127,12 @@ func TestBlockHeightCheckerInvalid_WithSlack(t *testing.T) {
 func TestBlockHeightChecker_ConfigureInvalid(t *testing.T) {
 	tests := []struct {
 		name   string
-		config map[string]string
+		config CheckerConfig
 		err    string
 	}{
-		{name: "test1", config: map[string]string{"slack": "abc"}, err: "failed to convert slack"},
-		{name: "test2", config: map[string]string{"slack": "-1"}, err: "invalid slack"},
-		{name: "test3", config: map[string]string{"slack": "256"}, err: "invalid slack"},
+		{name: "test1", config: CheckerConfig{"slack": "abc"}, err: "failed to convert slack"},
+		{name: "test2", config: CheckerConfig{"slack": -1}, err: "invalid slack"},
+		{name: "test3", config: CheckerConfig{"slack": 256}, err: "invalid slack"},
 	}
 
 	for _, test := range tests {

--- a/driver/checking/blocks_hashes.go
+++ b/driver/checking/blocks_hashes.go
@@ -38,7 +38,7 @@ type blocksHashesChecker struct {
 }
 
 // Configure returns itself since there is nothing to configure
-func (c *blocksHashesChecker) Configure(map[string]string) (Checker, error) {
+func (c *blocksHashesChecker) Configure(config CheckerConfig) (Checker, error) {
 	return c, nil
 }
 

--- a/driver/checking/blocks_rolling.go
+++ b/driver/checking/blocks_rolling.go
@@ -2,7 +2,6 @@ package checking
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/monitoring"
@@ -50,17 +49,17 @@ type blocksRollingChecker struct {
 // If the config doesn't provide any replacement value, copy from the value of the original.
 // If the config is invalid, return error instead.
 // If the config is nil, return original checker.
-func (c *blocksRollingChecker) Configure(config map[string]string) (Checker, error) {
+func (c *blocksRollingChecker) Configure(config CheckerConfig) (Checker, error) {
 	if config == nil {
 		return c, nil
 	}
 
 	tolerance := c.toleranceSamples
-	tString, exist := config["tolerance"]
+	val, exist := config["tolerance"]
 	if exist {
-		t, err := strconv.Atoi(tString)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert tolerance; %v", err)
+		t, ok := val.(int)
+		if !ok {
+			return nil, fmt.Errorf("failed to convert tolerance; %v", val)
 		}
 		tolerance = t
 	}

--- a/driver/checking/blocks_rolling_test.go
+++ b/driver/checking/blocks_rolling_test.go
@@ -97,22 +97,22 @@ func TestBlocksRolling_Configure(t *testing.T) {
 	// original returns error because it sees 1, 1, 1, 1, 1
 	original := blocksRollingChecker{monitor: monitor, toleranceSamples: 5}
 	// success will pass because it sees the entire series 1->6
-	success, err := original.Configure(map[string]string{"tolerance": "10"})
+	success, err := original.Configure(CheckerConfig{"tolerance": 10})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	// emptyOriginal has the same behavior as original
-	emptyOriginal, err := original.Configure(map[string]string{})
+	emptyOriginal, err := original.Configure(CheckerConfig{})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	// emptySuccess has the same behavior as success
-	emptySuccess, err := success.Configure(map[string]string{})
+	emptySuccess, err := success.Configure(CheckerConfig{})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	// misconfigured will throw an error
-	if _, err := original.Configure(map[string]string{"tolerance": "abc"}); err == nil || !strings.Contains(err.Error(), "failed to convert tolerance") {
+	if _, err := original.Configure(CheckerConfig{"tolerance": "abc"}); err == nil || !strings.Contains(err.Error(), "failed to convert tolerance") {
 		t.Errorf("not caught: failed to convert tolerance; %v", err)
 	}
 

--- a/driver/checking/checker.go
+++ b/driver/checking/checker.go
@@ -35,8 +35,11 @@ var registrations = make(registry)
 // Checker does the consistency check at the end of the scenario.
 type Checker interface {
 	Check() error
-	Configure(map[string]string) (Checker, error)
+	Configure(CheckerConfig) (Checker, error)
 }
+
+// CheckerConfig is used to configure Checker
+type CheckerConfig map[string]any
 
 // Checks is a slice of Checker.
 type Checks map[string]Checker

--- a/driver/checking/checker_mock.go
+++ b/driver/checking/checker_mock.go
@@ -54,7 +54,7 @@ func (mr *MockCheckerMockRecorder) Check() *gomock.Call {
 }
 
 // Configure mocks base method.
-func (m *MockChecker) Configure(arg0 map[string]string) (Checker, error) {
+func (m *MockChecker) Configure(arg0 CheckerConfig) (Checker, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Configure", arg0)
 	ret0, _ := ret[0].(Checker)

--- a/driver/parser/check_test.go
+++ b/driver/parser/check_test.go
@@ -623,7 +623,7 @@ func TestScenario_Checks_Success(t *testing.T) {
 			Name:     "Test_Check_Succuss3_TestConfig",
 			Duration: 60,
 			Checks: []Check{
-				{Time: 30, Check: "test", Config: map[string]string{
+				{Time: 30, Check: "test", Config: map[string]any{
 					"hello": "world",
 				}},
 			},

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -67,7 +67,7 @@ type AdvanceEpoch struct {
 type Check struct {
 	Time   float32
 	Check  string
-	Config map[string]string
+	Config map[string]any
 }
 
 // NetworkRulesUpdate defines a network rule update that can be applied at a specific time.


### PR DESCRIPTION
This PR introduces `type CheckerConfig map[string]any` to replace `map[string]string`, mainly to be consumed by `Check.Configure(config CheckerConfig)`.