### PR TITLE
Fix validator ID mismatched

### DIFF
--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -385,6 +385,7 @@ func scheduleNodeEvents(
 					// When generating ID for multiple instances, assume the
 					// sequence starting at the assigned id, e.g. node with
 					// instances = 3, client.validatorId = 10 will get 10, 11, 12.
+					var vid int
 					if nodeIsValidator {
 						id, err := registry.registerNewValidator()
 						if err != nil {
@@ -396,10 +397,8 @@ func scheduleNodeEvents(
 							if want, got := *node.Client.ValidatorId+i, id; want != got {
 								return fmt.Errorf("validator ID mismatch: expected %d, got %d", want, got)
 							}
-						} else {
-							node.Client.ValidatorId = new(int)
-							*node.Client.ValidatorId = id
 						}
+						vid = id
 					}
 
 					newNode, err := net.CreateNode(&driver.NodeConfig{
@@ -407,7 +406,7 @@ func scheduleNodeEvents(
 						Failing:     node.Failing,
 						Image:       image,
 						Validator:   nodeIsValidator,
-						ValidatorId: node.Client.ValidatorId,
+						ValidatorId: &vid,
 						Cheater:     nodeIsCheater,
 						DataVolume:  node.Client.DataVolume,
 					})


### PR DESCRIPTION
This PR fixes a  bug where `validator ID mismatched` when starting a validator node with `instances > 1`.
Example of symptoms:
```
19:50:58  [32mINFO [0m[07-22|12:50:58.019] Nodes: 7, epc/blk heights: [19/177 19/177 19/176 19/177 19/176 19/176 19/176], tx/s: [18.456375 18.487394 18.518518 18.518518 18.42546 18.42546 18.36394], txs: 11, gas: 1208411, blk processing: [6.385ms 4.964ms 5.207ms 4.574ms 4.664ms 5.758ms 6.268ms]
19:50:58  [32mINFO [0m[07-22|12:50:58.201] Completed registration of new validator node [32mvalidator_id[0m=6
19:50:58  [31mERROR[0m[07-22|12:50:58.202] event execution failed                   [31mtime[0m=142.1 [31mname[0m="[validator-C-1] Creating node" [31mevent_time[0m=140.0 [31merror[0m="validator ID mismatch: expected 7, got 6" [31mduration[0m=2.076s
```

Simplification of issue:

Consider
```
node:
  name: example
  instances: 2
  client:
    type: validator
```
The first node created will have its validator id assigned to some id `x` and it will also modify the configuration such that `node.client.val_id = x`. The second node will have its validator id assigned as the next id `x+1` which will contradicts the check that it should have id `x`.

Modification:
This PR proposes that the node does not modify its own configuration.

---

Run with issues: Norma/job/Sub-pipelines/job/run-13/22 -> red
Test Run with Fix: Norma/job/Sub-pipelines/job/run-13/23 -> green 