### PR TITLE
Add new versions to docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ BUILD_DIR := $(CURDIR)/build
 .PHONY: all test clean
 
 # Define a list of client versions
-CLIENT_VERSIONS := v2.0.3 v2.0.2 v2.0.1 v2.0.0
+CLIENT_VERSIONS := \
+	v2.0 v2.0.1 v2.0.2 v2.0.3 \
+	v2.1 v2.1.0 v2.1.1 
 CLIENT_URL=https://github.com/0xsoniclabs/sonic.git
 
 all: \


### PR DESCRIPTION
This PR extends the list of images available to Norma with the new release branch and the existing tags in it. 
Building an image from the release branch directly allows testing features from the branch before they get tagged. 

- v2.0 and v2.1 are branches, they will build an image with the HEAD of that branch at the time make is invoked. To be used during experiments.
- Vx.y.z are tags, they represent code released under that tag and will not change between builds. To be used for testing.

The need for adding tags comes from the need to test the current release branch features, which haven't been tagged yet. 