### PR TITLE
Rpc_test now checks Call instead of TransactionReceipt

### DIFF
--- a/driver/rpc/rpc.go
+++ b/driver/rpc/rpc.go
@@ -106,6 +106,9 @@ func (r Impl) WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error)
 func (r Impl) transactionReceipt(txHash common.Hash) (*types.Receipt, error) {
 	var result map[string]any
 	err := r.Call(&result, "eth_getTransactionReceipt", txHash)
+	if err != nil {
+		return nil, err
+	}
 	if err == nil && result == nil {
 		return nil, ethereum.NotFound
 	}

--- a/driver/rpc/rpc_test.go
+++ b/driver/rpc/rpc_test.go
@@ -24,17 +24,17 @@ func TestRpcClientImpl_WaitTransactionReceipt_Success(t *testing.T) {
 
 	injectedResult := map[string]any{
 		"cumulativeGasUsed": "0x0",
-		"logsBloom": "0x" + strings.Repeat("00", 256),
-		"logs": []map[string]any{},
-		"transactionHash": "0x" + strings.Repeat("00", 32),
-		"gasUsed": "0x0",
+		"logsBloom":         "0x" + strings.Repeat("00", 256),
+		"logs":              []map[string]any{},
+		"transactionHash":   "0x" + strings.Repeat("00", 32),
+		"gasUsed":           "0x0",
 	}
 	expectedReceipt := &types.Receipt{
 		CumulativeGasUsed: 0,
-		Bloom: types.BytesToBloom(make([]byte, 256)),
-		Logs: nil,
-		TxHash: common.BytesToHash(make([]byte, 32)),
-		GasUsed: 0,
+		Bloom:             types.BytesToBloom(make([]byte, 256)),
+		Logs:              nil,
+		TxHash:            common.BytesToHash(make([]byte, 32)),
+		GasUsed:           0,
 	}
 
 	mock.EXPECT().

--- a/driver/rpc/rpc_test.go
+++ b/driver/rpc/rpc_test.go
@@ -2,10 +2,11 @@ package rpc
 
 import (
 	"errors"
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"go.uber.org/mock/gomock"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -15,21 +16,43 @@ func TestRpcClientImpl_WaitTransactionReceipt_Success(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 
-	mock := NewMockethRpcClient(ctrl)
+	mock := NewMockrpcClient(ctrl)
 	client := Impl{
-		ethRpcClient:     mock,
+		rpcClient:        mock,
 		txReceiptTimeout: time.Hour,
 	}
 
-	expectedReceipt := &types.Receipt{}
+	injectedResult := map[string]any{
+		"cumulativeGasUsed": "0x0",
+		"logsBloom": "0x" + strings.Repeat("00", 256),
+		"logs": []map[string]any{},
+		"transactionHash": "0x" + strings.Repeat("00", 32),
+		"gasUsed": "0x0",
+	}
+	expectedReceipt := &types.Receipt{
+		CumulativeGasUsed: 0,
+		Bloom: types.BytesToBloom(make([]byte, 256)),
+		Logs: nil,
+		TxHash: common.BytesToHash(make([]byte, 32)),
+		GasUsed: 0,
+	}
 
-	mock.EXPECT().TransactionReceipt(gomock.Any(), gomock.Any()).Return(expectedReceipt, nil)
+	mock.EXPECT().
+		Call(gomock.Any(), "eth_getTransactionReceipt", gomock.Any()).
+		DoAndReturn(func(result interface{}, method string, args ...interface{}) error {
+			resultPtr, ok := result.(*map[string]any)
+			if !ok {
+				t.Fatalf("result type is not *map[string]any")
+			}
+			*resultPtr = injectedResult
+			return nil
+		})
 
 	receipt, err := client.WaitTransactionReceipt(common.Hash{})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if got, want := receipt, expectedReceipt; got != want {
+	if got, want := receipt, expectedReceipt; reflect.DeepEqual(got, want) {
 		t.Errorf("got receipt %v, want %v", got, want)
 	}
 }
@@ -39,13 +62,23 @@ func TestRpcClientImpl_WaitTransactionReceipt_Timeout(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 
-	mock := NewMockethRpcClient(ctrl)
+	mock := NewMockrpcClient(ctrl)
 	client := Impl{
-		ethRpcClient:     mock,
+		rpcClient:        mock,
 		txReceiptTimeout: 10 * time.Second,
 	}
 
-	mock.EXPECT().TransactionReceipt(gomock.Any(), gomock.Any()).Return(nil, ethereum.NotFound).AnyTimes()
+	mock.EXPECT().
+		Call(gomock.Any(), "eth_getTransactionReceipt", gomock.Any()).
+		DoAndReturn(func(result interface{}, method string, args ...interface{}) error {
+			resultPtr, ok := result.(*map[string]any)
+			if !ok {
+				t.Fatalf("result type is not *map[string]any")
+			}
+			*resultPtr = nil
+			return nil
+		}).
+		AnyTimes()
 
 	if _, err := client.WaitTransactionReceipt(common.Hash{}); err == nil || err.Error() != "failed to get transaction receipt: timeout" {
 		t.Fatalf("expected timeout error, got %v", err)
@@ -57,15 +90,18 @@ func TestRpcClientImpl_WaitTransactionReceipt_Error(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 
-	mock := NewMockethRpcClient(ctrl)
+	mock := NewMockrpcClient(ctrl)
 	client := Impl{
-		ethRpcClient:     mock,
+		rpcClient:        mock,
 		txReceiptTimeout: time.Hour,
 	}
 
 	injectedError := errors.New("injectedError")
 
-	mock.EXPECT().TransactionReceipt(gomock.Any(), gomock.Any()).Return(nil, injectedError).Times(1)
+	mock.EXPECT().
+		Call(gomock.Any(), "eth_getTransactionReceipt", gomock.Any()).
+		Return(injectedError).
+		Times(1)
 
 	if _, err := client.WaitTransactionReceipt(common.Hash{}); !errors.Is(err, injectedError) {
 		t.Fatalf("expected error %v, got %v", injectedError, err)


### PR DESCRIPTION
This PR modifies `driver/rpc/rpc_test.go` so that it checks `Call` instead of `TransactionReceipt`. 
The reason `TransactionReceipt` is no longer used can be found here: https://github.com/0xsoniclabs/norma/pull/121.