### PR TITLE
Fix docker image 1.24->1.24.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 #
 # It checks out the required version of the client, and builds it.
 #
-FROM golang:1.24 AS client-build
+FROM golang:1.24.0 AS client-build
 
 WORKDIR /client
 
@@ -44,7 +44,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build make sonicd sonictool
 #
 # It checks out the local version of the norma, and builds it.
 #
-FROM golang:1.24 AS norma-build
+FROM golang:1.24.0 AS norma-build
 
 # Download dependencies supporting Sonic run first to cache them for faster build when Norma changes.
 WORKDIR /


### PR DESCRIPTION
There is a recent update to docker image `golang:1.24` ([here](https://hub.docker.com/layers/library/golang/1.24/images/sha256-0af4599decd51bf42d73613abc9e0883acfa42b8a94b37ea973db58b01241d98)) 

<img width="1018" height="278" alt="image" src="https://github.com/user-attachments/assets/5e5bffd3-4bb4-4f10-93f6-2ccfe3e74181" />

that breaks sonic client builds, as follow:

- On Norma:
```
20:42:54  + build/norma run -o /mnt/tmp-disk/norma-runs --label run-baseline_check scenarios/test/baseline_check.yml
20:42:54  Reading 'scenarios/test/baseline_check.yml' ...
20:42:54  Starting evaluation run-baseline_check
20:42:54  Monitoring data is written to /mnt/tmp-disk/norma-runs/norma_data_run-baseline_check_2295391465
20:42:54  Network RoundTripTime: 200ms
20:42:54  Network Rule: MAX_BLOCK_GAS: 20500000000
20:42:54  Network Rule: MAX_EPOCH_GAS: 1500000000000
20:46:00  [32mINFO [0m[08-19|13:45:55.256] waiting for worker pool to close
20:46:00  [32mINFO [0m[08-19|13:45:55.256] worker pool has closed
20:46:00  failed to start opera docker; failed to get node online
20:46:00  failed to start opera docker; failed to get node online
```
- On the sonic container:
```
./sonicd: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./sonicd)
```

This PR proposes that we specifically call `golang:1.24.0` that has been known to work and has not received any update.
