### PR TITLE
Fix report, use execution seconds instead of real time

### DIFF
--- a/analysis/report/single_eval_report.Rmd
+++ b/analysis/report/single_eval_report.Rmd
@@ -179,12 +179,12 @@ sent_rate <- all_data %>%
 if (nrow(sent_rate) > 0) {
     sent_rate <- sent_rate %>%
         drop_na(rate) %>%
-        # convert time from UNIX to DateTime type
-        mutate(date = as_datetime(time / 1e9))
+        # convert time from UNIX nanoseconds to elapsed seconds
+        mutate(elapsed_sec = (time - as.numeric(start_time)) / 1e9)
 } else {
     sent_rate <- sent_rate %>%
         mutate(rate = 0) %>%
-        mutate(date = as_datetime(0))
+        mutate(elapsed_sec = 0)
 }
 
 
@@ -223,21 +223,21 @@ received_rate <- all_data %>%
 if (nrow(sent_rate) > 0) {
     received_rate <- received_rate %>%
         drop_na(rate) %>%
-        # convert time from UNIX to DateTime type
-        mutate(date = as_datetime(time / 1e9))
+        # convert time from UNIX nanoseconds to elapsed seconds
+        mutate(elapsed_sec = (time - as.numeric(start_time)) / 1e9)
 } else {
     received_rate <- received_rate %>%
         mutate(rate = 0) %>%
-        mutate(date = as_datetime(0))
+        mutate(elapsed_sec = 0)
 }
 
 ggplot() +
-    geom_line(data = sent_rate, aes(x = date, y = rate, color = "incomming [5s window]")) +
-    # geom_smooth(data=sent_rate, aes(x=date, y=rate)) +
-    geom_line(data = received_rate, aes(x = date, y = rate, color = "committed [5s window]")) +
-    # geom_smooth(data=received_rate, aes(x=date, y=rate)) +
+    geom_line(data = sent_rate, aes(x = elapsed_sec, y = rate, color = "incomming [5s window]")) +
+    # geom_smooth(data=sent_rate, aes(x=elapsed_sec, y=rate)) +
+    geom_line(data = received_rate, aes(x = elapsed_sec, y = rate, color = "committed [5s window]")) +
+    # geom_smooth(data=received_rate, aes(x=elapsed_sec, y=rate)) +
     ggtitle("Incomming and Committed Transaction Rates") +
-    xlab("Time") +
+    xlab("Time (s)") +
     ylab("Tx/s") +
     theme(plot.title = element_text(hjust = 0.5))
 ```


### PR DESCRIPTION
This PR fixes the scale in one graph where absolute time was used instead of experiment time. 