### PR TITLE
Handler errors in defers

### DIFF
--- a/analysis/report/report.go
+++ b/analysis/report/report.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+
+	"github.com/0xsoniclabs/sonic/utils/caution"
 )
 
 // Report is a template for a report to be produced from monitoring data
@@ -59,20 +61,28 @@ var renderScript []byte
 
 // Render renders this report using the given input data file (in CSV format)
 // and places its results into the defined output directory.
-func (r *Report) Render(datafile, outputdir string) (string, error) {
+func (r *Report) Render(datafile, outputdir string) (outputfile string, err error) {
 	script, err := createTempFile(renderScript, ".R")
 	if err != nil {
 		return "", err
 	}
-	defer os.Remove(script)
+	defer caution.ExecuteAndReportError(
+		&err,
+		func() error { return os.Remove(script) },
+		"failed to remove temporary file",
+	)
 
 	template, err := createTempFile(r.template, ".Rmd")
 	if err != nil {
 		return "", err
 	}
-	defer os.Remove(template)
+	defer caution.ExecuteAndReportError(
+		&err,
+		func() error { return os.Remove(template) },
+		"failed to remove temporary file",
+	)
 
-	outputfile := r.name + ".html"
+	outputfile = r.name + ".html"
 
 	cmd := exec.Command("docker", "run", "--rm",
 		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
@@ -94,12 +104,12 @@ func (r *Report) Render(datafile, outputdir string) (string, error) {
 	return outputfile, nil
 }
 
-func createTempFile(content []byte, suffix string) (string, error) {
+func createTempFile(content []byte, suffix string) (filename string, err error) {
 	file, err := os.CreateTemp("", "tmp_*"+suffix)
 	if err != nil {
 		return "", err
 	}
-	defer file.Close()
+	defer caution.CloseAndReportError(&err, file, "failed to close temporary file")
 	if _, err := file.Write(content); err != nil {
 		return "", err
 	}

--- a/analysis/report/report.go
+++ b/analysis/report/report.go
@@ -19,11 +19,10 @@ package report
 import (
 	"bytes"
 	_ "embed"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
-
-	"github.com/0xsoniclabs/sonic/utils/caution"
 )
 
 // Report is a template for a report to be produced from monitoring data
@@ -66,21 +65,13 @@ func (r *Report) Render(datafile, outputdir string) (outputfile string, err erro
 	if err != nil {
 		return "", err
 	}
-	defer caution.ExecuteAndReportError(
-		&err,
-		func() error { return os.Remove(script) },
-		"failed to remove temporary file",
-	)
+	defer func() { err = errors.Join(err, os.Remove(script)) }()
 
 	template, err := createTempFile(r.template, ".Rmd")
 	if err != nil {
 		return "", err
 	}
-	defer caution.ExecuteAndReportError(
-		&err,
-		func() error { return os.Remove(template) },
-		"failed to remove temporary file",
-	)
+	defer func() { err = errors.Join(err, os.Remove(template)) }()
 
 	outputfile = r.name + ".html"
 
@@ -109,7 +100,7 @@ func createTempFile(content []byte, suffix string) (filename string, err error) 
 	if err != nil {
 		return "", err
 	}
-	defer caution.CloseAndReportError(&err, file, "failed to close temporary file")
+	defer func() { err = errors.Join(err, file.Close()) }()
 	if _, err := file.Write(content); err != nil {
 		return "", err
 	}

--- a/driver/monitoring/node/cpu_profile.go
+++ b/driver/monitoring/node/cpu_profile.go
@@ -28,11 +28,12 @@ import (
 	mon "github.com/0xsoniclabs/norma/driver/monitoring"
 	"github.com/0xsoniclabs/norma/driver/monitoring/utils"
 	opera "github.com/0xsoniclabs/norma/driver/node"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 )
 
 type PprofData []byte
 
-func GetPprofData(node driver.Node, duration time.Duration) (PprofData, error) {
+func GetPprofData(node driver.Node, duration time.Duration) (data PprofData, err error) {
 	url := node.GetServiceUrl(&opera.OperaDebugService)
 	if url == nil {
 		return nil, fmt.Errorf("node does not offer the pprof service")
@@ -41,7 +42,7 @@ func GetPprofData(node driver.Node, duration time.Duration) (PprofData, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer caution.CloseAndReportError(&err, resp.Body, "failed to close response body")
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch result: %v", resp)
 	}

--- a/driver/monitoring/node/cpu_profile.go
+++ b/driver/monitoring/node/cpu_profile.go
@@ -17,6 +17,7 @@
 package nodemon
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -28,7 +29,6 @@ import (
 	mon "github.com/0xsoniclabs/norma/driver/monitoring"
 	"github.com/0xsoniclabs/norma/driver/monitoring/utils"
 	opera "github.com/0xsoniclabs/norma/driver/node"
-	"github.com/0xsoniclabs/sonic/utils/caution"
 )
 
 type PprofData []byte
@@ -42,7 +42,7 @@ func GetPprofData(node driver.Node, duration time.Duration) (data PprofData, err
 	if err != nil {
 		return nil, err
 	}
-	defer caution.CloseAndReportError(&err, resp.Body, "failed to close response body")
+	defer func() { err = errors.Join(err, resp.Body.Close()) }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch result: %v", resp)
 	}

--- a/driver/monitoring/node_log_provider.go
+++ b/driver/monitoring/node_log_provider.go
@@ -156,14 +156,22 @@ func (n *NodeLogDispatcher) runLogCollector(node driver.Node) {
 		log.Printf("failed to obtain logs of node %v, log is not captured: %v", label, err)
 		return
 	}
-	defer in.Close()
+	defer func() {
+		if err := in.Close(); err != nil {
+			log.Printf("failed to close log stream for node %v: %v", label, err)
+		}
+	}()
 	file := n.logDir + "/" + label + ".log"
 	out, err := os.Create(file)
 	if err != nil {
 		log.Printf("failed to create log file %v for node %v, log is not captured: %v", file, label, err)
 		return
 	}
-	defer out.Close()
+	defer func() {
+		if err := out.Close(); err != nil {
+			log.Printf("failed to close log file for node %v: %v", label, err)
+		}
+	}()
 	_, err = io.Copy(out, in)
 	if err != nil {
 		log.Printf("failed to capture log for node %v: %v", label, err)

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/0xsoniclabs/norma/driver/network"
 	"github.com/0xsoniclabs/norma/driver/parser"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/node"
@@ -567,7 +568,7 @@ func TestLocalNetwork_Can_Run_Multiple_Client_Images_TaggedVersions(t *testing.T
 
 // getChecksum creates a node of the provided image type on the provided network
 // and extract the checksum.
-func getChecksum(net *LocalNetwork, image string) (string, error) {
+func getChecksum(net *LocalNetwork, image string) (checksum string, err error) {
 	node, err := net.CreateNode(&driver.NodeConfig{
 		Name:  fmt.Sprintf("T-%s", image),
 		Image: image,
@@ -580,7 +581,9 @@ func getChecksum(net *LocalNetwork, image string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("cannot read node logs: %e", err)
 	}
-	defer reader.Close()
+	defer func() {
+		caution.CloseAndReportError(&err, reader, "cannot close log reader")
+	}()
 
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -18,6 +18,7 @@ package local
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -28,7 +29,6 @@ import (
 
 	"github.com/0xsoniclabs/norma/driver/network"
 	"github.com/0xsoniclabs/norma/driver/parser"
-	"github.com/0xsoniclabs/sonic/utils/caution"
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/node"
@@ -581,9 +581,7 @@ func getChecksum(net *LocalNetwork, image string) (checksum string, err error) {
 	if err != nil {
 		return "", fmt.Errorf("cannot read node logs: %e", err)
 	}
-	defer func() {
-		caution.CloseAndReportError(&err, reader, "cannot close log reader")
-	}()
+	defer func() { err = errors.Join(err, reader.Close()) }()
 
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {

--- a/driver/network/service.go
+++ b/driver/network/service.go
@@ -22,6 +22,8 @@ import (
 	"net"
 	"strconv"
 	"strings"
+
+	"github.com/0xsoniclabs/sonic/utils/caution"
 )
 
 // ServiceDescription is
@@ -70,8 +72,8 @@ func GetFreePort() (Port, error) {
 // GetFreePorts obtains a list of free TCP ports on the local system.  Note
 // that after this call the ports are not reserved. Thus, consecutive calls may
 // produce the same free ports until it is actually bound to some application.
-func GetFreePorts(num int) ([]Port, error) {
-	ports := make([]Port, 0, num)
+func GetFreePorts(num int) (ports []Port, err error) {
+	ports = make([]Port, 0, num)
 	for len(ports) < num {
 		found := false
 		for i := 0; !found && i < 10; i++ {
@@ -81,7 +83,7 @@ func GetFreePorts(num int) ([]Port, error) {
 				continue
 			}
 			// make sure to close the listener in case of an error
-			defer listener.Close()
+			defer caution.CloseAndReportError(&err, listener, "failed to close listener")
 
 			port := listener.Addr().String()
 			columnPos := strings.LastIndex(port, ":")

--- a/driver/network/service.go
+++ b/driver/network/service.go
@@ -17,13 +17,12 @@
 package network
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net"
 	"strconv"
 	"strings"
-
-	"github.com/0xsoniclabs/sonic/utils/caution"
 )
 
 // ServiceDescription is
@@ -83,7 +82,7 @@ func GetFreePorts(num int) (ports []Port, err error) {
 				continue
 			}
 			// make sure to close the listener in case of an error
-			defer caution.CloseAndReportError(&err, listener, "failed to close listener")
+			defer func() { err = errors.Join(err, listener.Close()) }()
 
 			port := listener.Addr().String()
 			columnPos := strings.LastIndex(port, ":")

--- a/driver/norma/diff.go
+++ b/driver/norma/diff.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/0xsoniclabs/norma/analysis/report"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/urfave/cli/v2"
 )
 
@@ -32,7 +33,7 @@ var diffCommand = cli.Command{
 	Usage:  "renders a report comparing the monitoring data of multiple evaluations",
 }
 
-func diff(ctx *cli.Context) error {
+func diff(ctx *cli.Context) (err error) {
 	args := ctx.Args()
 	if args.Len() < 1 {
 		return fmt.Errorf("requires at least one measurment file path as argument")
@@ -43,7 +44,7 @@ func diff(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer caution.CloseAndReportError(&err, file, "failed to close temporary file")
 	for _, src := range args.Slice() {
 		content, err := os.ReadFile(src)
 		if err != nil {
@@ -57,7 +58,11 @@ func diff(ctx *cli.Context) error {
 	if err := file.Close(); err != nil {
 		return err
 	}
-	defer os.Remove(file.Name())
+	defer caution.ExecuteAndReportError(
+		&err,
+		func() error { return os.Remove(file.Name()) },
+		"failed to remove temporary file",
+	)
 
 	currentDir, err := os.Getwd()
 	if err != nil {

--- a/driver/norma/diff.go
+++ b/driver/norma/diff.go
@@ -17,11 +17,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/0xsoniclabs/norma/analysis/report"
-	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/urfave/cli/v2"
 )
 
@@ -44,7 +44,7 @@ func diff(ctx *cli.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	defer caution.CloseAndReportError(&err, file, "failed to close temporary file")
+	defer func() { err = errors.Join(err, file.Close()) }()
 	for _, src := range args.Slice() {
 		content, err := os.ReadFile(src)
 		if err != nil {
@@ -58,11 +58,7 @@ func diff(ctx *cli.Context) (err error) {
 	if err := file.Close(); err != nil {
 		return err
 	}
-	defer caution.ExecuteAndReportError(
-		&err,
-		func() error { return os.Remove(file.Name()) },
-		"failed to remove temporary file",
-	)
+	defer func() { err = errors.Join(err, os.Remove(file.Name())) }()
 
 	currentDir, err := os.Getwd()
 	if err != nil {

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/0xsoniclabs/sonic/utils/caution"
 	"gopkg.in/yaml.v3"
 )
 
@@ -211,11 +212,11 @@ func ParseBytes(data []byte) (Scenario, error) {
 }
 
 // ParseFile parses the YAML encoded scenario in the given file.
-func ParseFile(path string) (Scenario, error) {
-	if reader, err := os.Open(path); err == nil {
-		defer reader.Close()
-		return Parse(reader)
-	} else {
+func ParseFile(path string) (scenario Scenario, err error) {
+	reader, err := os.Open(path)
+	if err != nil {
 		return Scenario{}, err
 	}
+	defer caution.CloseAndReportError(&err, reader, "failed to close scenario file")
+	return Parse(reader)
 }

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -18,11 +18,11 @@ package parser
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"time"
 
-	"github.com/0xsoniclabs/sonic/utils/caution"
 	"gopkg.in/yaml.v3"
 )
 
@@ -217,6 +217,6 @@ func ParseFile(path string) (scenario Scenario, err error) {
 	if err != nil {
 		return Scenario{}, err
 	}
-	defer caution.CloseAndReportError(&err, reader, "failed to close scenario file")
+	defer func() { err = errors.Join(err, reader.Close()) }()
 	return Parse(reader)
 }


### PR DESCRIPTION
This PR contributes to https://github.com/0xsoniclabs/sonic-admin/issues/787

This PR is part of a series of cleanup PRs to prepare norma for golangci linter.

In this PR the error in defer calls with `.Close()` or `os.Remove(...)` are handled.