### PR TITLE
Update Sonic dependency to use updated sponsorship registry address

### DIFF
--- a/genesis/go.mod
+++ b/genesis/go.mod
@@ -3,7 +3,7 @@ module github.com/0xsoniclabs/norma/genesistools
 go 1.24.0
 
 require (
-	github.com/0xsoniclabs/sonic v0.0.0-20250925063712-96aba1bd8afb
+	github.com/0xsoniclabs/sonic v0.0.0-20251003110647-d27136e14368
 	github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00
 	github.com/ethereum/go-ethereum v1.15.0
 	github.com/urfave/cli/v2 v2.27.5

--- a/genesis/go.sum
+++ b/genesis/go.sum
@@ -2,8 +2,8 @@ github.com/0xsoniclabs/carmen/go v0.0.0-20250708101910-3666ec34654c h1:xWV02BKxk
 github.com/0xsoniclabs/carmen/go v0.0.0-20250708101910-3666ec34654c/go.mod h1:pOYoZnXK6Dacga5Yoh7/38ibbOJ57/B3Q54zMxWtqG8=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250827114033-a49cee8740d2 h1:OHaJBUO/R6SOHCDNMskfnakEz59bo1fl7Tmz73GCUnA=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250827114033-a49cee8740d2/go.mod h1:pm9P/VM1zE+1AQPGpoCEaA/0sbu7GFNex/nyjjPRcrU=
-github.com/0xsoniclabs/sonic v0.0.0-20250925063712-96aba1bd8afb h1:8ydA4IG3SJO16ZJUN/eTN3nfK0qi4nKnqEG5xHvywU8=
-github.com/0xsoniclabs/sonic v0.0.0-20250925063712-96aba1bd8afb/go.mod h1:BY702cQsoXcC4b5GSKXZMoew13M4PneLSNqspVieo8Y=
+github.com/0xsoniclabs/sonic v0.0.0-20251003110647-d27136e14368 h1:bowhJMUBS6S0NePeiwH7Aca0GLnLdurYa5szkEjVorc=
+github.com/0xsoniclabs/sonic v0.0.0-20251003110647-d27136e14368/go.mod h1:BY702cQsoXcC4b5GSKXZMoew13M4PneLSNqspVieo8Y=
 github.com/0xsoniclabs/tosca v0.0.0-20250905062239-b2db1e70e826 h1:oTvp7bBOzh0H43tMfYuaak0naAMZvulAAXYakA3Yhh8=
 github.com/0xsoniclabs/tosca v0.0.0-20250905062239-b2db1e70e826/go.mod h1:HO+N0cPuqKXy77gCmHLPnRcD8VvLCdNi5N5wGZl+tuk=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/0xsoniclabs/carmen/go v0.0.0-20250708101910-3666ec34654c
 	github.com/0xsoniclabs/norma/genesistools v0.0.0-20250218144827-28263a9a85f9
-	github.com/0xsoniclabs/sonic v0.0.0-20250925063712-96aba1bd8afb
+	github.com/0xsoniclabs/sonic v0.0.0-20251003110647-d27136e14368
 	github.com/docker/docker v27.3.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/ethereum/go-ethereum v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/0xsoniclabs/carmen/go v0.0.0-20250708101910-3666ec34654c h1:xWV02BKxk
 github.com/0xsoniclabs/carmen/go v0.0.0-20250708101910-3666ec34654c/go.mod h1:pOYoZnXK6Dacga5Yoh7/38ibbOJ57/B3Q54zMxWtqG8=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250827114033-a49cee8740d2 h1:OHaJBUO/R6SOHCDNMskfnakEz59bo1fl7Tmz73GCUnA=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250827114033-a49cee8740d2/go.mod h1:pm9P/VM1zE+1AQPGpoCEaA/0sbu7GFNex/nyjjPRcrU=
-github.com/0xsoniclabs/sonic v0.0.0-20250925063712-96aba1bd8afb h1:8ydA4IG3SJO16ZJUN/eTN3nfK0qi4nKnqEG5xHvywU8=
-github.com/0xsoniclabs/sonic v0.0.0-20250925063712-96aba1bd8afb/go.mod h1:BY702cQsoXcC4b5GSKXZMoew13M4PneLSNqspVieo8Y=
+github.com/0xsoniclabs/sonic v0.0.0-20251003110647-d27136e14368 h1:bowhJMUBS6S0NePeiwH7Aca0GLnLdurYa5szkEjVorc=
+github.com/0xsoniclabs/sonic v0.0.0-20251003110647-d27136e14368/go.mod h1:BY702cQsoXcC4b5GSKXZMoew13M4PneLSNqspVieo8Y=
 github.com/0xsoniclabs/tosca v0.0.0-20250905062239-b2db1e70e826 h1:oTvp7bBOzh0H43tMfYuaak0naAMZvulAAXYakA3Yhh8=
 github.com/0xsoniclabs/tosca v0.0.0-20250905062239-b2db1e70e826/go.mod h1:HO+N0cPuqKXy77gCmHLPnRcD8VvLCdNi5N5wGZl+tuk=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=


### PR DESCRIPTION
This PR updates the Sonic dependency in Norma to include the most recent address selected for hosting the Sponsorship contract.