### PR TITLE
Make retrieval of receipts with logs backward compatible

### DIFF
--- a/driver/rpc/rpc.go
+++ b/driver/rpc/rpc.go
@@ -86,7 +86,7 @@ func (r Impl) WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error)
 	begin := time.Now()
 	delay := time.Millisecond
 	for time.Since(begin) < r.txReceiptTimeout {
-		receipt, err := r.transactionReceipt(context.Background(), txHash)
+		receipt, err := r.transactionReceipt(txHash)
 		if errors.Is(err, ethereum.NotFound) {
 			time.Sleep(delay)
 			delay = 2 * delay
@@ -103,7 +103,7 @@ func (r Impl) WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error)
 	return nil, fmt.Errorf("failed to get transaction receipt: timeout")
 }
 
-func (r Impl) transactionReceipt(ctxt context.Context, txHash common.Hash) (*types.Receipt, error) {
+func (r Impl) transactionReceipt(txHash common.Hash) (*types.Receipt, error) {
 	var result map[string]any
 	err := r.Call(&result, "eth_getTransactionReceipt", txHash)
 	if err == nil && result == nil {

--- a/driver/rpc/rpc.go
+++ b/driver/rpc/rpc.go
@@ -106,6 +106,9 @@ func (r Impl) WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error)
 func (r Impl) transactionReceipt(txHash common.Hash) (*types.Receipt, error) {
 	var result map[string]any
 	err := r.Call(&result, "eth_getTransactionReceipt", txHash)
+	if err != nil {
+		return nil, err
+	}
 	if err == nil && result == nil {
 		return nil, ethereum.NotFound
 	}

--- a/driver/rpc/rpc.go
+++ b/driver/rpc/rpc.go
@@ -18,11 +18,13 @@ package rpc
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum"
 	"math/big"
 	"time"
+
+	"github.com/ethereum/go-ethereum"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -59,7 +61,6 @@ type ethRpcClient interface {
 	NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error)
 	BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error)
 	ChainID(ctx context.Context) (*big.Int, error)
-	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 
 	Close()
 }
@@ -85,7 +86,7 @@ func (r Impl) WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error)
 	begin := time.Now()
 	delay := time.Millisecond
 	for time.Since(begin) < r.txReceiptTimeout {
-		receipt, err := r.TransactionReceipt(context.Background(), txHash)
+		receipt, err := r.transactionReceipt(context.Background(), txHash)
 		if errors.Is(err, ethereum.NotFound) {
 			time.Sleep(delay)
 			delay = 2 * delay
@@ -100,4 +101,40 @@ func (r Impl) WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error)
 		return receipt, nil
 	}
 	return nil, fmt.Errorf("failed to get transaction receipt: timeout")
+}
+
+func (r Impl) transactionReceipt(ctxt context.Context, txHash common.Hash) (*types.Receipt, error) {
+	var result map[string]any
+	err := r.Call(&result, "eth_getTransactionReceipt", txHash)
+	if err == nil && result == nil {
+		return nil, ethereum.NotFound
+	}
+
+	// Remove all log.blockTimestamps to provide backward compatibility.
+	// This fields was introduced in geth 1.16.1 or 1.16.2, but some versions
+	// of Sonic (at least up to 2.1.2) are using 1.16.0. However, the client
+	// used in this code is based on 1.16.2 or older, depending on this field
+	// to be present and formatted in a specific way to parse the JSON result.
+	// We do not need the field in Norma, so we can filter it out.
+	if logs, ok := result["logs"].([]any); ok {
+		for _, log := range logs {
+			if logMap, ok := log.(map[string]any); ok {
+				delete(logMap, "blockTimestamp")
+			}
+		}
+	}
+
+	// Re-encode the result to JSON and decode it into a types.Receipt.
+	jsonEncoded, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal transaction receipt: %w", err)
+	}
+
+	var receipt *types.Receipt
+	err = json.Unmarshal(jsonEncoded, &receipt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal transaction receipt: %w", err)
+	}
+
+	return receipt, nil
 }

--- a/driver/rpc/rpc_test.go
+++ b/driver/rpc/rpc_test.go
@@ -2,10 +2,11 @@ package rpc
 
 import (
 	"errors"
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"go.uber.org/mock/gomock"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -15,21 +16,43 @@ func TestRpcClientImpl_WaitTransactionReceipt_Success(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 
-	mock := NewMockethRpcClient(ctrl)
+	mock := NewMockrpcClient(ctrl)
 	client := Impl{
-		ethRpcClient:     mock,
+		rpcClient:        mock,
 		txReceiptTimeout: time.Hour,
 	}
 
-	expectedReceipt := &types.Receipt{}
+	injectedResult := map[string]any{
+		"cumulativeGasUsed": "0x0",
+		"logsBloom":         "0x" + strings.Repeat("00", 256),
+		"logs":              []map[string]any{},
+		"transactionHash":   "0x" + strings.Repeat("00", 32),
+		"gasUsed":           "0x0",
+	}
+	expectedReceipt := &types.Receipt{
+		CumulativeGasUsed: 0,
+		Bloom:             types.BytesToBloom(make([]byte, 256)),
+		Logs:              nil,
+		TxHash:            common.BytesToHash(make([]byte, 32)),
+		GasUsed:           0,
+	}
 
-	mock.EXPECT().TransactionReceipt(gomock.Any(), gomock.Any()).Return(expectedReceipt, nil)
+	mock.EXPECT().
+		Call(gomock.Any(), "eth_getTransactionReceipt", gomock.Any()).
+		DoAndReturn(func(result interface{}, method string, args ...interface{}) error {
+			resultPtr, ok := result.(*map[string]any)
+			if !ok {
+				t.Fatalf("result type is not *map[string]any")
+			}
+			*resultPtr = injectedResult
+			return nil
+		})
 
 	receipt, err := client.WaitTransactionReceipt(common.Hash{})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if got, want := receipt, expectedReceipt; got != want {
+	if got, want := receipt, expectedReceipt; reflect.DeepEqual(got, want) {
 		t.Errorf("got receipt %v, want %v", got, want)
 	}
 }
@@ -39,13 +62,23 @@ func TestRpcClientImpl_WaitTransactionReceipt_Timeout(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 
-	mock := NewMockethRpcClient(ctrl)
+	mock := NewMockrpcClient(ctrl)
 	client := Impl{
-		ethRpcClient:     mock,
+		rpcClient:        mock,
 		txReceiptTimeout: 10 * time.Second,
 	}
 
-	mock.EXPECT().TransactionReceipt(gomock.Any(), gomock.Any()).Return(nil, ethereum.NotFound).AnyTimes()
+	mock.EXPECT().
+		Call(gomock.Any(), "eth_getTransactionReceipt", gomock.Any()).
+		DoAndReturn(func(result interface{}, method string, args ...interface{}) error {
+			resultPtr, ok := result.(*map[string]any)
+			if !ok {
+				t.Fatalf("result type is not *map[string]any")
+			}
+			*resultPtr = nil
+			return nil
+		}).
+		AnyTimes()
 
 	if _, err := client.WaitTransactionReceipt(common.Hash{}); err == nil || err.Error() != "failed to get transaction receipt: timeout" {
 		t.Fatalf("expected timeout error, got %v", err)
@@ -57,15 +90,18 @@ func TestRpcClientImpl_WaitTransactionReceipt_Error(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 
-	mock := NewMockethRpcClient(ctrl)
+	mock := NewMockrpcClient(ctrl)
 	client := Impl{
-		ethRpcClient:     mock,
+		rpcClient:        mock,
 		txReceiptTimeout: time.Hour,
 	}
 
 	injectedError := errors.New("injectedError")
 
-	mock.EXPECT().TransactionReceipt(gomock.Any(), gomock.Any()).Return(nil, injectedError).Times(1)
+	mock.EXPECT().
+		Call(gomock.Any(), "eth_getTransactionReceipt", gomock.Any()).
+		Return(injectedError).
+		Times(1)
 
 	if _, err := client.WaitTransactionReceipt(common.Hash{}); !errors.Is(err, injectedError) {
 		t.Fatalf("expected error %v, got %v", injectedError, err)


### PR DESCRIPTION
Updates the retrieval of receipts to accept receipts with log messages produced by older and newer geth versions.