### PR TITLE
Enable OneOfBundle app test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,3 +127,4 @@ test: pull-hello-world-image pull-alpine-image pull-prometheus-image build-r-ren
 
 clean:
 	rm -rvf $(CURDIR)/build
+	docker image rm -f sonic sonic:local

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/0xsoniclabs/carmen/go v0.0.0-20260427113009-ed285bc2e427
 	github.com/0xsoniclabs/norma/genesistools v0.0.0-20250218144827-28263a9a85f9
-	github.com/0xsoniclabs/sonic v0.0.0-20260505095123-e821c67c97b2
+	github.com/0xsoniclabs/sonic v0.0.0-20260505152818-400acf397f1a
 	github.com/docker/docker v27.3.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/ethereum/go-ethereum v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,8 @@ github.com/0xsoniclabs/carmen/go v0.0.0-20260427113009-ed285bc2e427 h1:sMPNQv8eW
 github.com/0xsoniclabs/carmen/go v0.0.0-20260427113009-ed285bc2e427/go.mod h1:ebS6LBL8TM3tKnRf9AHVb4FYQbb+edg3f7Gw/HnAffA=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260424113012-971561538c58 h1:FXc86ukHR2flWIFTGanxow99cOagC8ek73GeagYP3wI=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260424113012-971561538c58/go.mod h1:F60oMGNtPsr0hhwnGzwZv4ooj0AfnXJ1iGMGXylfjrg=
-github.com/0xsoniclabs/sonic v0.0.0-20260504073722-eca599aa77f8 h1:K1sZadvMdQIFZqHrQMNtTUzNOvXYp4vXxIghF8KPmUU=
-github.com/0xsoniclabs/sonic v0.0.0-20260504073722-eca599aa77f8/go.mod h1:0H/+1j2PuKb+K5QAucEHamKv5O3wq1J99s5D9PnJauQ=
-github.com/0xsoniclabs/sonic v0.0.0-20260505095123-e821c67c97b2 h1:jW4n4nQ4czbMt24/MXd8yNWgc97KQ3t4/AlrfJLq6vg=
-github.com/0xsoniclabs/sonic v0.0.0-20260505095123-e821c67c97b2/go.mod h1:p9vjX11vFypX26+kKEpTCJIwx/UM1/MvoB3YwKV8sDs=
+github.com/0xsoniclabs/sonic v0.0.0-20260505152818-400acf397f1a h1:2axfIPTnmRFu2pYRWasyJoahLm+/VxeWcQMKOT16An4=
+github.com/0xsoniclabs/sonic v0.0.0-20260505152818-400acf397f1a/go.mod h1:p9vjX11vFypX26+kKEpTCJIwx/UM1/MvoB3YwKV8sDs=
 github.com/0xsoniclabs/tosca v0.0.0-20260429071638-3f4119284c42 h1:oJMc/vekaRHmIwiRYHzfn8pofD4AwR8awgJe8DeUaDs=
 github.com/0xsoniclabs/tosca v0.0.0-20260429071638-3f4119284c42/go.mod h1:iXtx7i9R25Oc5SD/xGI7aamdnF0nCteBpulZGIOIYJI=
 github.com/0xsoniclabs/tracy v0.0.0-20251027125423-00a5ab7968fb h1:mb6rPN+DpA/N2QWrQrLQEG2uzrYgy061PPauifstXNM=
@@ -325,8 +323,6 @@ go.opentelemetry.io/otel/trace v1.40.0 h1:WA4etStDttCSYuhwvEa8OP8I5EWu24lkOzp+ZY
 go.opentelemetry.io/otel/trace v1.40.0/go.mod h1:zeAhriXecNGP/s2SEG3+Y8X9ujcJOTqQ5RgdEJcawiA=
 go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjceRb/A=
 go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
-go.uber.org/mock v0.5.0 h1:KAMbZvZPyBPWgD14IrIQ38QCyjwpvVVV6K/bHl1IwQU=
-go.uber.org/mock v0.5.0/go.mod h1:ge71pBPLYDk7QIi1LupWxdAykm7KIEFchiOqd6z7qMM=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/load/app/bundle_app_test.go
+++ b/load/app/bundle_app_test.go
@@ -45,6 +45,7 @@ func TestGenerators_Bundles(t *testing.T) {
 
 	for appId, name := range []string{
 		"AllOfBundle",
+		"OneOfBundle",
 		"SubsidizedBundle",
 		"DuplicatedBundle",
 	} {
@@ -59,7 +60,6 @@ func TestGenerators_Bundles(t *testing.T) {
 
 	for appId, name := range []string{
 		"FailingBundle",
-		"OneOfBundle",
 	} {
 		t.Run(name, func(t *testing.T) {
 			application, err := app.NewApplication(name, appCtx, 0, uint32(appId))

--- a/load/app/bundle_app_test.go
+++ b/load/app/bundle_app_test.go
@@ -45,7 +45,6 @@ func TestGenerators_Bundles(t *testing.T) {
 
 	for appId, name := range []string{
 		"AllOfBundle",
-		// "OneOfBundle", // Temporarily disabled: fails because of sonic-admin#742
 		"SubsidizedBundle",
 		"DuplicatedBundle",
 	} {
@@ -60,13 +59,14 @@ func TestGenerators_Bundles(t *testing.T) {
 
 	for appId, name := range []string{
 		"FailingBundle",
+		"OneOfBundle",
 	} {
 		t.Run(name, func(t *testing.T) {
 			application, err := app.NewApplication(name, appCtx, 0, uint32(appId))
 			if err != nil {
 				t.Fatal(err)
 			}
-			testFailingBundleGenerator(t, application, appCtx)
+			testRpcNonceBundleGenerator(t, application, appCtx)
 		})
 	}
 }
@@ -136,7 +136,7 @@ func testBundleGenerator(t *testing.T, application app.Application, ctxt app.App
 	}
 }
 
-func testFailingBundleGenerator(t *testing.T, application app.Application, ctxt app.AppContext) {
+func testRpcNonceBundleGenerator(t *testing.T, application app.Application, ctxt app.AppContext) {
 	users, err := application.CreateUsers(ctxt, 1)
 	if err != nil {
 		t.Fatal(err)

--- a/load/app/oneofbundle_app.go
+++ b/load/app/oneofbundle_app.go
@@ -171,6 +171,7 @@ type OneOfBundleUser struct {
 }
 
 func (u *OneOfBundleUser) GenerateTx() (*types.Transaction, error) {
+	ctx := context.Background()
 	successfulFirst := rand.Intn(2) == 0
 
 	transferData, err := u.erc20Abi.Pack("transfer", u.targetAddress, big.NewInt(1))
@@ -178,13 +179,22 @@ func (u *OneOfBundleUser) GenerateTx() (*types.Transaction, error) {
 		return nil, fmt.Errorf("failed to pack rich transfer: %w", err)
 	}
 
-	currentBlock, err := u.client.BlockNumber(context.Background())
+	nonceRich, err := u.client.PendingNonceAt(ctx, u.richSender.address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get nonce for senderA: %w", err)
+	}
+	noncePoor, err := u.client.PendingNonceAt(ctx, u.richSender.address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get nonce for senderB: %w", err)
+	}
+
+	currentBlock, err := u.client.BlockNumber(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current block number: %w", err)
 	}
 
 	successfulStep := bundle.Step(u.richSender.privateKey, &types.DynamicFeeTx{
-		Nonce:     u.richSender.getCurrentNonce(),
+		Nonce:     nonceRich,
 		Gas:       70_000,
 		GasFeeCap: gasFeeCap,
 		GasTipCap: gasTipCap,
@@ -192,7 +202,7 @@ func (u *OneOfBundleUser) GenerateTx() (*types.Transaction, error) {
 		Data:      transferData,
 	})
 	failingStep := bundle.Step(u.poorSender.privateKey, &types.DynamicFeeTx{
-		Nonce:     u.poorSender.getCurrentNonce(),
+		Nonce:     noncePoor,
 		Gas:       70_000,
 		GasFeeCap: gasFeeCap,
 		GasTipCap: gasTipCap,
@@ -212,13 +222,6 @@ func (u *OneOfBundleUser) GenerateTx() (*types.Transaction, error) {
 		SetEarliest(currentBlock).
 		Build()
 
-	if successfulFirst {
-		u.richSender.getNextNonce()
-		// poorSender's step is second and not executed in OneOf
-	} else {
-		u.poorSender.getNextNonce() // first step (failed), nonce consumed
-		u.richSender.getNextNonce()
-	}
 	u.sentTxs.Add(1)
 	return envelope, nil
 }

--- a/load/app/oneofbundle_app.go
+++ b/load/app/oneofbundle_app.go
@@ -34,10 +34,11 @@ import (
 )
 
 // OneOfBundleApplication generates bundle transactions where each bundle
-// contains a OneOf section with two transfers to a target account: one from a
-// richSender (who has ERC-20 tokens) and one from a poorSender (who has none).
-// The OneOf execution plan picks the first successful transaction — exactly one
-// of the two inner transactions will execute per bundle.
+// contains a OneOf section with two transfers to a target account, both signed
+// by the same sender. One step transfers 1 token (succeeds) and the other
+// attempts to transfer more tokens than the sender holds (fails). The OneOf
+// execution plan picks the first successful transaction — exactly one of the
+// two inner transactions will execute per bundle.
 type OneOfBundleApplication struct {
 	erc20Contract  *contract.ERC20
 	erc20Address   common.Address
@@ -87,50 +88,42 @@ func NewOneOfBundleApplication(appContext AppContext, feederId, appId uint32) (A
 	}, nil
 }
 
-// CreateUsers creates numUsers user pairs (richSender, poorSender). All users
-// share the single target address created during application initialisation.
+// CreateUsers creates numUsers users. All users share the single target address
+// created during application initialisation.
 func (a *OneOfBundleApplication) CreateUsers(appContext AppContext, numUsers int) ([]User, error) {
 	users := make([]User, numUsers)
-	richSenderAddresses := make([]common.Address, numUsers)
-	poorSenderAddresses := make([]common.Address, numUsers)
+	senderAddresses := make([]common.Address, numUsers)
 
 	for i := range users {
-		richSender, err := a.accountFactory.CreateAccount(appContext.GetClient())
-		if err != nil {
-			return nil, err
-		}
-		poorSender, err := a.accountFactory.CreateAccount(appContext.GetClient())
+		sender, err := a.accountFactory.CreateAccount(appContext.GetClient())
 		if err != nil {
 			return nil, err
 		}
 		users[i] = &OneOfBundleUser{
 			erc20Address:   a.erc20Address,
 			erc20Abi:       a.erc20Abi,
-			richSender:     richSender,
-			poorSender:     poorSender,
+			sender:         sender,
 			targetAddress:  a.targetAddress,
 			accountFactory: a.accountFactory,
-			signer:         types.LatestSignerForChainID(richSender.chainID),
+			signer:         types.LatestSignerForChainID(sender.chainID),
 			client:         appContext.GetClient(),
 		}
-		richSenderAddresses[i] = richSender.address
-		poorSenderAddresses[i] = poorSender.address
+		senderAddresses[i] = sender.address
 	}
 
 	// Fund all tx sending accounts with native currency for gas.
 	fundsPerAccount := new(big.Int).Mul(big.NewInt(1_000), big.NewInt(1e18))
-	fundedAddresses := append(richSenderAddresses, poorSenderAddresses...)
-	if err := appContext.FundAccounts(fundedAddresses, fundsPerAccount); err != nil {
+	if err := appContext.FundAccounts(senderAddresses, fundsPerAccount); err != nil {
 		return nil, fmt.Errorf("failed to fund accounts: %w", err)
 	}
 
-	// Mint ERC-20 tokens only to richSender accounts; poorSenders receive none.
+	// Mint ERC-20 tokens to sender accounts.
 	tokenAmount := new(big.Int).Mul(big.NewInt(1_000_000), big.NewInt(1e18))
 	receipt, err := appContext.Run(func(opts *bind.TransactOpts) (*types.Transaction, error) {
-		return a.erc20Contract.MintForAll(opts, richSenderAddresses, tokenAmount)
+		return a.erc20Contract.MintForAll(opts, senderAddresses, tokenAmount)
 	})
 	if err != nil || receipt.Status != types.ReceiptStatusSuccessful {
-		return nil, errors.Join(fmt.Errorf("failed to mint ERC-20 tokens for rich senders"), err)
+		return nil, errors.Join(fmt.Errorf("failed to mint ERC-20 tokens for senders"), err)
 	}
 
 	return users, nil
@@ -150,19 +143,19 @@ func (a *OneOfBundleApplication) GetReceivedTransactions(rpcClient rpc.Client) (
 	return balance.Uint64(), nil
 }
 
-// OneOfBundleUser represents one (richSender, poorSender, target) triple. Each
-// GenerateTx call produces one bundle envelope containing a OneOf section with:
+// OneOfBundleUser holds a single sender account. Each GenerateTx call produces
+// one bundle envelope containing a OneOf section with:
 //
-//  1. richSender.transfer(target, 1) — succeeds (richSender has tokens)
-//  2. poorSender.transfer(target, 1) — fails   (poorSender has no tokens)
+//  1. sender.transfer(target, 1)               — succeeds (sender has tokens)
+//  2. sender.transfer(target, overBalance)     — fails   (amount exceeds balance)
 //
-// The order of the two steps within the OneOf section is randomized on every
-// call. The OneOf execution plan picks the first succeeding transaction.
+// Both steps share the same nonce. The order of the two steps within the OneOf
+// section is randomized on every call. The OneOf execution plan picks the first
+// succeeding transaction — exactly one execution per bundle.
 type OneOfBundleUser struct {
 	erc20Address   common.Address
 	erc20Abi       *abi.ABI
-	richSender     *Account
-	poorSender     *Account
+	sender         *Account
 	targetAddress  common.Address
 	accountFactory *AccountFactory
 	signer         types.Signer
@@ -171,50 +164,60 @@ type OneOfBundleUser struct {
 }
 
 func (u *OneOfBundleUser) GenerateTx() (*types.Transaction, error) {
-	ctx := context.Background()
 	successfulFirst := rand.Intn(2) == 0
 
-	transferData, err := u.erc20Abi.Pack("transfer", u.targetAddress, big.NewInt(1))
+	transferSuccessfulData, err := u.erc20Abi.Pack("transfer", u.targetAddress, big.NewInt(1))
 	if err != nil {
-		return nil, fmt.Errorf("failed to pack rich transfer: %w", err)
+		return nil, fmt.Errorf("failed to pack transfer data: %w", err)
 	}
 
-	nonceRich, err := u.client.PendingNonceAt(ctx, u.richSender.address)
+	// Exceeds the minted token supply (1_000_000 * 1e18), so this step always fails.
+	overBalanceAmount := new(big.Int).Mul(big.NewInt(2_000_000), big.NewInt(1e18))
+	transferFailingData, err := u.erc20Abi.Pack("transfer", u.targetAddress, overBalanceAmount)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get nonce for senderA: %w", err)
-	}
-	noncePoor, err := u.client.PendingNonceAt(ctx, u.richSender.address)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get nonce for senderB: %w", err)
+		return nil, fmt.Errorf("failed to pack over-balance transfer data: %w", err)
 	}
 
-	currentBlock, err := u.client.BlockNumber(ctx)
+	currentBlock, err := u.client.BlockNumber(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current block number: %w", err)
 	}
 
-	successfulStep := bundle.Step(u.richSender.privateKey, &types.DynamicFeeTx{
-		Nonce:     nonceRich,
-		Gas:       70_000,
-		GasFeeCap: gasFeeCap,
-		GasTipCap: gasTipCap,
-		To:        &u.erc20Address,
-		Data:      transferData,
-	})
-	failingStep := bundle.Step(u.poorSender.privateKey, &types.DynamicFeeTx{
-		Nonce:     noncePoor,
-		Gas:       70_000,
-		GasFeeCap: gasFeeCap,
-		GasTipCap: gasTipCap,
-		To:        &u.erc20Address,
-		Data:      transferData,
-	})
-
 	var firstStep, secondStep bundle.BuilderStep
 	if successfulFirst {
-		firstStep, secondStep = successfulStep, failingStep
+		firstStep = bundle.Step(u.sender.privateKey, &types.DynamicFeeTx{
+			Nonce:     u.sender.getNextNonce(),
+			Gas:       70_000,
+			GasFeeCap: gasFeeCap,
+			GasTipCap: gasTipCap,
+			To:        &u.erc20Address,
+			Data:      transferSuccessfulData,
+		})
+		secondStep = bundle.Step(u.sender.privateKey, &types.DynamicFeeTx{
+			Nonce:     u.sender.getCurrentNonce(), // will not run, nonce not consumed
+			Gas:       70_000,
+			GasFeeCap: gasFeeCap,
+			GasTipCap: gasTipCap,
+			To:        &u.erc20Address,
+			Data:      transferFailingData,
+		})
 	} else {
-		firstStep, secondStep = failingStep, successfulStep
+		firstStep = bundle.Step(u.sender.privateKey, &types.DynamicFeeTx{
+			Nonce:     u.sender.getNextNonce(),
+			Gas:       70_000,
+			GasFeeCap: gasFeeCap,
+			GasTipCap: gasTipCap,
+			To:        &u.erc20Address,
+			Data:      transferFailingData,
+		})
+		secondStep = bundle.Step(u.sender.privateKey, &types.DynamicFeeTx{
+			Nonce:     u.sender.getNextNonce(), // both will run, both nonces will be consumed
+			Gas:       70_000,
+			GasFeeCap: gasFeeCap,
+			GasTipCap: gasTipCap,
+			To:        &u.erc20Address,
+			Data:      transferSuccessfulData,
+		})
 	}
 	envelope := bundle.NewBuilder().
 		WithSigner(u.signer).

--- a/load/app/oneofbundle_app.go
+++ b/load/app/oneofbundle_app.go
@@ -33,12 +33,9 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-// OneOfBundleApplication generates bundle transactions where each bundle
-// contains a OneOf section with two transfers to a target account, both signed
-// by the same sender. One step transfers 1 token (succeeds) and the other
-// attempts to transfer more tokens than the sender holds (fails). The OneOf
-// execution plan picks the first successful transaction — exactly one of the
-// two inner transactions will execute per bundle.
+// OneOfBundleApplication generates OneOf bundles where only one transaction within the bundle is expected to succeed.
+// Both transactions have the same sender, the successful one transfers 1 token, failing attempts to transfer
+// more than available.
 type OneOfBundleApplication struct {
 	erc20Contract  *contract.ERC20
 	erc20Address   common.Address
@@ -146,12 +143,10 @@ func (a *OneOfBundleApplication) GetReceivedTransactions(rpcClient rpc.Client) (
 // OneOfBundleUser holds a single sender account. Each GenerateTx call produces
 // one bundle envelope containing a OneOf section with:
 //
-//  1. sender.transfer(target, 1)               — succeeds (sender has tokens)
-//  2. sender.transfer(target, overBalance)     — fails   (amount exceeds balance)
+//  1. sender.transfer(target, 1)           - succeeds
+//  2. sender.transfer(target, overBalance) - fails (amount exceeds balance)
 //
-// Both steps share the same nonce. The order of the two steps within the OneOf
-// section is randomized on every call. The OneOf execution plan picks the first
-// succeeding transaction — exactly one execution per bundle.
+// The order of the two steps within the OneOf section is randomized on every call.
 type OneOfBundleUser struct {
 	erc20Address   common.Address
 	erc20Abi       *abi.ABI
@@ -171,7 +166,7 @@ func (u *OneOfBundleUser) GenerateTx() (*types.Transaction, error) {
 		return nil, fmt.Errorf("failed to pack transfer data: %w", err)
 	}
 
-	// Exceeds the minted token supply (1_000_000 * 1e18), so this step always fails.
+	// overBalanceAmount exceeds the minted token supply
 	overBalanceAmount := new(big.Int).Mul(big.NewInt(2_000_000), big.NewInt(1e18))
 	transferFailingData, err := u.erc20Abi.Pack("transfer", u.targetAddress, overBalanceAmount)
 	if err != nil {


### PR DESCRIPTION
This enables OneOfBundle app, but lets it rely on obtaining nonces from RPC.

As discussed in https://github.com/0xsoniclabs/sonic-admin/issues/742, we are not going to support sending OneOf bundles in high-rate, it is expected to fail when trying to pass multiple following OneOf bundles.