### PR TITLE
Run R reporting in docker - remove R dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ all: \
     pull-hello-world-image \
     pull-alpine-image \
     pull-prometheus-image \
+    build-r-renderer-image \
     build-sonic-docker-image-main \
     build-sonic-docker-image-local \
     $(foreach version, $(CLIENT_VERSIONS), build-sonic-docker-image-$(version)) \
@@ -41,6 +42,9 @@ pull-alpine-image:
 
 pull-prometheus-image:
 	DOCKER_BUILDKIT=1 docker image pull prom/prometheus:v2.44.0
+
+build-r-renderer-image:
+	DOCKER_BUILDKIT=1 docker build analysis/report/ -t norma-r-renderer
 
 build-sonic-docker-image-main:
 	DOCKER_BUILDKIT=1 docker build --build-context client-src=$(CLIENT_URL) . -t sonic
@@ -106,10 +110,10 @@ load/contracts/abi/EcdsaCounter.abi: load/contracts/EcdsaCounter.sol
 generate-mocks: # requires installed mockgen
 	go generate ./...
 
-norma: pull-prometheus-image build-sonic-docker-image-main
+norma:
 	go build -o $(BUILD_DIR)/norma ./driver/norma
 
-test: pull-hello-world-image pull-alpine-image pull-prometheus-image build-sonic-docker-image-main
+test: pull-hello-world-image pull-alpine-image pull-prometheus-image build-r-renderer-image build-sonic-docker-image-main
 	go test ./... -v
 
 clean:

--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ For building/running the project, the following tools are required:
 * Docker: version 23.0 or later; we recommend to use your system's package manager or the installation manuals listed in the [Using Docker](#using-docker) section below
   * [Docker buildx](https://docs.docker.com/reference/cli/docker/buildx/): to install it on Ubuntu run `apt install docker-buildx`.
 * GNU make, or compatible
-* [R](https://www.r-project.org/): make sure the command `Rscript` is available on your system.
-  * To install R and all needed dependencies on Ubuntu, use `sudo apt install r-base-core pandoc libcurl4-openssl-dev libssl-dev libfontconfig1-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev`
-  * To install R packages manually (may be necessary for first-time R usage), start an R session by running the command `R`, and run the command `install.packages(c("rmarkdown", "tidyverse", "lubridate", "slider"))` inside the R session. You may be prompted to create a user-specific directory for library dependencies. If so, confirm this.
+* R report rendering is handled via Docker - no local R installation required.
 
 Optionally, before running `make generate-mocks`, make sure you installed:
 * GoMock: `go install github.com/golang/mock/mockgen@v1.6.0`

--- a/analysis/report/Dockerfile
+++ b/analysis/report/Dockerfile
@@ -1,0 +1,8 @@
+# Dockerfile for the Norma R report renderer.
+# Build with: make build-r-renderer-image
+#
+# rocker/tidyverse already includes R, rmarkdown, knitr, pandoc, and the full
+# tidyverse (including lubridate). Only `slider` needs to be added on top.
+FROM rocker/tidyverse:4.4
+
+RUN Rscript -e "install.packages('slider', repos='https://cloud.r-project.org')"

--- a/analysis/report/report.go
+++ b/analysis/report/report.go
@@ -74,7 +74,14 @@ func (r *Report) Render(datafile, outputdir string) (string, error) {
 
 	outputfile := r.name + ".html"
 
-	cmd := exec.Command("Rscript", script, template, datafile, outputdir, outputfile)
+	cmd := exec.Command("docker", "run", "--rm",
+		"-v", script+":/render.R:ro",
+		"-v", template+":/template.Rmd:ro",
+		"-v", datafile+":/input.csv:ro",
+		"-v", outputdir+":/output",
+		"norma-r-renderer",
+		"Rscript", "/render.R", "/template.Rmd", "/input.csv", "/output", outputfile,
+	)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out


### PR DESCRIPTION
Removes dependency on locally installed R, process reporting in a docker container.

Also modifies the `make norma` target to not rebuild docker images - unnecessary development slowdown.