### PR TITLE
Add ShellCheck Github CI workflow

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,17 @@
+name: ShellCheck
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master

--- a/scenarios/network_rules/generate_network_rules_scenarios.sh
+++ b/scenarios/network_rules/generate_network_rules_scenarios.sh
@@ -50,7 +50,7 @@ keys=(
 
 # Iterate over each key and generate a new YAML file
 for key in "${keys[@]}"; do
-  sanitized_key=$(echo "$key" | sed 's/[^a-zA-Z0-9_-]/_/g')
+  sanitized_key="${key//[^a-zA-Z0-9_-]/_}"
   # Replace the string "MAX_PARENTS: 0" with the current key
   sed "s/MAX_PARENTS:.*/$key/" "$input_yaml" > "$output_dir/network_rules_constraints_$sanitized_key.yml"
 done

--- a/scenarios/network_rules/run_network_rules_batches.sh
+++ b/scenarios/network_rules/run_network_rules_batches.sh
@@ -24,7 +24,7 @@ for yaml_file in "${yaml_files[@]}"; do
     run_yaml "${yaml_file}" &
 
     # Check if the number of running jobs has reached the limit
-    while [  "$(ls -1 ${yaml_dir}/*.job 2>/dev/null | wc -l)" -ge "$max_jobs" ]; do
+    while [[ "$(find "${yaml_dir}" -maxdepth 1 -name '*.job' 2>/dev/null | wc -l)" -ge "$max_jobs" ]]; do
       sleep 10s
     done
 done
@@ -34,5 +34,5 @@ wait
 
 # Check exit codes
 echo "Exit codes for all scenarios:"
-cat ${yaml_dir}/*.exitcode | sort
-rm ${yaml_dir}/*.exitcode
+sort "${yaml_dir}"/*.exitcode
+rm "${yaml_dir}"/*.exitcode

--- a/scripts/run_sonic.sh
+++ b/scripts/run_sonic.sh
@@ -4,8 +4,8 @@ set -euo pipefail # fail if anything fails
 echo "Sonic binary checksum: $(sha256sum   /sonicd | cut -d ' ' -f 1 )"
 
 # Get the local node's IP.
-list=`hostname -I`
-array=($list)
+list=$(hostname -I)
+read -ra array <<< "$list"
 external_ip=${array[0]}
 
 echo "Sonic is going to export its services on ${external_ip}"
@@ -18,8 +18,8 @@ echo "genesis validator count=${VALIDATORS_COUNT}"
 datadir=$STATE_DB_DATADIR
 # Initialize datadir
 if [[ ! -d "${datadir}/chaindata" ]]; then
-  mkdir -p ${datadir}
-  ./sonictool --datadir ${datadir} genesis json --experimental /genesis.json
+  mkdir -p "${datadir}"
+  ./sonictool --datadir "${datadir}" genesis json --experimental /genesis.json
 fi
 
 ##
@@ -27,8 +27,8 @@ fi
 ##
 if [[ $VALIDATOR_ID -ne 0 ]]
 then
-	cmd=`./genesistools validator from -id ${VALIDATOR_ID} -d ${datadir}`
-	res=($cmd)
+	cmd=$(./genesistools validator from -id "${VALIDATOR_ID}" -d "${datadir}")
+	read -ra res <<< "$cmd"
 	VALIDATOR_PUBKEY=${res[0]}
 	VALIDATOR_ADDRESS=${res[1]}
 fi
@@ -54,7 +54,7 @@ fi
 # when network starts with only one genesis validator, then he will not wait to start emitting
 # if there are two or more validators at genesis they have to wait 5 seconds after connecting to the network
 # if another validator connects to the network during run it will wait also 5 seconds to start emitting
-echo [Emitter.EmitIntervals] >> config.toml
+echo '[Emitter.EmitIntervals]' >> config.toml
 if [[ $VALIDATORS_COUNT == 1 && $VALIDATOR_ID == 1 ]]
 then
   echo DoublesignProtection = 0 >> config.toml
@@ -70,22 +70,23 @@ fi
 echo "NETWORK_LATENCY=${NETWORK_LATENCY}"
 if [[ -n "${NETWORK_LATENCY}" ]]; then
   echo "Adding network latency .."
-  tc qdisc add dev eth0 root netem delay $NETWORK_LATENCY
+  tc qdisc add dev eth0 root netem delay "${NETWORK_LATENCY}"
   if ip link show eth1 &>/dev/null; then # if eth1 exists
-    tc qdisc add dev eth1 root netem delay $NETWORK_LATENCY
+    tc qdisc add dev eth1 root netem delay "${NETWORK_LATENCY}"
   fi
 fi
 
 
 # Start sonic as part of a fake net with RPC service.
 export GOMEMLIMIT="1GiB"
+# shellcheck disable=SC2086
 ./sonicd \
-    --datadir=${datadir} \
+    --datadir="${datadir}" \
     ${val_flag} \
     --http --http.addr 0.0.0.0 --http.port 18545 --http.api admin,eth,ftm \
     --ws --ws.addr 0.0.0.0 --ws.port 18546 --ws.api admin,eth,ftm \
     --pprof --pprof.addr 0.0.0.0 \
-    --nat=extip:${external_ip} \
+    --nat="extip:${external_ip}" \
     --metrics \
     --metrics.expensive \
     --config config.toml \


### PR DESCRIPTION
Add ShellCheck to validate bash scripts in the project, fix scripts by its output:

```
./scripts/run_sonic.sh:7:6: note: Use $(...) notation instead of legacy backticks `...`. [SC2006]
./scripts/run_sonic.sh:8:8: warning: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a. [SC2206]
./scripts/run_sonic.sh:21:12: note: Double quote to prevent globbing and word splitting. [SC2086]
./scripts/run_sonic.sh:22:25: note: Double quote to prevent globbing and word splitting. [SC2086]
./scripts/run_sonic.sh:30:6: note: Use $(...) notation instead of legacy backticks `...`. [SC2006]
./scripts/run_sonic.sh:30:41: note: Double quote to prevent globbing and word splitting. [SC2086]
./scripts/run_sonic.sh:30:60: note: Double quote to prevent globbing and word splitting. [SC2086]
./scripts/run_sonic.sh:31:7: warning: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a. [SC2206]
./scripts/run_sonic.sh:57:6: note: Ranges can only match single chars (mentioned due to duplicates). [SC2102]
./scripts/run_sonic.sh:73:42: note: Double quote to prevent globbing and word splitting. [SC2086]
./scripts/run_sonic.sh:75:44: note: Double quote to prevent globbing and word splitting. [SC2086]
./scripts/run_sonic.sh:83:15: note: Double quote to prevent globbing and word splitting. [SC2086]
./scripts/run_sonic.sh:84:5: note: Double quote to prevent globbing and word splitting. [SC2086]
./scripts/run_sonic.sh:88:17: note: Double quote to prevent globbing and word splitting. [SC2086]
./scripts/run_sonic.sh:93:5: note: Double quote to prevent globbing and word splitting. [SC2086]
./scenarios/network_rules/generate_network_rules_scenarios.sh:53:19: note: See if you can use ${variable//search/replace} instead. [SC2001]
./scenarios/network_rules/run_network_rules_batches.sh:27:17: note: Use find instead of ls to better handle non-alphanumeric filenames. [SC2012]

```