### PR TITLE
Increase default block gas ceiling when checking block gas rate

### DIFF
--- a/driver/checking/block_gas_rate.go
+++ b/driver/checking/block_gas_rate.go
@@ -18,12 +18,13 @@ package checking
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/monitoring"
 )
 
-const defaultCeiling float64 = 30_000_000
+const defaultCeiling float64 = math.MaxFloat64
 
 func init() {
 	RegisterNetworkCheck("block_gas_rate", func(net driver.Network, monitor *monitoring.Monitor) Checker {


### PR DESCRIPTION
This PR increases the default `ceiling` value when checking block gas rate.
Current value is 30M, but there are some scenarios that exceed this limit without intending to use this check.
The new value default value is `math.MaxFloat64` and the scenario will specify the ceiling value when relevant.