### PR TITLE
Improve stop signal handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 #
 # It checks out the required version of the client, and builds it.
 #
-FROM golang:1.25.3 AS client-build
+FROM golang:1.26.3 AS client-build
 
 WORKDIR /client
 
@@ -44,7 +44,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build make sonicd sonictool
 #
 # It checks out the local version of the norma, and builds it.
 #
-FROM golang:1.25.3 AS norma-build
+FROM golang:1.26.3 AS norma-build
 
 # Download dependencies supporting Sonic run first to cache them for faster build when Norma changes.
 WORKDIR /

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -43,7 +43,6 @@ type Signal string
 var SigHup Signal = "SIGHUP"
 var SigKill Signal = "SIGKILL"
 var SigInt Signal = "SIGINT"
-var Sigterm Signal = "SIGTERM"
 
 // Client provides means to spawn Docker containers capable of hosting
 // services like the go-opera client.
@@ -234,6 +233,19 @@ func (c *Container) Hostname() string {
 // expected to offer its services.
 func (c *Container) IsRunning() bool {
 	return !c.stopped
+}
+
+// CheckRunning returns an error if the container process is no longer running,
+// either because it exited on its own or because its state cannot be determined.
+func (c *Container) CheckRunning() error {
+	info, err := c.client.cli.ContainerInspect(context.Background(), c.id)
+	if err != nil {
+		return fmt.Errorf("failed to inspect container: %w", err)
+	}
+	if !info.State.Running {
+		return fmt.Errorf("container exited with code %d", info.State.ExitCode)
+	}
+	return nil
 }
 
 // Stop terminates this container. Services within the container will be

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -98,7 +98,7 @@ func run(
 		scheduleNodeEvents(&node, queue, network, endTime, registry)
 	}
 	for _, app := range scenario.Applications {
-		if err := scheduleApplicationEvents(&app, queue, network, endTime); err != nil {
+		if err := scheduleApplicationEvents(ctx, &app, queue, network, endTime); err != nil {
 			return err
 		}
 	}
@@ -524,7 +524,7 @@ func (a netBasedValidatorRegistry) unregisterValidator(validatorId int) error {
 // scheduleApplicationEvents schedules a number of events covering the life-cycle of a class of
 // applications during the scenario execution. The nature of the scheduled applications is taken from the
 // given application description, and actions are applied to the given network.
-func scheduleApplicationEvents(source *parser.Application, queue *eventQueue, net driver.Network, end Time) error {
+func scheduleApplicationEvents(ctx context.Context, source *parser.Application, queue *eventQueue, net driver.Network, end Time) error {
 	instances := 1
 	if source.Instances != nil {
 		instances = *source.Instances
@@ -543,6 +543,9 @@ func scheduleApplicationEvents(source *parser.Application, queue *eventQueue, ne
 	}
 
 	for i := 0; i < instances; i++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		name := fmt.Sprintf("%s-%d", source.Name, i)
 		newApp, err := net.CreateApplication(&driver.ApplicationConfig{
 			Name:  name,

--- a/driver/network/host.go
+++ b/driver/network/host.go
@@ -34,6 +34,10 @@ type Host interface {
 	// IsRunning tests whether this host is running or has been stopped.
 	IsRunning() bool
 
+	// CheckRunning returns an error if the host process is no longer running,
+	// either because it exited on its own or because its state cannot be determined.
+	CheckRunning() error
+
 	// GetAddressForService returns the address of a service running on this
 	// host, or nil if such a service is not offered.
 	GetAddressForService(*ServiceDescription) *AddressPort

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -152,37 +152,22 @@ func NewLocalNetwork(ctx context.Context, config *driver.NetworkConfig) (*LocalN
 	return net, nil
 }
 
-// StartNode starts a node after it has been created.
-func (n *LocalNetwork) StartNode(nd driver.Node) (driver.Node, error) {
-	opera, ok := nd.(*node.OperaNode)
-	if !ok {
-		return nil, fmt.Errorf("trying to start non-sonic node")
-	}
-	return n.startNode(opera)
-}
-
-func (n *LocalNetwork) startNode(node *node.OperaNode) (*node.OperaNode, error) {
+// addNodeIntoNetwork connects the node with other nodes in the network, adds it into the list of nodes.
+func (n *LocalNetwork) addNodeIntoNetwork(node *node.OperaNode) error {
 	n.nodesMutex.Lock()
+	defer n.nodesMutex.Unlock()
+
 	id, err := node.GetNodeID()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get node id; %v", err)
+		return fmt.Errorf("failed to get node id; %v", err)
 	}
 	for _, other := range n.nodes {
 		if err = other.AddPeer(id); err != nil {
-			n.nodesMutex.Unlock()
-			return nil, fmt.Errorf("failed to add peer; %v", err)
+			return fmt.Errorf("failed to add peer; %v", err)
 		}
 	}
 	n.nodes[id] = node
-	n.nodesMutex.Unlock()
-
-	n.listenerMutex.Lock()
-	for listener := range n.listeners {
-		listener.AfterNodeCreation(node)
-	}
-	n.listenerMutex.Unlock()
-
-	return node, nil
+	return nil
 }
 
 // createNode is an internal version of CreateNode enabling the creation
@@ -192,7 +177,15 @@ func (n *LocalNetwork) createNode(ctx context.Context, nodeConfig *node.OperaNod
 	if err != nil {
 		return nil, fmt.Errorf("failed to start opera docker; %v", err)
 	}
-	return n.startNode(node)
+	if err := n.addNodeIntoNetwork(node); err != nil {
+		return nil, fmt.Errorf("failed to connect node; %w", err)
+	}
+	n.listenerMutex.Lock()
+	for listener := range n.listeners {
+		listener.AfterNodeCreation(node)
+	}
+	n.listenerMutex.Unlock()
+	return node, nil
 }
 
 // CreateNode creates nodes in the network during run.

--- a/driver/network/retry.go
+++ b/driver/network/retry.go
@@ -1,0 +1,57 @@
+package network
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+const DefaultRetryAttempts = 180
+
+// ErrPermanent is a sentinel error to be wrapped with fmt.Errorf when a
+// function passed to Retry or RetryReturn should not be retried.
+// Example: return fmt.Errorf("container exited: %w", network.ErrPermanent)
+var ErrPermanent = errors.New("permanent")
+
+// RetryReturn executes the input function until it produces no error.
+// It however executes only the configured number of times with the configured
+// delay between attempts. If the execution is not successful since,
+// the execution returns the last error.
+// When execution is successful, the execution result is returned from this method.
+// The context can be used to abort the retry loop early.
+// If the function returns a PermanentError, the retry loop stops immediately.
+func RetryReturn[Out any](ctx context.Context, numAttempts int, delay time.Duration, do func() (Out, error)) (Out, error) {
+	var out Out
+	var err error
+	for i := 0; i < numAttempts; i++ {
+		if ctx.Err() != nil {
+			return out, ctx.Err()
+		}
+		out, err = do()
+		if err == nil {
+			break
+		}
+		if errors.Is(err, ErrPermanent) {
+			return out, err // don't retry when the error is permanent
+		}
+		select {
+		case <-ctx.Done():
+			return out, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	return out, err
+}
+
+// Retry executes the input function until it produces no error.
+// It however executes only the configured number of times with the configured
+// delay between attempts. If the execution is not successful since,
+// the execution returns the last error.
+// The context can be used to abort the retry loop early.
+func Retry(ctx context.Context, numAttempts int, delay time.Duration, do func() error) error {
+	_, err := RetryReturn(ctx, numAttempts, delay, func() (*int, error) {
+		err := do()
+		return nil, err
+	})
+	return err
+}

--- a/driver/network/service.go
+++ b/driver/network/service.go
@@ -17,13 +17,11 @@
 package network
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"net"
 	"strconv"
 	"strings"
-	"time"
 )
 
 // ServiceDescription is
@@ -114,45 +112,4 @@ func GetFreePorts(num int) ([]Port, error) {
 		}
 	}
 	return ports, nil
-}
-
-const DefaultRetryAttempts = 180
-
-// RetryReturn executes the input function until it produces no error.
-// It however executes only the configured number of times with the configured
-// delay between attempts. If the execution is not successful since,
-// the execution returns the last error.
-// When execution is successful, the execution result is returned from this method.
-// The context can be used to abort the retry loop early.
-func RetryReturn[Out any](ctx context.Context, numAttempts int, delay time.Duration, do func() (Out, error)) (Out, error) {
-	var out Out
-	var err error
-	for i := 0; i < numAttempts; i++ {
-		if ctx.Err() != nil {
-			return out, ctx.Err()
-		}
-		out, err = do()
-		if err == nil {
-			break
-		}
-		select {
-		case <-ctx.Done():
-			return out, ctx.Err()
-		case <-time.After(delay):
-		}
-	}
-	return out, err
-}
-
-// Retry executes the input function until it produces no error.
-// It however executes only the configured number of times with the configured
-// delay between attempts. If the execution is not successful since,
-// the execution returns the last error.
-// The context can be used to abort the retry loop early.
-func Retry(ctx context.Context, numAttempts int, delay time.Duration, do func() error) error {
-	_, err := RetryReturn(ctx, numAttempts, delay, func() (*int, error) {
-		err := do()
-		return nil, err
-	})
-	return err
 }

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -190,7 +190,10 @@ func StartOperaDockerNode(ctx context.Context, client *docker.Client, dn *docker
 
 	// Wait until the OperaNode inside the Container is ready.
 	err = network.Retry(ctx, network.DefaultRetryAttempts, 1*time.Second, func() error {
-		_, err := node.GetNodeID()
+		if err := node.host.CheckRunning(); err != nil {
+			return fmt.Errorf("%w: %w", err, network.ErrPermanent)
+		}
+		_, err = node.GetNodeID()
 		return err
 	})
 	if err == nil {

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -101,6 +101,17 @@ func run(ctx *cli.Context) (err error) {
 
 	path := args.First()
 
+	// Create a context that is cancelled on SIGINT/SIGTERM so that both
+	// network startup and scenario execution can be interrupted cleanly,
+	// allowing all deferred shutdowns to execute.
+	stoppableCtx, stop := signal.NotifyContext(ctx.Context, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	go func() {
+		<-stoppableCtx.Done()
+		fmt.Printf("Interrupted - stopping...\n")
+		stop() // second Ctrl+C will force-kill
+	}()
+
 	// Check if the path is a directory
 	fileInfo, err := os.Stat(path)
 	if err != nil {
@@ -113,10 +124,13 @@ func run(ctx *cli.Context) (err error) {
 			if err != nil {
 				return err
 			}
+			if stoppableCtx.Err() != nil {
+				return stoppableCtx.Err()
+			}
 			if !d.IsDir() && (filepath.Ext(d.Name()) == ".yaml" || filepath.Ext(d.Name()) == ".yml") {
 				// Call runScenario for each YAML file
 				label := fmt.Sprintf("eval_%d", time.Now().Unix())
-				if err := runScenario(p, outputDir, label, keepPrometheusRunning, skipChecks, skipReportRendering); err != nil {
+				if err := runScenario(stoppableCtx, p, outputDir, label, keepPrometheusRunning, skipChecks, skipReportRendering); err != nil {
 					return fmt.Errorf("failed to run: %s: %w", p, err)
 				}
 			}
@@ -129,11 +143,13 @@ func run(ctx *cli.Context) (err error) {
 			label = fmt.Sprintf("eval_%d", time.Now().Unix())
 		}
 
-		return runScenario(path, outputDir, label, keepPrometheusRunning, skipChecks, skipReportRendering)
+		return runScenario(stoppableCtx, path, outputDir, label, keepPrometheusRunning, skipChecks, skipReportRendering)
 	}
 }
 
-func runScenario(path, outputDir, label string, keepPrometheusRunning, skipChecks, skipReportRendering bool) error {
+func runScenario(ctx context.Context, path, outputDir, label string, keepPrometheusRunning, skipChecks, skipReportRendering bool) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	// if not configured, default to /tmp/norma_data_<label>_<timestamp> else /configured/path/norma_data_<l>_<t>
 	outputDir, err := os.MkdirTemp(outputDir, fmt.Sprintf("norma_data_%s_", label))
@@ -175,12 +191,6 @@ func runScenario(path, outputDir, label string, keepPrometheusRunning, skipCheck
 	if err != nil {
 		return err
 	}
-
-	// Create a context that is cancelled on SIGINT/SIGTERM so that both
-	// network startup and scenario execution can be interrupted cleanly,
-	// allowing all deferred shutdowns to execute.
-	ctx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stopSignals()
 
 	clock := executor.NewWallTimeClock()
 

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -232,7 +232,7 @@ func runScenario(ctx context.Context, path, outputDir, label string, keepPrometh
 		fmt.Printf("Monitoring data was written to %v\n", outputDir)
 		fmt.Printf("Raw data was exported to %s\n", monitor.GetMeasurementFileName())
 
-		if !skipReportRendering {
+		if !skipReportRendering && ctx.Err() != nil {
 			fmt.Printf("Rendering summary report (may take a few minutes the first time if R packages need to be installed) ...\n")
 			if file, err := report.SingleEvalReport.Render(monitor.GetMeasurementFileName(), outputDir); err != nil {
 				fmt.Printf("Report generation failed:\n%v\n", err)


### PR DESCRIPTION
* Handle stop signal already in run() to interrupt multiple running scenarios correctly
* Detect crashed sonic container - interrupt Retry when sonic failed to start
* Refactor `network.startNode()` into `network.addNodeIntoNetwork()` (clean naming)
* Skip rendering report when stopped by signal (faster shutdown)