### PR TITLE
Support disabling default checks

### DIFF
--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -99,7 +99,7 @@ func run(
 		scheduleAdvanceEpochEvents(adv.Time, epochs, queue, network)
 	}
 
-	for _, c := range scenario.Checks {
+	for _, c := range scenario.Checks.CustomChecks {
 		checker := checks.GetCheckerByName(c.Check)
 		if checker == nil {
 			return fmt.Errorf("check '%s' not found", c.Check)

--- a/driver/parser/check.go
+++ b/driver/parser/check.go
@@ -115,7 +115,7 @@ func (s *Scenario) Check() error {
 		}
 	}
 
-	for _, chk := range s.Checks {
+	for _, chk := range s.Checks.CustomChecks {
 		if chk.Time < 0 || chk.Time > s.Duration {
 			errs = append(errs, fmt.Errorf("invalid timing for checks: %f", chk.Time))
 		}

--- a/driver/parser/check_test.go
+++ b/driver/parser/check_test.go
@@ -643,29 +643,29 @@ func TestScenario_Checks_Success(t *testing.T) {
 		{
 			Name:     "Test_Check_Success1",
 			Duration: 60,
-			Checks: []Check{
+			Checks: Check{CustomChecks: []CustomCheck{
 				{Time: 30, Check: "test"},
-			},
+			}},
 		},
 		{
 			Name:     "Test_Check_Succuss2",
 			Duration: 60,
-			Checks: []Check{
+			Checks: Check{CustomChecks: []CustomCheck{
 				{Time: 30, Check: "test"},
 				{Time: 30, Check: "test2"},
 				{Time: 20, Check: "test3"},
 				{Time: 40, Check: "test4"},
 				{Time: 45, Check: "test"},
-			},
+			}},
 		},
 		{
 			Name:     "Test_Check_Succuss3_TestConfig",
 			Duration: 60,
-			Checks: []Check{
+			Checks: Check{CustomChecks: []CustomCheck{
 				{Time: 30, Check: "test", Config: map[string]any{
 					"hello": "world",
 				}},
-			},
+			}},
 		},
 	}
 
@@ -684,16 +684,16 @@ func TestScenario_Checks_Failure(t *testing.T) {
 		{
 			Name:     "Test_Check_Failure1_BeforeSim",
 			Duration: 60,
-			Checks: []Check{
+			Checks: Check{CustomChecks: []CustomCheck{
 				{Time: -1, Check: "test"},
-			},
+			}},
 		},
 		{
 			Name:     "Test_Check_Failure_AfterSim",
 			Duration: 60,
-			Checks: []Check{
+			Checks: Check{CustomChecks: []CustomCheck{
 				{Time: 70, Check: "test"},
-			},
+			}},
 		},
 	}
 

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -37,7 +37,7 @@ type Scenario struct {
 	Cheats        []Cheat        `yaml:",omitempty"`
 	NetworkRules  NetworkRules   `yaml:"network_rules,omitempty"`
 	AdvanceEpoch  []AdvanceEpoch `yaml:"advance_epoch,omitempty"`
-	Checks        []Check        `yaml:"checks,omitempty"`
+	Checks        Check          `yaml:"checks,omitempty"`
 }
 
 func (s *Scenario) GetRoundTripTime() time.Duration {
@@ -63,8 +63,14 @@ type AdvanceEpoch struct {
 	Epochs *int `yaml:",omitempty"` // nil is interpreted as 1
 }
 
-// Check defines what timing to perform what check
+// Check defines the checks that are carried out during the simulation
 type Check struct {
+	DefaultChecks map[string]bool `yaml:"default,omitempty"` // this allow disabling of default checks by nameing the check and setting it to false
+	CustomChecks  []CustomCheck   `yaml:"custom,omitempty"`  // this allows custom checks
+}
+
+// Check defines what timing to perform what check
+type CustomCheck struct {
 	Time   float32
 	Check  string
 	Config map[string]any

--- a/driver/parser/parser_test.go
+++ b/driver/parser/parser_test.go
@@ -200,14 +200,18 @@ func TestParseExampleWithAdvanceEpoch(t *testing.T) {
 var withChecks = smallExample + `
 
 checks:
-  - time: 25
-    check: block_rolling
-  - time: 50 
-    check: block_rolling
-    config:
-      this: could
-      be: anything
-      even: 123
+  default:
+    blocks_rolling: true
+    block_gas_rate: false
+  custom:
+    - time: 25
+      check: block_rolling
+    - time: 50 
+      check: block_rolling
+      config:
+        this: could
+        be: anything
+        even: 123
 `
 
 func TestParseExampleWithChecks(t *testing.T) {


### PR DESCRIPTION
This PR introduces a way to disable default checks.

Currently we have 4 checks that are enabled by default:
- `block_height` - pass iff the maximum difference between node's block height is less than some slack (defaults to 5)
- `blocks_hashes` - pass iff each node provides the same hashes for all blocks/stateRoots.
- `blocks_rolling` - pass iff for any time interval (defaults to 10 samples) there is at least one node with block height increase.
- `block_gas_rate` - pass iff block gas rate does not exceed a ceiling (defaults to `math.MaxFloat64`)

In blackout scenario, we need to turn off `blocks_rolling` since during blackout, no block height increase is expected for all nodes.
Thus, we need a way to disable default checks.
