### PR TITLE
Upgrade golang to 1.26.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Project Norma is a system testing infrastructure for the Sonic blockchain client
 ## Requirements
 
 For building/running the project, the following tools are required:
-* Go: version 1.25 or later; we recommend to use your system's package manager; alternatively, you can follow Go's [installation manual](https://go.dev/doc/install) or; if you need to maintain multiple versions, [this tutorial](https://go.dev/doc/manage-install) describes how to do so
+* Go: version 1.26 or later; we recommend to use your system's package manager; alternatively, you can follow Go's [installation manual](https://go.dev/doc/install) or; if you need to maintain multiple versions, [this tutorial](https://go.dev/doc/manage-install) describes how to do so
 * Docker: version 23.0 or later; we recommend to use your system's package manager or the installation manuals listed in the [Using Docker](#using-docker) section below
   * [Docker buildx](https://docs.docker.com/reference/cli/docker/buildx/): to install it on Ubuntu run `apt install docker-buildx`.
 * GNU make, or compatible

--- a/genesis/go.mod
+++ b/genesis/go.mod
@@ -1,6 +1,6 @@
 module github.com/0xsoniclabs/norma/genesistools
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/0xsoniclabs/sonic v0.0.0-20260414143741-680121a212bc

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/0xsoniclabs/norma
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/0xsoniclabs/carmen/go v0.0.0-20260427113009-ed285bc2e427


### PR DESCRIPTION
This PR updates go version to 1.26.0.
I didn't update the Dockerfile, which refers to 1.26.3 explicitly. We usually don't pin patch version in Dockerfile in Sonic, but I think this is done to avoid mismatches between go and debian image versions