### PR TITLE
Fix user permissions issue on R report

### DIFF
--- a/analysis/report/render.R
+++ b/analysis/report/render.R
@@ -29,4 +29,5 @@ rmarkdown::render(
     params = list(datafile = data),
     output_dir = outputdir,
     output_file = outputfile,
+    intermediates_dir = outputdir,
 )

--- a/analysis/report/report.go
+++ b/analysis/report/report.go
@@ -75,6 +75,8 @@ func (r *Report) Render(datafile, outputdir string) (string, error) {
 	outputfile := r.name + ".html"
 
 	cmd := exec.Command("docker", "run", "--rm",
+		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
+		"-w", "/output",
 		"-v", script+":/render.R:ro",
 		"-v", template+":/template.Rmd:ro",
 		"-v", datafile+":/input.csv:ro",


### PR DESCRIPTION
Forward uid in container so that files created are not owned by root.
Change working directory in r execution so that newly created files are not written into / (where user does not have permissions) 