### PR TITLE
Include into Mix app only apps supported by current NetworkRules

### DIFF
--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -140,7 +140,7 @@ func NewLocalNetwork(config *driver.NetworkConfig) (*LocalNetwork, error) {
 	}
 
 	// Setup infrastructure for managing applications on the network.
-	appContext, err := app.NewContext(net, primaryAccount)
+	appContext, err := app.NewContext(net, primaryAccount, config.NetworkRules)
 	if err != nil {
 		return nil, errors.Join(
 			fmt.Errorf("failed to create app context; %w", err),

--- a/load/app/app_test.go
+++ b/load/app/app_test.go
@@ -117,11 +117,11 @@ func TestGenerators(t *testing.T) {
 		"UPGRADES_BRIO",
 	} {
 		t.Run(upgrade, func(t *testing.T) {
-
 			// run local network of one node
+			rules := getCumulativeUpgrades(upgrade)
 			net, err := local.NewLocalNetwork(&driver.NetworkConfig{
 				Validators:   driver.DefaultValidators,
-				NetworkRules: getCumulativeUpgrades(upgrade),
+				NetworkRules: rules,
 			})
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
@@ -137,7 +137,7 @@ func TestGenerators(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			appCtx, err := app.NewContext(net, primaryAccount)
+			appCtx, err := app.NewContext(net, primaryAccount, rules)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -175,11 +175,12 @@ func getCumulativeUpgrades(lastSupported string) map[string]string {
 }
 
 func TestGenerators_Subsidies(t *testing.T) {
+	rules := map[string]string{
+		"UPGRADES_GAS_SUBSIDIES": "true",
+	}
 	net, err := local.NewLocalNetwork(&driver.NetworkConfig{
-		Validators: driver.DefaultValidators,
-		NetworkRules: map[string]string{
-			"UPGRADES_GAS_SUBSIDIES": "true",
-		},
+		Validators:   driver.DefaultValidators,
+		NetworkRules: rules,
 	})
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
@@ -195,7 +196,7 @@ func TestGenerators_Subsidies(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	appCtx, err := app.NewContext(net, primaryAccount)
+	appCtx, err := app.NewContext(net, primaryAccount, rules)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -289,7 +290,7 @@ func TestGenerators_Bundles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	context, err := app.NewContext(net, primaryAccount)
+	context, err := app.NewContext(net, primaryAccount, rules)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/load/app/context.go
+++ b/load/app/context.go
@@ -38,6 +38,7 @@ import (
 type AppContext interface {
 	GetClient() rpc.Client
 	GetTreasure() *Account
+	GetNetworkRules() map[string]string
 	GetTransactOptions(account *Account) (*bind.TransactOpts, error)
 	GetReceipt(txHash common.Hash) (*types.Receipt, error)
 	Run(operation func(*bind.TransactOpts) (*types.Transaction, error)) (*types.Receipt, error)
@@ -49,7 +50,7 @@ type RpcClientFactory interface {
 	DialRandomRpc() (rpc.Client, error)
 }
 
-func NewContext(factory RpcClientFactory, treasury *Account) (*appContext, error) {
+func NewContext(factory RpcClientFactory, treasury *Account, networkRules map[string]string) (AppContext, error) {
 	rpcClient, err := factory.DialRandomRpc()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to network: %w", err)
@@ -58,8 +59,9 @@ func NewContext(factory RpcClientFactory, treasury *Account) (*appContext, error
 	// Install the helper contract used by this contract for its operations.
 	// Create a context to interact with the network.
 	res := &appContext{
-		rpcClient: rpcClient,
-		treasury:  treasury,
+		rpcClient:    rpcClient,
+		treasury:     treasury,
+		networkRules: networkRules,
 	}
 
 	// Install a helper contract on the network to perform operations.
@@ -73,9 +75,10 @@ func NewContext(factory RpcClientFactory, treasury *Account) (*appContext, error
 }
 
 type appContext struct {
-	rpcClient rpc.Client       // < access to the network
-	treasury  *Account         // < the account paying for management tasks
-	helper    *contract.Helper // < a contract used for on-chain operations
+	rpcClient    rpc.Client       // < access to the network
+	treasury     *Account         // < the account paying for management tasks
+	helper       *contract.Helper // < a contract used for on-chain operations
+	networkRules map[string]string
 }
 
 func (c *appContext) Close() {
@@ -88,6 +91,10 @@ func (c *appContext) GetClient() rpc.Client {
 
 func (c *appContext) GetTreasure() *Account {
 	return c.treasury
+}
+
+func (c *appContext) GetNetworkRules() map[string]string {
+	return c.networkRules
 }
 
 // GetTransactOptions provides transaction options to be used to send a transaction

--- a/load/app/context_mock.go
+++ b/load/app/context_mock.go
@@ -85,6 +85,20 @@ func (mr *MockAppContextMockRecorder) FundAccounts(accounts, value any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FundAccounts", reflect.TypeOf((*MockAppContext)(nil).FundAccounts), accounts, value)
 }
 
+// GetNetworkRules mocks base method.
+func (m *MockAppContext) GetNetworkRules() map[string]string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetworkRules")
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
+}
+
+// GetNetworkRules indicates an expected call of GetNetworkRules.
+func (mr *MockAppContextMockRecorder) GetNetworkRules() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkRules", reflect.TypeOf((*MockAppContext)(nil).GetNetworkRules))
+}
+
 // GetClient mocks base method.
 func (m *MockAppContext) GetClient() rpc.Client {
 	m.ctrl.T.Helper()

--- a/load/app/large_contract_app_test.go
+++ b/load/app/large_contract_app_test.go
@@ -34,13 +34,14 @@ import (
 // LargeContractCounter and LargeContract on a network without the Brio upgrade
 // fails due to the contract code size exceeding the pre-Brio limits.
 func TestLargeContractDeploymentFailsWithoutBrio(t *testing.T) {
+	rules := map[string]string{
+		"UPGRADES_SONIC":   "true",
+		"UPGRADES_ALLEGRO": "true",
+		// UPGRADES_BRIO omitted intentionally - deployment of large contracts should fail
+	}
 	net, err := local.NewLocalNetwork(&driver.NetworkConfig{
-		Validators: driver.DefaultValidators,
-		NetworkRules: map[string]string{
-			"UPGRADES_SONIC":   "true",
-			"UPGRADES_ALLEGRO": "true",
-			// UPGRADES_BRIO omitted intentionally - deployment of large contracts should fail
-		},
+		Validators:   driver.DefaultValidators,
+		NetworkRules: rules,
 	})
 	if err != nil {
 		t.Fatalf("failed to create local network: %v", err)
@@ -56,7 +57,7 @@ func TestLargeContractDeploymentFailsWithoutBrio(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctxt, err := app.NewContext(net, primaryAccount)
+	ctxt, err := app.NewContext(net, primaryAccount, rules)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/load/app/mix_app.go
+++ b/load/app/mix_app.go
@@ -25,29 +25,39 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-// mixEntry pairs an application type name with a relative weight.
-// The probability of picking an app equals its weight divided by the sum of
-// all weights.
+// mixEntry pairs an application type name with a relative weight and the set
+// of NetworkRules that must be set for this app to be supported.
 type mixEntry struct {
-	appType string
-	weight  int
+	appType       string
+	weight        int
+	requiredRules []string
+}
+
+func (e mixEntry) isEnabled(have map[string]string) bool {
+	for _, name := range e.requiredRules {
+		if have[name] != "true" {
+			return false
+		}
+	}
+	return true
 }
 
 // mixAppTypes lists the application types included in the mix together with
-// their relative selection weights.
+// their relative selection weights and required network rules.
 var mixAppTypes = []mixEntry{
-	{"erc20", 10},
-	{"counter", 10},
-	{"store", 10},
-	{"uniswap", 5},
-	{"smartaccount", 1},
-	{"subsidies", 1},
-	{"transient", 1},
-	{"selfdestructoldcontract", 1},
-	{"selfdestructnewcontract", 1},
-	{"ecdsa", 4},
-	{"largecontract", 1},
-	{"allofbundle", 3},
+	{"erc20", 10, nil},
+	{"counter", 10, nil},
+	{"store", 10, nil},
+	{"uniswap", 5, nil},
+	{"smartaccount", 1, nil},
+	{"subsidies", 1, []string{"UPGRADES_GAS_SUBSIDIES"}},
+	{"transient", 1, nil},
+	{"selfdestructoldcontract", 1, nil},
+	{"selfdestructnewcontract", 1, nil},
+	{"ecdsa", 4, nil},
+	{"largecontract", 1, nil},
+	{"allofbundle", 3, []string{"UPGRADES_TRANSACTION_BUNDLES"}},
+	{"subsidizedbundle", 1, []string{"UPGRADES_GAS_SUBSIDIES", "UPGRADES_TRANSACTION_BUNDLES"}},
 }
 
 // MixApplication initialises one instance of every application type and
@@ -63,9 +73,13 @@ func NewMixApplication(appContext AppContext, feederId, appId uint32) (Applicati
 	cumulativeWeights := make([]int, 0, len(mixAppTypes))
 	totalWeight := 0
 
+	networkRules := appContext.GetNetworkRules()
 	for i, entry := range mixAppTypes {
 		if entry.weight <= 0 {
 			return nil, fmt.Errorf("mix: weight for %q must be positive, got %d", entry.appType, entry.weight)
+		}
+		if !entry.isEnabled(networkRules) {
+			continue
 		}
 
 		// choose subAppId to avoid collision with regular apps, even with sub-apps of other Mix apps

--- a/load/controller/controller_test.go
+++ b/load/controller/controller_test.go
@@ -85,7 +85,7 @@ func TestLoadGeneration_CanRealizeConstantTrafficShape(t *testing.T) {
 			clientFactory.EXPECT().DialRandomRpc().AnyTimes().Return(rpcClient, nil)
 
 			shaper := shaper.NewConstantShaper(float64(rate))
-			appContext, err := app.NewContext(clientFactory, treasure)
+			appContext, err := app.NewContext(clientFactory, treasure, nil)
 			if err != nil {
 				t.Fatalf("failed to create app context: %v", err)
 			}

--- a/load/controller/rpc_test.go
+++ b/load/controller/rpc_test.go
@@ -44,7 +44,7 @@ func TestTrafficGenerating(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	appContext, err := app.NewContext(net, primaryAccount)
+	appContext, err := app.NewContext(net, primaryAccount, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
* prevent generating bundle txs from the Mix app when bundles not enabled on the chain etc.
* adds NetworkRules into AppContext