### PR TITLE
Upgrade sonic, use latest bundles execution plan version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 Project Norma
 =============
 
-Project of integrating Carmen Storage and Tosca VM into go-opera.
+Project Norma is a system testing infrastructure for the Sonic blockchain client.
 
 # Building and Running
 
 ## Requirements
 
 For building/running the project, the following tools are required:
-* Go: version 1.20 or later; we recommend to use your system's package manager; alternatively, you can follow Go's [installation manual](https://go.dev/doc/install) or; if you need to maintain multiple versions, [this tutorial](https://go.dev/doc/manage-install) describes how to do so
+* Go: version 1.25 or later; we recommend to use your system's package manager; alternatively, you can follow Go's [installation manual](https://go.dev/doc/install) or; if you need to maintain multiple versions, [this tutorial](https://go.dev/doc/manage-install) describes how to do so
 * Docker: version 23.0 or later; we recommend to use your system's package manager or the installation manuals listed in the [Using Docker](#using-docker) section below
   * [Docker buildx](https://docs.docker.com/reference/cli/docker/buildx/): to install it on Ubuntu run `apt install docker-buildx`.
 * GNU make, or compatible
 * R report rendering is handled via Docker - no local R installation required.
 
 Optionally, before running `make generate-mocks`, make sure you installed:
-* GoMock: `go install github.com/golang/mock/mockgen@v1.6.0`
-  * Make sure `$GOPATH/bin` is in your `$PATH`. `$GOPATH` defaults to `$HOME/go` if not set, i.e. configure `$PATH` 
-  * either to `PATH=$GOPATH/bin:$PATH` or `PATH=$HOME/go/bin:$PATH` 
+* mockgen from `go.uber.org/mock`: `go install go.uber.org/mock/mockgen@latest`
+  * Make sure `$GOPATH/bin` is in your `$PATH`. `$GOPATH` defaults to `$HOME/go` if not set, i.e. configure `$PATH`
+  * either to `PATH=$GOPATH/bin:$PATH` or `PATH=$HOME/go/bin:$PATH`
 
 Optionally, before running `make generate-abi`, make sure you have installed:
 * Solidity Compiler (solc) - see [Installing the Solidity Compiler](https://docs.soliditylang.org/en/latest/installing-solidity.html)
@@ -90,7 +90,7 @@ alternatively
 
 
 ### Building
-The experiments use the docker image that wraps the forked Opera/Norma client. The image is build as part of 
+The experiments use the docker image that wraps the Sonic client. The image is built as part of
 the build process, and can be explicitly triggered:
 ```
 make build-docker-image
@@ -99,7 +99,7 @@ make build-docker-image
 ### Commands
 During the development, a few Docker commands can come handy:
 ```
-docker run -i -t -d opera         // runs container with Opera in background (without -d it would run in foreground)
+docker run -i -t -d sonic         // runs container with Sonic in background (without -d it would run in foreground)
 docker ps                         // shows running container
 docker exec -it <ID> /bin/sh      // opens interactive shell inside the container, the ID is obtained by previous command
 docker logs <ID>                  // prints stdout (log) of the container
@@ -207,7 +207,7 @@ The directory has the following structure:
     | - <sample_number>.prof
       ...
 ```
-These files can be transfered to a developer's machine, and analysed by running
+These files can be transferred to a developer's machine, and analysed by running
 
 ```
 go tool pprof -http=":8000" <sample_number>.prof
@@ -216,5 +216,5 @@ go tool pprof -http=":8000" <sample_number>.prof
 ## Known Norma Restrictions
 
 Known restrictions
- - only one node will be a validator, and it is the first node to be started; this node must life until the end of the scenario
- - currently, all transactions are send to the validator node
+ - validator nodes must be started at the beginning of the simulation and must remain running throughout; adding validators after the simulation has started is not supported
+ - generating double-sign events simulating misbehaving validators is not supported

--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,14 @@ go 1.25.0
 require (
 	github.com/0xsoniclabs/carmen/go v0.0.0-20260427113009-ed285bc2e427
 	github.com/0xsoniclabs/norma/genesistools v0.0.0-20250218144827-28263a9a85f9
-	github.com/0xsoniclabs/sonic v0.0.0-20260504073722-eca599aa77f8
+	github.com/0xsoniclabs/sonic v0.0.0-20260505095123-e821c67c97b2
 	github.com/docker/docker v27.3.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/ethereum/go-ethereum v1.17.1
 	github.com/holiman/uint256 v1.3.2
 	github.com/jupp0r/go-priority-queue v0.0.0-20160601094913-ab1073853bde
 	github.com/urfave/cli/v2 v2.27.5
-	go.uber.org/mock v0.5.0
+	go.uber.org/mock v0.6.0
 	golang.org/x/exp v0.0.0-20241204233417-43b7b7cde48d
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/0xsoniclabs/go-ethereum v0.0.0-20260424113012-971561538c58 h1:FXc86uk
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260424113012-971561538c58/go.mod h1:F60oMGNtPsr0hhwnGzwZv4ooj0AfnXJ1iGMGXylfjrg=
 github.com/0xsoniclabs/sonic v0.0.0-20260504073722-eca599aa77f8 h1:K1sZadvMdQIFZqHrQMNtTUzNOvXYp4vXxIghF8KPmUU=
 github.com/0xsoniclabs/sonic v0.0.0-20260504073722-eca599aa77f8/go.mod h1:0H/+1j2PuKb+K5QAucEHamKv5O3wq1J99s5D9PnJauQ=
+github.com/0xsoniclabs/sonic v0.0.0-20260505095123-e821c67c97b2 h1:jW4n4nQ4czbMt24/MXd8yNWgc97KQ3t4/AlrfJLq6vg=
+github.com/0xsoniclabs/sonic v0.0.0-20260505095123-e821c67c97b2/go.mod h1:p9vjX11vFypX26+kKEpTCJIwx/UM1/MvoB3YwKV8sDs=
 github.com/0xsoniclabs/tosca v0.0.0-20260429071638-3f4119284c42 h1:oJMc/vekaRHmIwiRYHzfn8pofD4AwR8awgJe8DeUaDs=
 github.com/0xsoniclabs/tosca v0.0.0-20260429071638-3f4119284c42/go.mod h1:iXtx7i9R25Oc5SD/xGI7aamdnF0nCteBpulZGIOIYJI=
 github.com/0xsoniclabs/tracy v0.0.0-20251027125423-00a5ab7968fb h1:mb6rPN+DpA/N2QWrQrLQEG2uzrYgy061PPauifstXNM=
@@ -325,6 +327,8 @@ go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjce
 go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
 go.uber.org/mock v0.5.0 h1:KAMbZvZPyBPWgD14IrIQ38QCyjwpvVVV6K/bHl1IwQU=
 go.uber.org/mock v0.5.0/go.mod h1:ge71pBPLYDk7QIi1LupWxdAykm7KIEFchiOqd6z7qMM=
+go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
+go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=


### PR DESCRIPTION
Upgrade sonic dependency to resolve unsupported execution plan version error:
```
=== RUN   TestGenerators_Bundles/AllOfBundle
    bundle_app_test.go:98: invalid bundle transaction
        invalid bundle encoding: failed to decode execution plan: unsupported execution plan version: 196
```
Also updates the README.md.