### PR TITLE
Name container after their unique label.

### DIFF
--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -73,6 +73,7 @@ type Container struct {
 
 // ContainerConfig defines parameters for running Docker Containers.
 type ContainerConfig struct {
+	Name            string
 	ImageName       string
 	ShutdownTimeout *time.Duration
 	PortForwarding  map[network.Port]network.Port // Container Port => Host Port
@@ -176,7 +177,7 @@ func (c *Client) Start(config *ContainerConfig) (*Container, error) {
 		Init:         &init,
 		CapAdd:       []string{"NET_ADMIN"},
 		Binds:        binds,
-	}, nil, nil, "")
+	}, nil, nil, config.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -145,6 +145,7 @@ func StartOperaDockerNode(client *docker.Client, dn *docker.Network, config *Ope
 		maps.Copy(envs, config.NetworkConfig.NetworkRules) // put in the network rules
 
 		return client.Start(&docker.ContainerConfig{
+			Name:            config.Label,
 			ImageName:       config.Image,
 			ShutdownTimeout: &shutdownTimeout,
 			PortForwarding:  portForwarding,


### PR DESCRIPTION
This is a quality of live patch to name containers after the unique Norma label given to the client instance. 

This is useful to debug execution, for example using `$ watch docker ps`