### PR TITLE
Add epoch sealing to the end of each scenario

### DIFF
--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -65,6 +65,7 @@ func run(
 	}))
 
 	if checks != nil {
+		// apply default check unless custom checks are provided
 		if len(scenario.Checks) == 0 {
 			// Seal two epochs after the scenario ends, before default consistency checks run.
 			scheduleAdvanceEpochEvents(scenario.Duration+1, 2, queue, network)

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -64,15 +64,17 @@ func run(
 		return nil
 	}))
 
-	// schedule network consistency just before the end of simulation
 	if checks != nil {
-		// apply default check unless custom checks are provided
 		if len(scenario.Checks) == 0 {
-			queue.add(toSingleEvent(endTime-1, "consistency check", func() error {
+			// Seal two epochs after the scenario ends, before default consistency checks run.
+			scheduleAdvanceEpochEvents(scenario.Duration+1, 2, queue, network)
+			// Schedule default consistency checks 2 seconds after the scenario end (after the epoch sealing).
+			queue.add(toSingleEvent(Seconds(scenario.Duration+2), "consistency check", func() error {
 				log.Printf("Checking network consistency ...\n")
 				return checks.Check()
 			}))
 		} else {
+			// Schedule custom checks defined in the scenario.
 			for _, c := range scenario.Checks {
 				checker := checks.GetCheckerByName(c.Check)
 				if checker == nil {

--- a/driver/executor/executor_test.go
+++ b/driver/executor/executor_test.go
@@ -367,6 +367,8 @@ func TestExecutor_RunScenarioWithDefaultChecks(t *testing.T) {
 		return checkBlockGasRate
 	})
 
+	net.EXPECT().AdvanceEpoch(2).Return(nil)
+
 	checkBlockHeight.EXPECT().Check().Return(nil)
 	checkBlocksHashes.EXPECT().Check().Return(nil)
 	checkBlocksRolling.EXPECT().Check().Return(nil)

--- a/driver/monitoring/node/node_source_test.go
+++ b/driver/monitoring/node/node_source_test.go
@@ -72,9 +72,9 @@ func TestNodeSourceRetrievesSensorData(t *testing.T) {
 	node2.EXPECT().GetLabel().AnyTimes().Return(string(node2Id))
 	node3.EXPECT().GetLabel().AnyTimes().Return(string(node3Id))
 
-	url1 := driver.URL("node1")
-	url2 := driver.URL("node2")
-	url3 := driver.URL("node3")
+	url1 := driver.URL("http://node1")
+	url2 := driver.URL("http://node2")
+	url3 := driver.URL("http://node3")
 	node1.EXPECT().GetServiceUrl(gomock.Any()).AnyTimes().Return(&url1)
 	node2.EXPECT().GetServiceUrl(gomock.Any()).AnyTimes().Return(&url2)
 	node3.EXPECT().GetServiceUrl(gomock.Any()).AnyTimes().Return(&url3)

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -108,7 +108,7 @@ func run(ctx *cli.Context) (err error) {
 	defer stop()
 	go func() {
 		<-stoppableCtx.Done()
-		fmt.Printf("Interrupted - stopping...\n")
+		fmt.Printf("Stopping...\n")
 		stop() // second Ctrl+C will force-kill
 	}()
 


### PR DESCRIPTION
Automatically add explicit epoch sealing in between the end of each scenario, before the default checks.

Automatic epoch sealing is added **only when default checks are being added** to the end of scenario - when checks are not defined otherwise in the scenario.