### PR TITLE
Fix norma run interrupting using context/signal

### DIFF
--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -192,7 +192,7 @@ func (c *Client) Start(config *ContainerConfig) (*Container, error) {
 		}
 	}
 
-	if err := network.Retry(network.DefaultRetryAttempts, 1*time.Second, func() error {
+	if err := network.Retry(context.Background(), network.DefaultRetryAttempts, 1*time.Second, func() error {
 		return c.cli.ContainerStart(context.Background(), resp.ID, container.StartOptions{})
 	}); err != nil {
 		return nil, err

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
-	"os"
-	"os/signal"
 	"time"
 
 	"github.com/0xsoniclabs/norma/driver/checking"
@@ -37,9 +35,9 @@ import (
 
 // Run executes the given scenario on the given network using the provided clock
 // as a time source. Execution will fail (fast) if the scenario is not valid (see
-// Scenario's Check() function).
-func Run(clock Clock, network driver.Network, scenario *parser.Scenario, checks checking.Checks) error {
-	return run(clock, network, scenario, checks, &netBasedValidatorRegistry{
+// Scenario's Check() function). The context can be used to abort the execution.
+func Run(ctx context.Context, clock Clock, network driver.Network, scenario *parser.Scenario, checks checking.Checks) error {
+	return run(ctx, clock, network, scenario, checks, &netBasedValidatorRegistry{
 		net: network,
 	})
 }
@@ -47,6 +45,7 @@ func Run(clock Clock, network driver.Network, scenario *parser.Scenario, checks 
 // run is the internal implementation of the Run function, allowing to
 // inject a validatorRegistry for testing purposes.
 func run(
+	ctx context.Context,
 	clock Clock,
 	network driver.Network,
 	scenario *parser.Scenario,
@@ -117,11 +116,6 @@ func run(
 		scheduleAdvanceEpochEvents(adv.Time, epochs, queue, network)
 	}
 
-	// Register a handler for Ctrl+C events.
-	abort := make(chan os.Signal, 1)
-	signal.Notify(abort, os.Interrupt)
-	defer signal.Stop(abort)
-
 	// restart clock as network initialization could time considerable amount of time.
 	clock.Restart()
 	// Run all events.
@@ -135,7 +129,7 @@ func run(
 		select {
 		case <-clock.NotifyAt(event.time()):
 			// continue processing
-		case <-abort:
+		case <-ctx.Done():
 			// abort processing
 			slog.Warn("received user abort, ending execution")
 			return fmt.Errorf("aborted by user")

--- a/driver/executor/executor_test.go
+++ b/driver/executor/executor_test.go
@@ -17,11 +17,11 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 	"github.com/0xsoniclabs/norma/driver/checking"
 	"github.com/0xsoniclabs/norma/driver/monitoring"
 	"reflect"
-	"syscall"
 	"testing"
 
 	"github.com/0xsoniclabs/norma/driver"
@@ -39,7 +39,7 @@ func TestExecutor_RunEmptyScenario(t *testing.T) {
 		Validators: []parser.Validator{{Name: "validator"}},
 	}
 
-	if err := Run(clock, net, &scenario, nil); err != nil {
+	if err := Run(t.Context(), clock, net, &scenario, nil); err != nil {
 		t.Errorf("failed to run empty scenario: %v", err)
 	}
 	want := Seconds(10)
@@ -74,7 +74,7 @@ func TestExecutor_RunSingleNodeScenario(t *testing.T) {
 		node.EXPECT().Cleanup(),
 	)
 
-	if err := Run(clock, net, &scenario, nil); err != nil {
+	if err := Run(t.Context(), clock, net, &scenario, nil); err != nil {
 		t.Errorf("failed to run scenario: %v", err)
 	}
 	want := Seconds(10)
@@ -117,7 +117,7 @@ func TestExecutor_RunMultipleNodeScenario(t *testing.T) {
 		node2.EXPECT().Cleanup(),
 	)
 
-	if err := Run(clock, net, &scenario, nil); err != nil {
+	if err := Run(t.Context(), clock, net, &scenario, nil); err != nil {
 		t.Errorf("failed to run scenario: %v", err)
 	}
 	want := Seconds(10)
@@ -226,7 +226,7 @@ func TestExecutor_Validator_StartEndRejoinLeave(t *testing.T) {
 		node4.EXPECT().Cleanup(),
 	)
 
-	if err := run(clock, net, &scenario, nil, registry); err != nil {
+	if err := run(t.Context(), clock, net, &scenario, nil, registry); err != nil {
 		t.Errorf("failed to run scenario: %v", err)
 	}
 }
@@ -256,7 +256,7 @@ func TestExecutor_RunSingleApplicationScenario(t *testing.T) {
 	app.EXPECT().Start()
 	app.EXPECT().Stop()
 
-	if err := Run(clock, net, &scenario, nil); err != nil {
+	if err := Run(t.Context(), clock, net, &scenario, nil); err != nil {
 		t.Errorf("failed to run scenario: %v", err)
 	}
 	want := Seconds(10)
@@ -295,7 +295,7 @@ func TestExecutor_RunMultipleApplicationScenario(t *testing.T) {
 	app2.EXPECT().Start()
 	app2.EXPECT().Stop()
 
-	if err := Run(clock, net, &scenario, nil); err != nil {
+	if err := Run(t.Context(), clock, net, &scenario, nil); err != nil {
 		t.Errorf("failed to run scenario: %v", err)
 	}
 	want := Seconds(10)
@@ -322,13 +322,15 @@ func TestExecutor_TestUserAbort(t *testing.T) {
 	net := driver.NewMockNetwork(ctrl)
 	node := driver.NewMockNode(ctrl)
 
-	// In this scenario, a node is created, after which a user interrupt is send.
+	ctx, cancel := context.WithCancel(t.Context())
+
+	// In this scenario, a node is created, after which the context is cancelled.
 	net.EXPECT().CreateNode(gomock.Any()).Do(func(_ any) {
-		fmt.Printf("Sending interrupt signal to local process ..\n")
-		syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+		fmt.Printf("Cancelling context to simulate user abort ..\n")
+		cancel()
 	}).Return(node, nil)
 
-	if err := Run(clock, net, &scenario, nil); err == nil {
+	if err := Run(ctx, clock, net, &scenario, nil); err == nil {
 		t.Errorf("a user interrupt error should be reported")
 	}
 	want := Seconds(1)
@@ -371,7 +373,7 @@ func TestExecutor_RunScenarioWithDefaultChecks(t *testing.T) {
 	checkBlockGasRate.EXPECT().Check().Return(nil)
 
 	checks := checking.InitNetworkChecks(net, nil)
-	if err := Run(clock, net, &scenario, checks); err != nil {
+	if err := Run(t.Context(), clock, net, &scenario, checks); err != nil {
 		t.Errorf("failed to run scenario with default checks: %v", err)
 	}
 	want := Seconds(10)
@@ -400,7 +402,7 @@ func TestExecutor_scheduleNetworkRulesEvents(t *testing.T) {
 		net.EXPECT().ApplyNetworkRules(map[string]string{"MAX_EPOCH_GAS": "1500000000000"}),
 	)
 
-	if err := Run(clock, net, &scenario, nil); err != nil {
+	if err := Run(t.Context(), clock, net, &scenario, nil); err != nil {
 		t.Errorf("failed to run scenario: %v", err)
 	}
 }
@@ -452,7 +454,7 @@ func TestExecutor_scheduleAdvanceEpochEvents(t *testing.T) {
 		net.EXPECT().AdvanceEpoch(7),
 	)
 
-	if err := Run(clock, net, &scenario, nil); err != nil {
+	if err := Run(t.Context(), clock, net, &scenario, nil); err != nil {
 		t.Errorf("failed to run scenario: %v", err)
 	}
 }

--- a/driver/monitoring/monitor_test.go
+++ b/driver/monitoring/monitor_test.go
@@ -167,7 +167,7 @@ func TestMonitorIntegrationPrometheusLogReceived(t *testing.T) {
 	t.Cleanup(func() {
 		_ = client.Close()
 	})
-	node, err := opera.StartOperaDockerNode(client, nil, &opera.OperaNodeConfig{
+	node, err := opera.StartOperaDockerNode(t.Context(), client, nil, &opera.OperaNodeConfig{
 		Label:         "test",
 		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},

--- a/driver/monitoring/node/cpu_profile_test.go
+++ b/driver/monitoring/node/cpu_profile_test.go
@@ -33,7 +33,7 @@ func TestCanCollectCpuProfileDateFromOperaNode(t *testing.T) {
 	t.Cleanup(func() {
 		_ = docker.Close()
 	})
-	node, err := opera.StartOperaDockerNode(docker, nil, &opera.OperaNodeConfig{
+	node, err := opera.StartOperaDockerNode(t.Context(), docker, nil, &opera.OperaNodeConfig{
 		Label:         "test",
 		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},

--- a/driver/monitoring/node/prom_log_source_test.go
+++ b/driver/monitoring/node/prom_log_source_test.go
@@ -98,7 +98,7 @@ func TestLogsIntegrationGetRealMetric(t *testing.T) {
 	t.Cleanup(func() {
 		_ = client.Close()
 	})
-	node, err := opera.StartOperaDockerNode(client, nil, &opera.OperaNodeConfig{
+	node, err := opera.StartOperaDockerNode(t.Context(), client, nil, &opera.OperaNodeConfig{
 		Label:         "test",
 		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},

--- a/driver/monitoring/prometheus/prometheus.go
+++ b/driver/monitoring/prometheus/prometheus.go
@@ -17,6 +17,7 @@
 package prometheusmon
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -82,7 +83,7 @@ func Start(net driver.Network, dn *docker.Network) (*Prometheus, error) {
 
 	// wait until the prometheus inside the Container is ready.
 	// this is necessary for SIGHUP signal to be delivered correctly
-	if err := network.Retry(network.DefaultRetryAttempts, 1*time.Second, func() error {
+	if err := network.Retry(context.Background(), network.DefaultRetryAttempts, 1*time.Second, func() error {
 		resp, err := http.Get(prometheus.GetUrl() + "/-/ready")
 		if err == nil && resp.StatusCode != http.StatusOK {
 			err = fmt.Errorf("not yet HTTP OK")

--- a/driver/monitoring/prometheus/prometheus_test.go
+++ b/driver/monitoring/prometheus/prometheus_test.go
@@ -78,7 +78,7 @@ func TestNodeCanBeAdded(t *testing.T) {
 		t.Fatalf("error: %v", err)
 	}
 	// wait for prometheus to reload config
-	err := network.Retry(network.DefaultRetryAttempts, 1*time.Second, func() error {
+	err := network.Retry(t.Context(), network.DefaultRetryAttempts, 1*time.Second, func() error {
 		// verify node is added by calling prometheus API
 		resp, err := http.Get(prom.GetUrl() + "/api/v1/targets")
 		if err != nil {
@@ -122,7 +122,7 @@ func startPrometheus(t *testing.T, net *local.LocalNetwork) *Prometheus {
 // createLocalNetwork creates a docker network and returns it.
 func createLocalNetwork(t *testing.T) *local.LocalNetwork {
 	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
-	net, err := local.NewLocalNetwork(&config)
+	net, err := local.NewLocalNetwork(t.Context(), &config)
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -75,7 +75,7 @@ type LocalNetwork struct {
 	appContext app.AppContext
 }
 
-func NewLocalNetwork(config *driver.NetworkConfig) (*LocalNetwork, error) {
+func NewLocalNetwork(ctx context.Context, config *driver.NetworkConfig) (*LocalNetwork, error) {
 	client, err := docker.NewClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create docker client; %v", err)
@@ -127,7 +127,7 @@ func NewLocalNetwork(config *driver.NetworkConfig) (*LocalNetwork, error) {
 					Label:          label,
 					ExtraArguments: validator.ExtraArguments,
 				}
-				_, errs[idx] = net.createNode(&nodeConfig)
+				_, errs[idx] = net.createNode(ctx, &nodeConfig)
 			}(idx)
 			idx++
 		}
@@ -187,8 +187,8 @@ func (n *LocalNetwork) startNode(node *node.OperaNode) (*node.OperaNode, error) 
 
 // createNode is an internal version of CreateNode enabling the creation
 // of validator and non-validator nodes in the network.
-func (n *LocalNetwork) createNode(nodeConfig *node.OperaNodeConfig) (*node.OperaNode, error) {
-	node, err := node.StartOperaDockerNode(n.docker, n.network, nodeConfig)
+func (n *LocalNetwork) createNode(ctx context.Context, nodeConfig *node.OperaNodeConfig) (*node.OperaNode, error) {
+	node, err := node.StartOperaDockerNode(ctx, n.docker, n.network, nodeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start opera docker; %v", err)
 	}
@@ -198,7 +198,7 @@ func (n *LocalNetwork) createNode(nodeConfig *node.OperaNodeConfig) (*node.Opera
 // CreateNode creates nodes in the network during run.
 func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error) {
 	if config.Cheater {
-		_, err := n.createNode(&node.OperaNodeConfig{
+		_, err := n.createNode(context.Background(), &node.OperaNodeConfig{
 			Label:          "cheater-" + config.Name,
 			Failing:        config.Failing,
 			Image:          config.Image,
@@ -217,7 +217,7 @@ func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error
 		*datadir = fmt.Sprintf("%s/%s", n.config.OutputDir, *config.DataVolume)
 	}
 
-	return n.createNode(&node.OperaNodeConfig{
+	return n.createNode(context.Background(), &node.OperaNodeConfig{
 		Label:          config.Name,
 		Failing:        config.Failing,
 		Image:          config.Image,

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -47,7 +47,7 @@ func TestLocalNetwork_CanStartNodesAndShutThemDown(t *testing.T) {
 		N := N
 		t.Run(fmt.Sprintf("num_nodes=%d", N), func(t *testing.T) {
 			t.Parallel()
-			net, err := NewLocalNetwork(&config)
+			net, err := NewLocalNetwork(t.Context(), &config)
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
 			}
@@ -92,7 +92,7 @@ func TestLocalNetwork_CanEnforceNetworkLatency(t *testing.T) {
 				Validators:    driver.NewDefaultValidators(2),
 				RoundTripTime: rtt,
 			}
-			net, err := NewLocalNetwork(&config)
+			net, err := NewLocalNetwork(t.Context(), &config)
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
 			}
@@ -127,7 +127,7 @@ func TestLocalNetwork_CanStartApplicationsAndShutThemDown(t *testing.T) {
 		t.Run(fmt.Sprintf("num_nodes=%d", N), func(t *testing.T) {
 			t.Parallel()
 
-			net, err := NewLocalNetwork(&config)
+			net, err := NewLocalNetwork(t.Context(), &config)
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
 			}
@@ -171,7 +171,7 @@ func TestLocalNetwork_CanPerformNetworkShutdown(t *testing.T) {
 	N := 2
 	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
 
-	net, err := NewLocalNetwork(&config)
+	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestLocalNetwork_Shutdown_Graceful(t *testing.T) {
 	N := 3
 	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
 
-	net, err := NewLocalNetwork(&config)
+	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
@@ -275,7 +275,7 @@ func TestLocalNetwork_CanRunWithMultipleValidators(t *testing.T) {
 		config := driver.NetworkConfig{Validators: driver.NewDefaultValidators(N)}
 		t.Run(fmt.Sprintf("num_validators=%d", N), func(t *testing.T) {
 			t.Parallel()
-			net, err := NewLocalNetwork(&config)
+			net, err := NewLocalNetwork(t.Context(), &config)
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
 			}
@@ -317,7 +317,7 @@ func TestLocalNetwork_CanRunWithVariousValidators(t *testing.T) {
 	})
 
 	config := driver.NetworkConfig{Validators: validators}
-	net, err := NewLocalNetwork(&config)
+	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
@@ -339,7 +339,7 @@ func TestLocalNetwork_NotifiesListenersOnNodeStartup(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	listener := driver.NewMockNetworkListener(ctrl)
 
-	net, err := NewLocalNetwork(&config)
+	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
@@ -376,7 +376,7 @@ func TestLocalNetwork_NotifiesListenersOnAppStartup(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	listener := driver.NewMockNetworkListener(ctrl)
 
-	net, err := NewLocalNetwork(&config)
+	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
@@ -402,7 +402,7 @@ func TestLocalNetwork_CanRemoveNode(t *testing.T) {
 		N := N
 		t.Run(fmt.Sprintf("num_nodes=%d", N), func(t *testing.T) {
 			t.Parallel()
-			net, err := NewLocalNetwork(&config)
+			net, err := NewLocalNetwork(t.Context(), &config)
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
 			}
@@ -465,7 +465,7 @@ func TestLocalNetwork_Num_Validators_Started(t *testing.T) {
 		t.Run(fmt.Sprintf("num_validators=%d", i), func(t *testing.T) {
 			t.Parallel()
 			config := driver.NetworkConfig{Validators: driver.NewDefaultValidators(i)}
-			net, err := NewLocalNetwork(&config)
+			net, err := NewLocalNetwork(t.Context(), &config)
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
 			}
@@ -488,7 +488,7 @@ func TestLocalNetwork_Can_Run_Multiple_Client_Images_LatestVersions(t *testing.T
 	t.Parallel()
 	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
 
-	net, err := NewLocalNetwork(&config)
+	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
@@ -530,7 +530,7 @@ func TestLocalNetwork_Can_Run_Multiple_Client_Images_TaggedVersions(t *testing.T
 	t.Parallel()
 	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
 
-	net, err := NewLocalNetwork(&config)
+	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
@@ -599,7 +599,7 @@ func getChecksum(net *LocalNetwork, image string) (string, error) {
 func TestLocalNetworkApplyNetworkRules_Success(t *testing.T) {
 	t.Parallel()
 	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
-	net, err := NewLocalNetwork(&config)
+	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
@@ -648,7 +648,7 @@ func TestLocalNetworkApplyNetworkRules_Success(t *testing.T) {
 func TestLocalNetworkAdvanceEpoch_Success(t *testing.T) {
 	t.Parallel()
 	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
-	net, err := NewLocalNetwork(&config)
+	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
@@ -690,7 +690,7 @@ func TestLocalNetwork_FailingFlagPropagated(t *testing.T) {
 	config := driver.NetworkConfig{Validators: []driver.Validator{
 		{Name: "validator", Failing: true, Instances: 1, ImageName: driver.DefaultClientDockerImageName}},
 	}
-	net, err := NewLocalNetwork(&config)
+	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
@@ -731,7 +731,7 @@ func TestLocalNetwork_MountDataDir_Can_Be_Reused(t *testing.T) {
 	}()
 
 	config := driver.NetworkConfig{Validators: driver.DefaultValidators, OutputDir: temp}
-	net, err := NewLocalNetwork(&config)
+	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}

--- a/driver/network/rpc/rpc_pool.go
+++ b/driver/network/rpc/rpc_pool.go
@@ -158,10 +158,7 @@ func (p *worker) close() {
 
 func (p *worker) runRpcSenderLoop() error {
 	defer close(p.done)
-	rpcClient, err := network.RetryReturn(network.DefaultRetryAttempts, 1*time.Second, func() (*ethclient.Client, error) {
-		if p.ctx.Err() == context.Canceled {
-			return nil, nil
-		}
+	rpcClient, err := network.RetryReturn(p.ctx, network.DefaultRetryAttempts, 1*time.Second, func() (*ethclient.Client, error) {
 		return ethclient.Dial(string(p.rpcUrl))
 	})
 

--- a/driver/network/service.go
+++ b/driver/network/service.go
@@ -17,6 +17,7 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
@@ -122,15 +123,23 @@ const DefaultRetryAttempts = 180
 // delay between attempts. If the execution is not successful since,
 // the execution returns the last error.
 // When execution is successful, the execution result is returned from this method.
-func RetryReturn[Out any](numAttempts int, delay time.Duration, do func() (Out, error)) (Out, error) {
+// The context can be used to abort the retry loop early.
+func RetryReturn[Out any](ctx context.Context, numAttempts int, delay time.Duration, do func() (Out, error)) (Out, error) {
 	var out Out
 	var err error
 	for i := 0; i < numAttempts; i++ {
+		if ctx.Err() != nil {
+			return out, ctx.Err()
+		}
 		out, err = do()
 		if err == nil {
 			break
 		}
-		time.Sleep(delay)
+		select {
+		case <-ctx.Done():
+			return out, ctx.Err()
+		case <-time.After(delay):
+		}
 	}
 	return out, err
 }
@@ -139,8 +148,9 @@ func RetryReturn[Out any](numAttempts int, delay time.Duration, do func() (Out, 
 // It however executes only the configured number of times with the configured
 // delay between attempts. If the execution is not successful since,
 // the execution returns the last error.
-func Retry(numAttempts int, delay time.Duration, do func() error) error {
-	_, err := RetryReturn(numAttempts, delay, func() (*int, error) {
+// The context can be used to abort the retry loop early.
+func Retry(ctx context.Context, numAttempts int, delay time.Duration, do func() error) error {
+	_, err := RetryReturn(ctx, numAttempts, delay, func() (*int, error) {
 		err := do()
 		return nil, err
 	})

--- a/driver/network/service_test.go
+++ b/driver/network/service_test.go
@@ -77,7 +77,7 @@ func TestRetry(t *testing.T) {
 	t.Parallel()
 
 	var count int
-	err := Retry(5, 1*time.Millisecond, func() error {
+	err := Retry(t.Context(), 5, 1*time.Millisecond, func() error {
 		count++
 		if count >= 5 {
 			return nil

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -103,7 +103,7 @@ type OperaNodeConfig struct {
 var labelPattern = regexp.MustCompile("[A-Za-z0-9_-]+")
 
 // StartOperaDockerNode creates a new OperaNode running in a Docker container.
-func StartOperaDockerNode(client *docker.Client, dn *docker.Network, config *OperaNodeConfig) (*OperaNode, error) {
+func StartOperaDockerNode(ctx context.Context, client *docker.Client, dn *docker.Network, config *OperaNodeConfig) (*OperaNode, error) {
 	if !labelPattern.Match([]byte(config.Label)) {
 		return nil, fmt.Errorf("invalid label for node: '%v'", config.Label)
 	}
@@ -115,7 +115,7 @@ func StartOperaDockerNode(client *docker.Client, dn *docker.Network, config *Ope
 		validatorId = fmt.Sprintf("%d", *config.ValidatorId)
 	}
 
-	host, err := network.RetryReturn(network.DefaultRetryAttempts, 1*time.Second, func() (*docker.Container, error) {
+	host, err := network.RetryReturn(ctx, network.DefaultRetryAttempts, 1*time.Second, func() (*docker.Container, error) {
 		ports, err := network.GetFreePorts(len(operaServices.Services()))
 		if err != nil {
 			return nil, err
@@ -189,7 +189,7 @@ func StartOperaDockerNode(client *docker.Client, dn *docker.Network, config *Ope
 	}
 
 	// Wait until the OperaNode inside the Container is ready.
-	err = network.Retry(network.DefaultRetryAttempts, 1*time.Second, func() error {
+	err = network.Retry(ctx, network.DefaultRetryAttempts, 1*time.Second, func() error {
 		_, err := node.GetNodeID()
 		return err
 	})
@@ -293,7 +293,7 @@ func (n *OperaNode) DialRpc() (rpcdriver.Client, error) {
 		return nil, fmt.Errorf("node %s does not export an RPC server", n.GetLabel())
 	}
 
-	rpcClient, err := network.RetryReturn(network.DefaultRetryAttempts, 1*time.Second, func() (*rpc.Client, error) {
+	rpcClient, err := network.RetryReturn(context.Background(), network.DefaultRetryAttempts, 1*time.Second, func() (*rpc.Client, error) {
 		return rpc.DialContext(context.Background(), string(*url))
 	})
 	if err != nil {
@@ -309,7 +309,7 @@ func (n *OperaNode) AddPeer(id driver.NodeID) error {
 	if err != nil {
 		return err
 	}
-	return network.Retry(network.DefaultRetryAttempts, 1*time.Second, func() error {
+	return network.Retry(context.Background(), network.DefaultRetryAttempts, 1*time.Second, func() error {
 		return rpcClient.Call(nil, "admin_addPeer", id)
 	})
 }
@@ -321,7 +321,7 @@ func (n *OperaNode) RemovePeer(id driver.NodeID) error {
 	if err != nil {
 		return err
 	}
-	return network.Retry(network.DefaultRetryAttempts, 1*time.Second, func() error {
+	return network.Retry(context.Background(), network.DefaultRetryAttempts, 1*time.Second, func() error {
 		return rpcClient.Call(nil, "admin_removePeer", id)
 	})
 }

--- a/driver/node/opera_test.go
+++ b/driver/node/opera_test.go
@@ -43,7 +43,7 @@ func TestOperaNode_StartAndStop(t *testing.T) {
 	t.Cleanup(func() {
 		_ = docker.Close()
 	})
-	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
+	node, err := StartOperaDockerNode(t.Context(), docker, nil, &OperaNodeConfig{
 		Label:         "test",
 		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
@@ -67,7 +67,7 @@ func TestOperaNode_RpcServiceIsReadyAfterStartup(t *testing.T) {
 	t.Cleanup(func() {
 		_ = docker.Close()
 	})
-	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
+	node, err := StartOperaDockerNode(t.Context(), docker, nil, &OperaNodeConfig{
 		Label:         "test",
 		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
@@ -92,7 +92,7 @@ func TestOperaNode_StreamLog(t *testing.T) {
 		_ = docker.Close()
 	})
 
-	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
+	node, err := StartOperaDockerNode(t.Context(), docker, nil, &OperaNodeConfig{
 		Label:         "test",
 		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
@@ -146,7 +146,7 @@ func TestOperaNode_MetricsExposed(t *testing.T) {
 		_ = docker.Close()
 	})
 
-	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
+	node, err := StartOperaDockerNode(t.Context(), docker, nil, &OperaNodeConfig{
 		Label:         "test",
 		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
@@ -192,7 +192,7 @@ func TestClient_Stop_Graceful(t *testing.T) {
 		}
 	}()
 
-	node, err := StartOperaDockerNode(client, nil, &OperaNodeConfig{
+	node, err := StartOperaDockerNode(t.Context(), client, nil, &OperaNodeConfig{
 		Label:         "test",
 		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -19,15 +19,15 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/0xsoniclabs/norma/driver/checking"
-	"golang.org/x/exp/maps"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
 	"time"
+
+	"github.com/0xsoniclabs/norma/driver/checking"
+	"golang.org/x/exp/maps"
 
 	"github.com/0xsoniclabs/norma/analysis/report"
 	"github.com/0xsoniclabs/norma/driver"
@@ -155,19 +155,23 @@ func runScenario(path, outputDir, label string, keepPrometheusRunning, skipCheck
 
 	// create symlink as qol (_latest => _####) where #### is the randomly generated name
 	symlink := filepath.Join(filepath.Dir(outputDir), fmt.Sprintf("norma_data_%s_latest", label))
-	if _, err := os.Lstat(symlink); err == nil {
-		os.Remove(symlink)
+	if _, lstatErr := os.Lstat(symlink); lstatErr == nil {
+		if err := os.Remove(symlink); err != nil {
+			return fmt.Errorf("failed to remove existing _latest symlink: %w", err)
+		}
 	}
-	os.Symlink(outputDir, symlink)
+	if err := os.Symlink(outputDir, symlink); err != nil {
+		return fmt.Errorf("failed to create _latest symlink: %w", err)
+	}
 
 	fmt.Printf("Monitoring data is written to %v\n", outputDir)
 
 	// Copy scenario yml to outputDir as well to provide context
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath.Join(outputDir, filepath.Base(path)), data, 0644)
+	err = os.WriteFile(filepath.Join(outputDir, filepath.Base(path)), data, 0644)
 	if err != nil {
 		return err
 	}

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -17,13 +17,16 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"github.com/0xsoniclabs/norma/driver/checking"
 	"golang.org/x/exp/maps"
 	"io/fs"
 	"io/ioutil"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/0xsoniclabs/norma/analysis/report"
@@ -169,6 +172,12 @@ func runScenario(path, outputDir, label string, keepPrometheusRunning, skipCheck
 		return err
 	}
 
+	// Create a context that is cancelled on SIGINT/SIGTERM so that both
+	// network startup and scenario execution can be interrupted cleanly,
+	// allowing all deferred shutdowns to execute.
+	ctx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stopSignals()
+
 	clock := executor.NewWallTimeClock()
 
 	// Startup network.
@@ -177,7 +186,7 @@ func runScenario(path, outputDir, label string, keepPrometheusRunning, skipCheck
 		fmt.Printf("Network Rule: %s: %s\n", k, v)
 	}
 
-	net, err := local.NewLocalNetwork(&driver.NetworkConfig{
+	net, err := local.NewLocalNetwork(ctx, &driver.NetworkConfig{
 		Validators:    driver.NewValidators(scenario.Validators),
 		RoundTripTime: scenario.GetRoundTripTime(),
 		NetworkRules:  driver.NetworkRules(maps.Clone(scenario.NetworkRules.Genesis)),
@@ -252,7 +261,7 @@ func runScenario(path, outputDir, label string, keepPrometheusRunning, skipCheck
 	fmt.Printf("Running '%s' ...\n", path)
 	logger := startProgressLogger(monitor, net)
 	defer logger.shutdown()
-	err = executor.Run(clock, net, &scenario, checks)
+	err = executor.Run(ctx, clock, net, &scenario, checks)
 	if err != nil {
 		return err
 	}

--- a/load/app/app_test.go
+++ b/load/app/app_test.go
@@ -112,7 +112,7 @@ func TestGenerators(t *testing.T) {
 		t.Run(upgrade, func(t *testing.T) {
 			// run local network of one node
 			rules := getCumulativeUpgrades(upgrade)
-			net, err := local.NewLocalNetwork(&driver.NetworkConfig{
+			net, err := local.NewLocalNetwork(t.Context(), &driver.NetworkConfig{
 				Validators:   driver.DefaultValidators,
 				NetworkRules: rules,
 			})
@@ -171,7 +171,7 @@ func TestGenerators_Subsidies(t *testing.T) {
 	rules := map[string]string{
 		"UPGRADES_GAS_SUBSIDIES": "true",
 	}
-	net, err := local.NewLocalNetwork(&driver.NetworkConfig{
+	net, err := local.NewLocalNetwork(t.Context(), &driver.NetworkConfig{
 		Validators:   driver.DefaultValidators,
 		NetworkRules: rules,
 	})
@@ -247,7 +247,7 @@ func testGenerator(t *testing.T, app app.Application, ctxt app.AppContext) {
 		t.Errorf("invalid number of sent transactions reported, wanted %d, got %d", want, got)
 	}
 
-	err = network.Retry(network.DefaultRetryAttempts, 1*time.Second, func() error {
+	err = network.Retry(t.Context(), network.DefaultRetryAttempts, 1*time.Second, func() error {
 		received, err := app.GetReceivedTransactions(rpcClient)
 		if err != nil {
 			return fmt.Errorf("unable to get amount of received txs; %v", err)

--- a/load/app/bundle_app_test.go
+++ b/load/app/bundle_app_test.go
@@ -20,7 +20,7 @@ func TestGenerators_Bundles(t *testing.T) {
 	rules := getCumulativeUpgrades("UPGRADES_BRIO")
 	rules["UPGRADES_TRANSACTION_BUNDLES"] = "true"
 	rules["UPGRADES_GAS_SUBSIDIES"] = "true"
-	net, err := local.NewLocalNetwork(&driver.NetworkConfig{
+	net, err := local.NewLocalNetwork(t.Context(), &driver.NetworkConfig{
 		Validators:   driver.DefaultValidators,
 		NetworkRules: rules,
 	})
@@ -120,7 +120,7 @@ func testBundleGenerator(t *testing.T, application app.Application, ctxt app.App
 		fmt.Printf("bundle %d (plan %s) executed: block=%d position=%d count=%d\n", i, planHash, info.Block, info.Position, info.Count)
 	}
 
-	err = network.Retry(network.DefaultRetryAttempts, 1*time.Second, func() error {
+	err = network.Retry(t.Context(), network.DefaultRetryAttempts, 1*time.Second, func() error {
 		sent := user.GetSentTransactions()
 		received, err := application.GetReceivedTransactions(rpcClient)
 		if err != nil {
@@ -165,7 +165,7 @@ func testFailingBundleGenerator(t *testing.T, application app.Application, ctxt 
 		fmt.Printf("Sent bundle %d\n", i)
 
 		// wait for tx to be processed (necessary because of nonce loading in GenerateTx())
-		_ = network.Retry(5, 1*time.Second, func() error {
+		_ = network.Retry(t.Context(), 5, 1*time.Second, func() error {
 			received, err := application.GetReceivedTransactions(rpcClient)
 			if err != nil {
 				return fmt.Errorf("unable to get amount of received txs; %v", err)
@@ -179,7 +179,7 @@ func testFailingBundleGenerator(t *testing.T, application app.Application, ctxt 
 		})
 	}
 
-	err = network.Retry(10, 1*time.Second, func() error {
+	err = network.Retry(t.Context(), 10, 1*time.Second, func() error {
 		received, err := application.GetReceivedTransactions(rpcClient)
 		if err != nil {
 			return fmt.Errorf("unable to get amount of received txs; %v", err)

--- a/load/app/large_contract_app_test.go
+++ b/load/app/large_contract_app_test.go
@@ -39,7 +39,7 @@ func TestLargeContractDeploymentFailsWithoutBrio(t *testing.T) {
 		"UPGRADES_ALLEGRO": "true",
 		// UPGRADES_BRIO omitted intentionally - deployment of large contracts should fail
 	}
-	net, err := local.NewLocalNetwork(&driver.NetworkConfig{
+	net, err := local.NewLocalNetwork(t.Context(), &driver.NetworkConfig{
 		Validators:   driver.DefaultValidators,
 		NetworkRules: rules,
 	})

--- a/load/controller/rpc_test.go
+++ b/load/controller/rpc_test.go
@@ -33,7 +33,7 @@ const FakeNetworkID = 0xfa3
 
 func TestTrafficGenerating(t *testing.T) {
 	// run local network of one node
-	net, err := local.NewLocalNetwork(&driver.NetworkConfig{Validators: driver.DefaultValidators})
+	net, err := local.NewLocalNetwork(t.Context(), &driver.NetworkConfig{Validators: driver.DefaultValidators})
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}


### PR DESCRIPTION
When norma run is interrupted during the initialization (waiting for the validator nodes start), norma does not delete created containers.

This PR moves the signal handling from the executor.Run() into its caller main.runScenario(). The executor and the node initialization will get a context which can be cancelled by the interrupt.