### PR TITLE
Add scenarios for Brio testing

### DIFF
--- a/scenarios/brio/enabling_brio.yml
+++ b/scenarios/brio/enabling_brio.yml
@@ -1,0 +1,69 @@
+# This scenario simulates a network with Allegro and Gas Subsidies enabled from the start.
+# At some point it enables Brio hardfork, verifying that the clients are able to handle it.
+name: Enabling Brio
+
+# The duration of the scenario's runtime, in seconds.
+duration: 120
+
+# Initial validator nodes in the network.
+validators:
+  - name: validators
+    instances: 3
+    imagename: "sonic:latest"
+
+  #- name: validator-v2.2.0  # uncomment when v2.2.0 is released
+  #  imagename: "sonic:v2.2.0" # the first version supporting Brio, should be compatible with latest
+
+  - name: validator-v2.1.6
+    failing: true # this node should stop working after the hardfork
+    imagename: "sonic:v2.1.6" # the last version not supporting Brio
+
+# Start with Brio disabled, enable it 30 seconds after the start
+network_rules:
+  genesis:
+    UPGRADES_SONIC: true
+    UPGRADES_ALLEGRO: true
+    UPGRADES_GAS_SUBSIDIES: true
+    UPGRADES_BRIO: false
+    UPGRADES_TRANSACTION_BUNDLES: false
+    MAX_EPOCH_DURATION: 3s
+  updates:
+    - time: 30
+      rules:
+        UPGRADES_BRIO: true
+
+# Start few nodes with delays, after enabling Brio, let them sync with existing network
+nodes:
+  - name: node-latest
+    start: 60
+
+  #- name: node-v2.2.0  # uncomment when v2.2.0 is released
+  #  start: 60
+  #  client:
+  #    imagename: "sonic:v2.2.0" # the first version supporting Brio, should be compatible with latest
+
+  - name: node-v2.1.6
+    start: 60
+    failing: true # this node should not be able to sync when Brio is enabled
+    client:
+      imagename: "sonic:v2.1.6" # the last version not supporting Brio, should be compatible as long as Brio is disabled
+
+# In the network, there is a few applications producing the load.
+applications:
+  - name: mix
+    type: mix
+    users: 10
+    rate:
+      constant: 5 # Tx/s
+
+  - name: largecontract
+    type: largecontract # fails until Brio enabled, Brio enables large contract size
+    users: 2
+    rate:
+      constant: 1 # Tx/s
+
+  - name: ecdsa
+    type: ecdsa # fails until Brio enabled, Brio enables P256Verify precompile
+    users: 2
+    rate:
+      constant: 1 # Tx/s

--- a/scenarios/brio/enabling_bundles.yml
+++ b/scenarios/brio/enabling_bundles.yml
@@ -1,0 +1,70 @@
+# This scenario simulates a network with Brio hardfork and Gas Subsidies enabled from the start.
+# At some point it enables bundles support, verifying that the clients are able to handle it.
+name: Enabling Bundles
+
+# The duration of the scenario's runtime, in seconds.
+duration: 120
+
+# Initial validator nodes in the network.
+validators:
+  - name: validators
+    instances: 3
+    imagename: "sonic:latest"
+
+  #- name: validator-v2.2.0  # uncomment when v2.2.0 is released
+  #  imagename: "sonic:v2.2.0" # nodes at 2.2.0 should stay compatible with main
+
+# Start with the Brio hardfork and transaction bundles enabled
+network_rules:
+  genesis:
+    UPGRADES_SONIC: true
+    UPGRADES_ALLEGRO: true
+    UPGRADES_GAS_SUBSIDIES: true
+    UPGRADES_BRIO: true
+    UPGRADES_TRANSACTION_BUNDLES: false
+    MAX_EPOCH_DURATION: 3s
+  updates:
+    - time: 30
+      rules:
+        UPGRADES_TRANSACTION_BUNDLES: true  # bundles enabled 30s after the start
+
+nodes:
+  - name: node-latest
+    start: 60
+
+  #- name: node-v2.2.0 # uncomment when v2.2.0 is released
+  #  start: 60
+  #  client:
+  #    imagename: "sonic:v2.2.0" # the first version supporting Brio, should be compatible with latest
+
+# In the network, there is a few applications producing the load.
+applications:
+  - name: mix
+    type: mix
+    users: 10
+    rate:
+      constant: 5 # Tx/s
+
+  - name: allofbundle
+    type: allofbundle
+    users: 2
+    rate:
+      constant: 1 # Tx/s
+
+  - name: oneofbundle
+    type: oneofbundle
+    users: 2
+    rate:
+      constant: 1 # Tx/s
+
+  - name: subsidizedbundle
+    type: subsidizedbundle
+    users: 2
+    rate:
+      constant: 1 # Tx/s
+
+  - name: failingbundle
+    type: failingbundle
+    users: 4
+    rate:
+      constant: 1 # Tx/s

--- a/scenarios/brio/pre-brio.yml
+++ b/scenarios/brio/pre-brio.yml
@@ -1,0 +1,47 @@
+# This scenario the Sonic client upgrade. It verifies that the new client is compatible
+# with the older clients, while the Brio hardfork is disabled.
+name: Pre-Brio
+
+# The duration of the scenario's runtime, in seconds.
+duration: 120
+
+# Initial validator nodes in the network.
+validators:
+  - name: validators
+    instances: 3
+    imagename: "sonic:latest"
+  #- name: validator-v2.2.0 # uncomment when v2.2.0 is released
+  #  imagename: "sonic:v2.2.0" # the first version supporting Brio, should be compatible with latest
+  - name: validator-v2.1.6
+    imagename: "sonic:v2.1.6" # the last version not supporting Brio, should be compatible as long as Brio is disabled
+
+# Start with the Brio hardfork disabled, no enabling in this scenario
+network_rules:
+  genesis:
+    UPGRADES_SONIC: true
+    UPGRADES_ALLEGRO: true
+    UPGRADES_GAS_SUBSIDIES: true
+    UPGRADES_BRIO: false
+    MAX_EPOCH_DURATION: 3s
+
+# Start few nodes with delays, let them sync with existing network
+nodes:
+  - name: node-latest
+    start: 60
+
+  #- name: node-v2.2.0 # uncomment when v2.2.0 is released
+  #  start: 60
+  #  client:
+  #    imagename: "sonic:v2.2.0" # the first version supporting Brio, should be compatible with latest
+
+  - name: node-v2.1.6
+    start: 60
+    client:
+      imagename: "sonic:v2.1.6" # the last version not supporting Brio, should be compatible as long as Brio is disabled
+
+applications:
+  - name: mix
+    type: mix
+    users: 10
+    rate:
+      constant: 5 # Tx/s


### PR DESCRIPTION
Added three scenarios for the Brio release testing:
1. **pre-brio tests upgrade to the new client version**: runs network with old and new clients (all of 2.1.6 - 2.2.x  versions), checks they are compatible (while Brio is disabled)
2. **enabling_brio tests enabling Brio upgrade**: runs network with old and new clients on Allegro, enables Brio in the middle, checks that only old clients fails (because they does not support Brio)
3. **enabling_bundles tests enabling Bundles**: runs network with new clients (2.2.x) on Brio, enables Bundles in the middle

2 and 3 includes all types of bundle txs, it is expected (but not checked), that:
* bundle txs are handled as a regular txs before Brio (2)
* bundle txs are being rejected when Brio but not Bundles are enabled (2+3)
* bundle txs are processed correctly when Brio and Bundles are enabled (3)
