### PR TITLE
Add scenario where validators are upgraded before starting brio

### DIFF
--- a/genesis/app/validator.go
+++ b/genesis/app/validator.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
 	"path"
 
@@ -108,11 +109,13 @@ func generateValidatorFrom(ctx *cli.Context) (err error) {
 		Type: validatorpk.Types.Secp256k1,
 	}
 
-	var pathSecretFile string = ""
+	pathSecretFile := ""
 	if datadir != "" {
 		valKeystore := valkeystore.NewDefaultFileRawKeystore(path.Join(datadir, "keystore", "validator"))
 		err = valKeystore.Add(publicKey, privateKey, "password")
-		if err != nil {
+
+		// Allowing creating an already existing validator allows to restart them
+		if err != nil && !errors.Is(err, valkeystore.ErrAlreadyExists) {
 			return fmt.Errorf("failed to create account: %w", err)
 		}
 

--- a/scenarios/test/bundles_activation_coherence.yml
+++ b/scenarios/test/bundles_activation_coherence.yml
@@ -1,0 +1,93 @@
+# This scenario verifies that three v2.1.6 validators can be upgraded
+# one-by-one to v2.2.0 while maintaining network coherence.
+# Each upgrade is separated by two epoch sealings.
+#
+# Sequence of events:
+# 1. Network starts with 3 v2.1.6 validators
+# 2. First validator is stopped and restarted as v2.2.0 (epoch sealed before and after)
+# 3. Two epochs later, second validator is upgraded the same way
+# 4. Two epochs later, third validator is upgraded
+# 5. Brio and transaction bundles are enabled
+# 6. All three v2.2.0 nodes have the same history hash
+
+name: Bundles Activation Coherence
+
+# The duration of the scenario's runtime, in seconds.
+duration: 90
+
+validators:
+  - name: validator
+    instances: 3
+    imagename: "sonic:local"
+
+# 5s epoch duration for automatic epoch sealing.
+# Brio and bundles start disabled and are enabled after all nodes are upgraded.
+network_rules:
+  genesis:
+    MAX_EPOCH_DURATION: 5s
+    UPGRADES_ALLEGRO: true
+    UPGRADES_GAS_SUBSIDIES: true
+    UPGRADES_BRIO: false
+    UPGRADES_TRANSACTION_BUNDLES: false
+  updates:
+    - time: 50
+      rules:
+        UPGRADES_BRIO: true
+        UPGRADES_TRANSACTION_BUNDLES: true
+
+
+# Nodes: stop old version, start new version reusing the same data_volume.
+nodes:
+  # --- node 1 upgrade ---
+  - name: old-1
+    start: 0
+    leave: 10
+    client:
+      type: validator
+      imagename: "sonic:v2.1.6"
+      data_volume: "vol-1"
+      val_id: 4
+
+  - name: new-1
+    rejoin: 20
+    client:
+      type: validator
+      imagename: "sonic:local"
+      data_volume: "vol-1"
+      val_id: 4
+
+  # --- node 2 upgrade ---
+  # notice that node 2 is offline during the update, 
+  # this means that it has to reconstruct the bundle history correctly
+  # during syncing
+  - name: old-2
+    start: 0
+    leave: 30
+    client:
+      type: validator
+      imagename: "sonic:v2.1.6"
+      data_volume: "vol-2"
+      val_id: 5
+
+  - name: new-2
+    rejoin: 60
+    client:
+      type: validator
+      imagename: "sonic:local"
+      data_volume: "vol-2"
+      val_id: 5
+
+# Background counter transactions for the entire duration.
+applications:
+  - name: background
+    type: counter
+    users: 20
+    rate:
+      constant: 10
+
+  - name: bundles
+    type: subsidizedbundle
+    start: 60
+    users: 10
+    rate:
+      constant: 5


### PR DESCRIPTION
The scenario runs nodes which upgrade at different times and start using bundles, Epoch hashes must remain coherent.

The sonic client keeps a local history of bundles executed within the last ~1000 blocks.
This test checks that all nodes start filling this storage at the same block height independently of when the node has been upgraded to 2.2.

This scenario has two validators updated during its execution, one of them is offline during the upgrade.