### PR TITLE
Better parsing any to float64

### DIFF
--- a/driver/checking/block_gas_rate.go
+++ b/driver/checking/block_gas_rate.go
@@ -50,12 +50,25 @@ func (c *blockGasRateChecker) Configure(config CheckerConfig) (Checker, error) {
 		return c, nil
 	}
 
+	toFloat64 := func(val any) (float64, error) {
+		switch v := val.(type) {
+		case float64:
+			return v, nil
+		case int:
+			return float64(v), nil
+		case uint64:
+			return float64(v), nil
+		default:
+			return 0, fmt.Errorf("invalid type; %T", val)
+		}
+	}
+
 	ceiling := c.ceiling
 	val, exist := config["ceiling"]
 	if exist {
-		cl, ok := val.(float64)
-		if !ok {
-			return nil, fmt.Errorf("failed to convert ceiling; %v", val)
+		cl, err := toFloat64(val)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert ceiling; %v", err)
 		}
 		ceiling = cl
 	}

--- a/driver/checking/block_gas_rate_test.go
+++ b/driver/checking/block_gas_rate_test.go
@@ -68,7 +68,7 @@ func TestBlocksGasRate_Configure(t *testing.T) {
 	// original will fail because gas rates exceed 30
 	original := blockGasRateChecker{monitor: monitor, ceiling: 30}
 	// success will pass because ceiling is now 50
-	success, err := original.Configure(CheckerConfig{"ceiling": 50.0})
+	success, err := original.Configure(CheckerConfig{"ceiling": 50})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -111,4 +111,25 @@ func createGasRateSeries(t *testing.T, gasRates []float64) monitoring.Series[mon
 		}
 	}
 	return &series
+}
+
+// TestBlocksGasRate_ParsingCeiling checks parsing any to float64
+func TestBlocksGasRate_ParsingCeiling(t *testing.T) {
+	tests := []any{
+		123,        // int
+		456.7,      // float
+		uint64(89), // uint64
+		^uint64(0), // max uint64
+	}
+
+	for _, test := range tests {
+		ctrl := gomock.NewController(t)
+		monitor := NewMockMonitoringData(ctrl)
+
+		original := blockGasRateChecker{monitor: monitor, ceiling: 30}
+		_, err := original.Configure(CheckerConfig{"ceiling": test})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
 }


### PR DESCRIPTION
This PR replaces `cl, ok := val.(float64)` when parsing any to float64. The expression is not flexible enough to parse integers, the most likely type when creating a scenario.

```
checks:
  - time: 
    check: block_gas_rate 
    config:
      ceiling: 30_000_000   ### example here
 ```