### PR TITLE
Use tag sonic:main instead of sonic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILD_DIR := $(CURDIR)/build
 .PHONY: all test clean
 
 # Define a list of client versions
-CLIENT_VERSIONS := \
+CLIENT_VERSIONS := main \
 	v2.0 v2.0.1 v2.0.2 v2.0.3 \
 	v2.1 v2.1.0 v2.1.1 
 CLIENT_URL=https://github.com/0xsoniclabs/sonic.git
@@ -29,7 +29,6 @@ all: \
     pull-hello-world-image \
     pull-alpine-image \
     pull-prometheus-image \
-    build-sonic-docker-image-main \
     build-sonic-docker-image-local \
     $(foreach version, $(CLIENT_VERSIONS), build-sonic-docker-image-$(version)) \
 
@@ -41,9 +40,6 @@ pull-alpine-image:
 
 pull-prometheus-image:
 	DOCKER_BUILDKIT=1 docker image pull prom/prometheus:v2.44.0
-
-build-sonic-docker-image-main:
-	DOCKER_BUILDKIT=1 docker build --build-context client-src=$(CLIENT_URL) . -t sonic
 
 build-sonic-docker-image-local:
 	DOCKER_BUILDKIT=1 docker build --build-context client-src=sonic . -t sonic:local

--- a/driver/network.go
+++ b/driver/network.go
@@ -28,7 +28,7 @@ import (
 //go:generate mockgen -source network.go -destination network_mock.go -package driver
 
 // DefaultClientDockerImageName is the name of the docker image to use for clients.
-const DefaultClientDockerImageName = "sonic"
+const DefaultClientDockerImageName = "sonic:main"
 
 // DefaultValidators is a default configuration for a single validator.
 var DefaultValidators = NewDefaultValidators(1)

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -312,7 +312,7 @@ func TestLocalNetwork_CanRunWithVariousValidators(t *testing.T) {
 		{Name: "validator1", Instances: &three, ImageName: "sonic:v2.0.0"},
 		{Name: "validator2", Instances: &two, ImageName: "sonic:v2.0.1"},
 		{Name: "validator3", Instances: &one, ImageName: "sonic:v2.0.2"},
-		{Name: "validator4", ImageName: "sonic"},
+		{Name: "validator4", ImageName: "sonic:main"},
 	})
 
 	config := driver.NetworkConfig{Validators: validators}
@@ -479,7 +479,7 @@ func TestLocalNetwork_Num_Validators_Started(t *testing.T) {
 }
 
 // TestLocalNetwork_Can_Run_Multiple_Client_Images_LatestVersions checks if
-// docker can create client through images called "sonic" and "sonic:local"
+// docker can create client through images called "sonic:main" and "sonic:local"
 func TestLocalNetwork_Can_Run_Multiple_Client_Images_LatestVersions(t *testing.T) {
 	t.Parallel()
 	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
@@ -492,7 +492,7 @@ func TestLocalNetwork_Can_Run_Multiple_Client_Images_LatestVersions(t *testing.T
 		_ = net.Shutdown()
 	})
 
-	images := []string{"sonic", "sonic:local"}
+	images := []string{"sonic:main", "sonic:local"}
 	checksum := make(chan string)
 	gotChecksums := 0
 	for _, image := range images {

--- a/driver/parser/parser_test.go
+++ b/driver/parser/parser_test.go
@@ -68,7 +68,7 @@ validators:
     imagename: "sonic:v2.0.1"
   - name: validator-4
     instances: 3
-    imagename: "sonic"
+    imagename: "sonic:main"
 
 nodes:
   - name: A

--- a/scenarios/subsidies.yml
+++ b/scenarios/subsidies.yml
@@ -9,7 +9,7 @@ network_rules:
 validators:
   - name: A
     instances: 2
-    imagename: "sonic"
+    imagename: "sonic:main"
 
 applications:
 

--- a/scenarios/test/advance_epoch.yml
+++ b/scenarios/test/advance_epoch.yml
@@ -14,7 +14,7 @@ duration: 90
 validators:
   - name: validator-latest
     instances: 2
-    imagename: "sonic"
+    imagename: "sonic:main"
 
 # Network rules to be applied to the network.
 # It is an extensible list of key-value pairs.

--- a/scenarios/test/base_fee_add_new_client.yml
+++ b/scenarios/test/base_fee_add_new_client.yml
@@ -29,7 +29,7 @@ nodes:
     instances: 1
     start: 60   # will start when the base fee is already updated
     client:
-      imagename: "sonic"
+      imagename: "sonic:main"
       type: validator
 
 # In the network, there is a few applications producing the load.

--- a/scenarios/test/base_fee_add_older_client.yml
+++ b/scenarios/test/base_fee_add_older_client.yml
@@ -21,7 +21,7 @@ network_rules:
 # Initial validator nodes in the network.
 validators:
   - name: validator-latest
-    imagename: "sonic"
+    imagename: "sonic:main"
 
 # Append updated nodes in the network.
 nodes:

--- a/scenarios/test/baseline_check.yml
+++ b/scenarios/test/baseline_check.yml
@@ -11,7 +11,7 @@ round_trip_time: "200ms"
 validators:
   - name: validator-latest
     instances: 2
-    imagename: "sonic"
+    imagename: "sonic:main"
 
 # Network rules to be applied to the network.
 # It is an extensible list of key-value pairs.

--- a/scenarios/test/custom_checks.yml
+++ b/scenarios/test/custom_checks.yml
@@ -10,7 +10,7 @@ round_trip_time: "200ms"
 validators:
   - name: validator-latest
     instances: 2
-    imagename: "sonic"
+    imagename: "sonic:main"
 
 network_rules:
   genesis:

--- a/scenarios/test/eip7702.yml
+++ b/scenarios/test/eip7702.yml
@@ -15,7 +15,7 @@ network_rules:
 # Initial validator nodes in the network.
 validators:
   - name: validator-allegro
-    imagename: "sonic"
+    imagename: "sonic:main"
 
 # In the network there is a single application producing constant load.
 applications:

--- a/scenarios/test/min_base_fee_update.yml
+++ b/scenarios/test/min_base_fee_update.yml
@@ -17,7 +17,7 @@ validators:
   - name: validator-v2.0.3
     imagename: "sonic:v2.0.3"
   - name: validator-allegro
-    imagename: "sonic"
+    imagename: "sonic:main"
 
 # Update the base fee on the network.
 network_rules:

--- a/scenarios/test/various_validator_versions.yml
+++ b/scenarios/test/various_validator_versions.yml
@@ -24,7 +24,7 @@ validators:
     imagename: "sonic:v2.0.1"
   - name: validator-latest
     instances: 3
-    imagename: "sonic"
+    imagename: "sonic:main"
 
 
 # In the network, there is a few applications producing the load.


### PR DESCRIPTION
This is an optional cleanup which makes the tagging of the sonic branch explicit.
This avoids confusion between "sonic" and "sonic:local" tags. 

The reason why this PR is optional is that it may break downstream projects that rely on the existence of the "sonic" tag.