### PR TITLE
Handle new txpool requirement for using current nonce

### DIFF
--- a/load/app/allofbundle_app.go
+++ b/load/app/allofbundle_app.go
@@ -170,6 +170,7 @@ type AllOfBundleUser struct {
 }
 
 func (u *AllOfBundleUser) GenerateTx() (*types.Transaction, error) {
+	ctx := context.Background()
 
 	approveData, err := u.erc20Abi.Pack("approve", u.spender.address, big.NewInt(1))
 	if err != nil {
@@ -181,16 +182,27 @@ func (u *AllOfBundleUser) GenerateTx() (*types.Transaction, error) {
 		return nil, fmt.Errorf("failed to pack transferFrom: %w", err)
 	}
 
-	currentBlock, err := u.client.BlockNumber(context.Background())
+	nonceApprover, err := u.client.PendingNonceAt(ctx, u.approver.address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get nonce for approver: %w", err)
+	}
+
+	nonceSpender, err := u.client.PendingNonceAt(ctx, u.spender.address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get nonce for spender: %w", err)
+	}
+
+	currentBlock, err := u.client.BlockNumber(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current block number: %w", err)
 	}
 
-	envelope := bundle.NewBuilder().
+	u.sentTxs.Add(1)
+	return bundle.NewBuilder().
 		WithSigner(u.signer).
 		AllOf(
 			bundle.Step(u.approver.privateKey, &types.DynamicFeeTx{
-				Nonce:     u.approver.getCurrentNonce(),
+				Nonce:     nonceApprover,
 				Gas:       70_000, // base (21k) + approve SSTORE (22k) + event
 				GasFeeCap: gasFeeCap,
 				GasTipCap: gasTipCap,
@@ -198,7 +210,7 @@ func (u *AllOfBundleUser) GenerateTx() (*types.Transaction, error) {
 				Data:      approveData,
 			}),
 			bundle.Step(u.spender.privateKey, &types.DynamicFeeTx{
-				Nonce:     u.spender.getCurrentNonce(),
+				Nonce:     nonceSpender,
 				Gas:       90_000, // base (21k) + 3x SLOAD + 3x SSTORE (22k) + event
 				GasFeeCap: gasFeeCap,
 				GasTipCap: gasTipCap,
@@ -207,12 +219,7 @@ func (u *AllOfBundleUser) GenerateTx() (*types.Transaction, error) {
 			}),
 		).
 		SetEarliest(currentBlock).
-		Build()
-
-	u.approver.getNextNonce()
-	u.spender.getNextNonce()
-	u.sentTxs.Add(1)
-	return envelope, nil
+		Build(), nil
 }
 
 func (u *AllOfBundleUser) GetSentTransactions() uint64 {

--- a/load/app/bundle_app_test.go
+++ b/load/app/bundle_app_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/0xsoniclabs/norma/driver/network/local"
 	"github.com/0xsoniclabs/norma/load/app"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -83,7 +83,6 @@ func testBundleGenerator(t *testing.T, application app.Application, ctxt app.App
 
 	numBundles := 5
 	rpcClient := ctxt.GetClient()
-	planHashes := make([]common.Hash, 0, numBundles)
 	signer := types.LatestSignerForChainID(big.NewInt(FakeNetworkID))
 	for i := range numBundles {
 		tx, err := user.GenerateTx()
@@ -95,6 +94,12 @@ func testBundleGenerator(t *testing.T, application app.Application, ctxt app.App
 		}
 
 		if err := rpcClient.SendTransaction(t.Context(), tx); err != nil {
+			// DuplicatedBundle intentionally re-sends the same plan after it has been
+			// committed, so ErrBundleAlreadyProcessed is expected in that case.
+			if strings.Contains(err.Error(), "already been processed") {
+				fmt.Printf("bundle %d: plan already processed, skipping wait\n", i)
+				continue
+			}
 			t.Fatal(err)
 		}
 
@@ -104,16 +109,12 @@ func testBundleGenerator(t *testing.T, application app.Application, ctxt app.App
 		}
 		planHash := txBundle.Plan.Hash()
 		fmt.Printf("Sent bundle %d (plan %s)\n", i, planHash)
-		planHashes = append(planHashes, planHash)
-	}
 
-	// Wait for each successful bundle execution via sonic_getBundleInfo. This detects
-	// rolled-back bundles which commit no transactions and have no receipts.
-	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
-	defer cancel()
-	for i, planHash := range planHashes {
-		fmt.Printf("Awaiting bundle %d (plan %s)...\n", i, planHash)
+		// Wait for this bundle to execute before sending the next one so that
+		// the pending nonce of the inner-transaction accounts is up to date.
+		ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 		info, err := rpcClient.WaitForBundleInfo(ctx, planHash)
+		cancel()
 		if err != nil {
 			t.Fatalf("bundle %d (plan %s) not executed: %v", i, planHash, err)
 		}

--- a/load/app/duplicatedbundle_app.go
+++ b/load/app/duplicatedbundle_app.go
@@ -196,7 +196,8 @@ func (u *DuplicatedBundleUser) GenerateTx() (*types.Transaction, error) {
 
 // generateNewBundleTx builds a fresh bundle tx.
 func (u *DuplicatedBundleUser) generateNewBundleTx() (*types.Transaction, error) {
-	currentBlock, err := u.client.BlockNumber(context.Background())
+	ctx := context.Background()
+	currentBlock, err := u.client.BlockNumber(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current block number: %w", err)
 	}
@@ -209,21 +210,30 @@ func (u *DuplicatedBundleUser) generateNewBundleTx() (*types.Transaction, error)
 		return nil, fmt.Errorf("failed to pack transfer: %w", err)
 	}
 
+	nonceA, err := u.client.PendingNonceAt(ctx, u.senderA.address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get nonce for senderA: %w", err)
+	}
+	nonceB, err := u.client.PendingNonceAt(ctx, u.senderB.address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get nonce for senderB: %w", err)
+	}
+
 	b := bundle.NewBuilder().WithSigner(u.signer).SetEarliest(currentBlock)
 	if rand.Intn(2) == 0 {
 		b = b.OneOf(bundle.Step(u.senderA.privateKey, types.DynamicFeeTx{
-			Nonce: u.senderA.getNextNonce(), Gas: 70_000, GasFeeCap: gasFeeCap, GasTipCap: gasTipCap,
+			Nonce: nonceA, Gas: 70_000, GasFeeCap: gasFeeCap, GasTipCap: gasTipCap,
 			To: &u.erc20Address, Data: transferToTargetData,
 		}), bundle.Step(u.senderB.privateKey, &types.DynamicFeeTx{
-			Nonce: u.senderB.getCurrentNonce(), Gas: 70_000, GasFeeCap: gasFeeCap, GasTipCap: gasTipCap,
+			Nonce: nonceB, Gas: 70_000, GasFeeCap: gasFeeCap, GasTipCap: gasTipCap,
 			To: &u.erc20Address, Data: transferToTargetData,
 		}))
 	} else {
 		b = b.AllOf(bundle.Step(u.senderA.privateKey, types.DynamicFeeTx{
-			Nonce: u.senderA.getNextNonce(), Gas: 70_000, GasFeeCap: gasFeeCap, GasTipCap: gasTipCap,
+			Nonce: nonceA, Gas: 70_000, GasFeeCap: gasFeeCap, GasTipCap: gasTipCap,
 			To: &u.erc20Address, Data: transferToBData,
 		}), bundle.Step(u.senderB.privateKey, &types.DynamicFeeTx{
-			Nonce: u.senderB.getNextNonce(), Gas: 70_000, GasFeeCap: gasFeeCap, GasTipCap: gasTipCap,
+			Nonce: nonceB, Gas: 70_000, GasFeeCap: gasFeeCap, GasTipCap: gasTipCap,
 			To: &u.erc20Address, Data: transferToTargetData,
 		}))
 	}

--- a/load/app/oneofbundle_app.go
+++ b/load/app/oneofbundle_app.go
@@ -173,15 +173,22 @@ func (u *OneOfBundleUser) GenerateTx() (*types.Transaction, error) {
 		return nil, fmt.Errorf("failed to pack over-balance transfer data: %w", err)
 	}
 
-	currentBlock, err := u.client.BlockNumber(context.Background())
+	ctx := context.Background()
+
+	currentBlock, err := u.client.BlockNumber(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current block number: %w", err)
+	}
+
+	nonce, err := u.client.PendingNonceAt(ctx, u.sender.address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get nonce for sender: %w", err)
 	}
 
 	var firstStep, secondStep bundle.BuilderStep
 	if successfulFirst {
 		firstStep = bundle.Step(u.sender.privateKey, &types.DynamicFeeTx{
-			Nonce:     u.sender.getNextNonce(),
+			Nonce:     nonce,
 			Gas:       70_000,
 			GasFeeCap: gasFeeCap,
 			GasTipCap: gasTipCap,
@@ -189,7 +196,7 @@ func (u *OneOfBundleUser) GenerateTx() (*types.Transaction, error) {
 			Data:      transferSuccessfulData,
 		})
 		secondStep = bundle.Step(u.sender.privateKey, &types.DynamicFeeTx{
-			Nonce:     u.sender.getCurrentNonce(), // will not run, nonce not consumed
+			Nonce:     nonce, // will not run, nonce not consumed
 			Gas:       70_000,
 			GasFeeCap: gasFeeCap,
 			GasTipCap: gasTipCap,
@@ -198,7 +205,7 @@ func (u *OneOfBundleUser) GenerateTx() (*types.Transaction, error) {
 		})
 	} else {
 		firstStep = bundle.Step(u.sender.privateKey, &types.DynamicFeeTx{
-			Nonce:     u.sender.getNextNonce(),
+			Nonce:     nonce,
 			Gas:       70_000,
 			GasFeeCap: gasFeeCap,
 			GasTipCap: gasTipCap,
@@ -206,7 +213,7 @@ func (u *OneOfBundleUser) GenerateTx() (*types.Transaction, error) {
 			Data:      transferFailingData,
 		})
 		secondStep = bundle.Step(u.sender.privateKey, &types.DynamicFeeTx{
-			Nonce:     u.sender.getNextNonce(), // both will run, both nonces will be consumed
+			Nonce:     nonce + 1, // both will run, both nonces will be consumed
 			Gas:       70_000,
 			GasFeeCap: gasFeeCap,
 			GasTipCap: gasTipCap,

--- a/load/app/subsidizedbundle_app.go
+++ b/load/app/subsidizedbundle_app.go
@@ -226,16 +226,29 @@ func (u *SubsidizedBundleUser) GenerateTx() (*types.Transaction, error) {
 		return nil, fmt.Errorf("failed to pack transferFrom: %w", err)
 	}
 
-	currentBlock, err := u.client.BlockNumber(context.Background())
+	ctx := context.Background()
+
+	currentBlock, err := u.client.BlockNumber(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current block number: %w", err)
 	}
 
-	envelope := bundle.NewBuilder().
+	nonceSponsor, err := u.client.PendingNonceAt(ctx, u.sponsor.address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get nonce for sponsor: %w", err)
+	}
+
+	nonceUser, err := u.client.PendingNonceAt(ctx, u.user.address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get nonce for user: %w", err)
+	}
+
+	u.sentTxs.Add(1)
+	return bundle.NewBuilder().
 		WithSigner(u.signer).
 		AllOf(
 			bundle.Step(u.sponsor.privateKey, &types.DynamicFeeTx{
-				Nonce:     u.sponsor.getCurrentNonce(),
+				Nonce:     nonceSponsor,
 				Gas:       90_000,
 				GasFeeCap: gasFeeCap,
 				GasTipCap: gasTipCap,
@@ -244,7 +257,7 @@ func (u *SubsidizedBundleUser) GenerateTx() (*types.Transaction, error) {
 				Data:      sponsorData,
 			}),
 			bundle.Step(u.user.privateKey, &types.DynamicFeeTx{
-				Nonce:     u.user.getCurrentNonce(),
+				Nonce:     nonceUser,
 				Gas:       approveGasLimit.Uint64(),
 				GasFeeCap: big.NewInt(0), // gasPrice=0: covered by the subsidy from step 1
 				GasTipCap: big.NewInt(0),
@@ -252,7 +265,7 @@ func (u *SubsidizedBundleUser) GenerateTx() (*types.Transaction, error) {
 				Data:      approveData,
 			}),
 			bundle.Step(u.sponsor.privateKey, &types.DynamicFeeTx{
-				Nonce:     u.sponsor.getCurrentNonce() + 1,
+				Nonce:     nonceSponsor + 1,
 				Gas:       90_000,
 				GasFeeCap: gasFeeCap,
 				GasTipCap: gasTipCap,
@@ -261,13 +274,7 @@ func (u *SubsidizedBundleUser) GenerateTx() (*types.Transaction, error) {
 			}),
 		).
 		SetEarliest(currentBlock).
-		Build()
-
-	u.sponsor.getNextNonce()
-	u.user.getNextNonce()
-	u.sponsor.getNextNonce()
-	u.sentTxs.Add(1)
-	return envelope, nil
+		Build(), nil
 }
 
 func (u *SubsidizedBundleUser) GetSentTransactions() uint64 {


### PR DESCRIPTION
Handle new txpool requirement for bundles introduced in https://github.com/0xsoniclabs/sonic/pull/1005.

* wait for previous bundle to be on-chain before sending another one (fix tests)
* load nonces for bundles from rpc (allow recovery when some bundle is rejected by txpool)
