### PR TITLE
Add support for shutting down initial validators

### DIFF
--- a/driver/parser/check.go
+++ b/driver/parser/check.go
@@ -27,7 +27,7 @@ import (
 	"github.com/0xsoniclabs/norma/load/app"
 )
 
-const namePatternStr = "^[A-Za-z0-9-]+$"
+const namePatternStr = `^[A-Za-z0-9-.]+$`
 
 var namePattern = regexp.MustCompile(namePatternStr)
 
@@ -128,7 +128,7 @@ func (s *Scenario) Check() error {
 func (v *Validator) Check(scenario *Scenario) error {
 	errs := []error{}
 
-	if !namePattern.Match([]byte(v.Name)) {
+	if len(v.Name) != 0 && !namePattern.Match([]byte(v.Name)) {
 		errs = append(errs, fmt.Errorf("validator name must match %v, got %v", namePatternStr, v.Name))
 	}
 

--- a/driver/parser/check_test.go
+++ b/driver/parser/check_test.go
@@ -324,9 +324,6 @@ func TestApplication_DetectsShapeIssue(t *testing.T) {
 func TestValidator_InvalidNameIsDetected(t *testing.T) {
 	scenario := Scenario{}
 	validator := Validator{}
-	if err := validator.Check(&scenario); err == nil || !strings.Contains(err.Error(), "validator name must match") {
-		t.Errorf("missing name was not detected")
-	}
 	validator.Name = "   "
 	if err := validator.Check(&scenario); err == nil || !strings.Contains(err.Error(), "validator name must match") {
 		t.Errorf("missing name was not detected")

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -80,8 +80,9 @@ type NetworkRulesUpdate struct {
 type Validator struct {
 	Name      string
 	Failing   bool
-	Instances *int   `yaml:",omitempty"` // nil is interpreted as 1
-	ImageName string `yaml:",omitempty"` // empty is interpreted as DefaultClientDockerImageName
+	Instances *int     `yaml:",omitempty"` // nil is interpreted as 1
+	ImageName string   `yaml:",omitempty"` // empty is interpreted as DefaultClientDockerImageName
+	End       *float32 `yaml:",omitempty"` // nil is interpreted as end-of-scenario
 }
 
 // Node is a configuration for a group of nodes with similar properties.

--- a/scenarios/scenario_test.go
+++ b/scenarios/scenario_test.go
@@ -25,10 +25,10 @@ import (
 	"github.com/0xsoniclabs/norma/driver/parser"
 )
 
-// TestCheckScenarious iterates through all scenarios in this directory
+// TestCheckScenarios iterates through all scenarios in this directory
 // and its sub-directories and checks whether the contained YAML files
 // define valid scenarios.
-func TestCheckScenarious(t *testing.T) {
+func TestCheckScenarios(t *testing.T) {
 	files, err := listAll()
 	if err != nil {
 		t.Fatalf("failed to get list of all scenario files: %v", err)
@@ -38,12 +38,12 @@ func TestCheckScenarious(t *testing.T) {
 	}
 	for _, file := range files {
 		t.Run(file, func(t *testing.T) {
-			scenaro, err := parser.ParseFile(file)
+			scenario, err := parser.ParseFile(file)
 			if err != nil {
 				t.Fatalf("failed to parse file: %v", err)
 			}
-			if err = scenaro.Check(); err != nil {
-				t.Fatalf("scenaro check failed for: %s: %v", file, err)
+			if err = scenario.Check(); err != nil {
+				t.Fatalf("scenario check failed for: %s: %v", file, err)
 			}
 		})
 	}

--- a/scenarios/test/shutdown_initial_validator.yml
+++ b/scenarios/test/shutdown_initial_validator.yml
@@ -1,0 +1,43 @@
+# This scenario simulates a minimal scenario demonstrating the ability to
+# shut down a validator used during the network boot-up.
+name: Shutdown Initial Validator
+
+# The duration of the scenario's runtime, in seconds.
+duration: 150
+
+# Initial validator nodes in the network.
+validators:
+  - name: validator-initial
+    instances: 1
+    end: 100
+    imagename: "sonic:local"
+
+# Pace epoch changes to match the validator operations.
+advance_epoch:
+  - time: 80   # replacements got online
+  - time: 120   # initial validator is shut down
+
+# We need to start 3 additional validators to ensure that after the shutdown
+# of the initial validator more than 2/3 of the voting power remains.
+nodes:
+  - name: validator-replacement-1
+    start: 20
+    client:
+      type: validator
+  - name: validator-replacement-2
+    start: 40
+    client:
+      type: validator
+  - name: validator-replacement-3
+    start: 60
+    client:
+      type: validator
+
+
+# In the network there is a single application producing constant load.
+applications:
+  - name: load
+    type: counter
+    users: 50
+    rate:
+      constant: 20    # Tx/s


### PR DESCRIPTION
This PR introduces the support for a `end` field the configuration of validators used during network start-ups.

When configuring an initial validator to get offline at a given time, it is undelegating its stake and shutting down analog to what a dynamically introduced validator would do.

This extension facilitates the simulation of scenarios where the set of validators is fully exchanged over time.