### PR TITLE
App controller checks if network has no node

### DIFF
--- a/driver/monitoring/utils/periodic_source.go
+++ b/driver/monitoring/utils/periodic_source.go
@@ -19,7 +19,6 @@ package utils
 import (
 	"errors"
 	"math/rand"
-	"strings"
 	"time"
 
 	"github.com/0xsoniclabs/norma/driver"

--- a/driver/monitoring/utils/periodic_source.go
+++ b/driver/monitoring/utils/periodic_source.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"errors"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/0xsoniclabs/norma/driver/monitoring"
@@ -124,9 +125,9 @@ func (s *PeriodicDataSource[S, T]) AddSubject(subject S, sensor Sensor[T]) error
 			select {
 			case now := <-ticker.C:
 				value, err := sensor.ReadValue()
-				if err != nil {
+				if err != nil && !strings.Contains(err.Error(), "no node in network") {
 					errs = append(errs, err)
-				} else {
+				} else if err == nil {
 					if err := data.Append(monitoring.NewTime(now), value); err != nil {
 						errs = append(errs, err)
 					}

--- a/driver/monitoring/utils/periodic_source.go
+++ b/driver/monitoring/utils/periodic_source.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/monitoring"
 )
 
@@ -125,7 +126,7 @@ func (s *PeriodicDataSource[S, T]) AddSubject(subject S, sensor Sensor[T]) error
 			select {
 			case now := <-ticker.C:
 				value, err := sensor.ReadValue()
-				if err != nil && !strings.Contains(err.Error(), "no node in network") {
+				if err != nil && !errors.Is(err, driver.ErrEmptyNetwork) {
 					errs = append(errs, err)
 				} else if err == nil {
 					if err := data.Append(monitoring.NewTime(now), value); err != nil {

--- a/driver/network.go
+++ b/driver/network.go
@@ -19,6 +19,7 @@ package driver
 import (
 	"time"
 
+	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/norma/driver/parser"
 	"github.com/0xsoniclabs/norma/driver/rpc"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -31,6 +32,11 @@ const DefaultClientDockerImageName = "sonic"
 
 // DefaultValidators is a default configuration for a single validator.
 var DefaultValidators = NewDefaultValidators(1)
+
+const (
+	// ErrEmptyNetwork is returned when trying to connect to an empty network.
+	ErrEmptyNetwork = common.ConstError("network is empty")
+)
 
 // Network abstracts an execution environment for running scenarios.
 // Implementations may run nodes and applications locally, in docker images, or
@@ -72,6 +78,8 @@ type Network interface {
 
 	SendTransaction(tx *types.Transaction)
 
+	// Create a connection to a random node on the network. May fail if there
+	// is no node on the network with a ErrorEmptyNetwork error.
 	DialRandomRpc() (rpc.Client, error)
 
 	// ApplyNetworkRules applies the given network rules to the network.

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -276,7 +276,7 @@ func (n *LocalNetwork) SendTransaction(tx *types.Transaction) {
 
 func (n *LocalNetwork) DialRandomRpc() (rpcdriver.Client, error) {
 	if len(n.nodes) == 0 {
-		return nil, fmt.Errorf("no nodes in the network")
+		return nil, driver.ErrEmptyNetwork
 	}
 	nodes := n.GetActiveNodes()
 	return nodes[rand.Intn(len(nodes))].DialRpc()

--- a/load/controller/controller.go
+++ b/load/controller/controller.go
@@ -140,6 +140,12 @@ func (ac *AppController) GetReceivedTransactions() (uint64, error) {
 
 		// attempt a re-connect
 		ac.rpcClient.Close()
+
+		nodes := ac.network.GetActiveNodes()
+		if len(nodes) == 0 {
+			return 0, fmt.Errorf("no node in network")
+		}
+
 		ac.rpcClient, err = ac.network.DialRandomRpc()
 		if err != nil {
 			return 0, fmt.Errorf("failed to dial random RPC; %v", err)

--- a/load/controller/controller.go
+++ b/load/controller/controller.go
@@ -140,12 +140,6 @@ func (ac *AppController) GetReceivedTransactions() (uint64, error) {
 
 		// attempt a re-connect
 		ac.rpcClient.Close()
-
-		nodes := ac.network.GetActiveNodes()
-		if len(nodes) == 0 {
-			return 0, fmt.Errorf("no node in network")
-		}
-
 		ac.rpcClient, err = ac.network.DialRandomRpc()
 		if err != nil {
 			return 0, fmt.Errorf("failed to dial random RPC; %v", err)


### PR DESCRIPTION
This PR modifies `load/controller`'s `GetReceivedTransactions()` method so that it checks if the network is empty.
If so, it returns an error that the `periodic_source` knows to catch and do nothing and not panic.

This solves the problem that currently, there's a timing between last node removal and monitoring shutdown that a periodic source could `ReadValue()`. When such a call happen, the monitor shutdown will fail, sometimes panic.