### PR TITLE
Cleanup: Automatically remove containers after stop.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,15 +26,17 @@ WORKDIR /client
 # Download expected Client version from the outside defined location.
 # The 'client-src' parameter is passed as '--build-context' to the docker build command.
 
-# Copy the client source from a tagged remote location
-COPY --from=client-src . .
-
-# Download Sonic dependencies first
+# Download Sonic dependencies first to cache them.
+COPY --from=client-src go.mod .
 RUN go mod download
+
+# Copy the rest of the client source code to build it.
+COPY --from=client-src . .
 
 # Build the client
 RUN --mount=type=cache,target=/root/.cache/go-build make sonicd sonictool
 
+#
 # Stage 1b: Build Norma related tools supporting Client runs.
 #
 # It prepeares an image with dependencies for the norma.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,17 +26,15 @@ WORKDIR /client
 # Download expected Client version from the outside defined location.
 # The 'client-src' parameter is passed as '--build-context' to the docker build command.
 
-# Download Sonic dependencies first to cache them.
-COPY --from=client-src go.mod .
-RUN go mod download
-
-# Copy the rest of the client source code to build it.
+# Copy the client source from a tagged remote location
 COPY --from=client-src . .
+
+# Download Sonic dependencies first
+RUN go mod download
 
 # Build the client
 RUN --mount=type=cache,target=/root/.cache/go-build make sonicd sonictool
 
-#
 # Stage 1b: Build Norma related tools supporting Client runs.
 #
 # It prepeares an image with dependencies for the norma.

--- a/Makefile
+++ b/Makefile
@@ -41,14 +41,14 @@ pull-prometheus-image:
 	DOCKER_BUILDKIT=1 docker image pull prom/prometheus:v2.44.0
 
 build-sonic-docker-image-main:
-	DOCKER_BUILDKIT=1 docker build --build-context client-src=$(CLIENT_URL) . -t sonic
+	DOCKER_BUILDKIT=1 docker build --rm --build-context client-src=$(CLIENT_URL) . -t sonic
 
 build-sonic-docker-image-local:
-	DOCKER_BUILDKIT=1 docker build --build-context client-src=sonic . -t sonic:local
+	DOCKER_BUILDKIT=1 docker build --rm --build-context client-src=sonic . -t sonic:local
 
 # Build various client versions
 $(foreach version, $(CLIENT_VERSIONS), build-sonic-docker-image-$(version)):
-	DOCKER_BUILDKIT=1 docker build --build-context client-src=$(CLIENT_URL)\#$(subst build-sonic-docker-image-,,$@) . -t sonic:$(subst build-sonic-docker-image-,,$@)
+	DOCKER_BUILDKIT=1 docker build --rm --build-context client-src=$(CLIENT_URL)\#$(subst build-sonic-docker-image-,,$@) . -t sonic:$(subst build-sonic-docker-image-,,$@)
 
 generate-abi: load/contracts/abi/Counter.abi load/contracts/abi/ERC20.abi load/contracts/abi/Store.abi load/contracts/abi/UniswapV2Pair.abi load/contracts/abi/UniswapRouter.abi load/contracts/abi/Helper.abi load/contracts/abi/SmartAccount.abi load/contracts/abi/EntryPoint.abi # requires installed solc and Ethereum abigen - check README.md
 

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -176,6 +176,7 @@ func (c *Client) Start(config *ContainerConfig) (*Container, error) {
 		Init:         &init,
 		CapAdd:       []string{"NET_ADMIN"},
 		Binds:        binds,
+		AutoRemove:   true, // remove containers after stop
 	}, nil, nil, "")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
These changes affect both building and running containers, docker will release resources after completed. This affects to the container and implicit file systems generated by running the container, not to the images.
This changes will dramatically reduce disk usage over time in developer machines and CI nodes. 

When calling [docker build](https://docs.docker.com/reference/cli/docker/build-legacy/):  ` --rm	Remove intermediate containers after a successful build `
When calling [docker run](https://docs.docker.com/reference/cli/docker/container/run/): `Automatically remove the container and its associated anonymous volumes when it exits `
The latter is equivalent to  `AutoRemove`  in `container.HostConfig` from the go API. 