### PR TITLE
Handle errors

### DIFF
--- a/driver/executor/clock_test.go
+++ b/driver/executor/clock_test.go
@@ -53,7 +53,9 @@ func TestClock_SleepSkipsTimeAccurately(t *testing.T) {
 			clock := test.clock
 			start := clock.Now()
 			time := Seconds(0.5)
-			clock.SleepUntil(time)
+			if err := clock.SleepUntil(time); err != nil {
+				t.Fatalf("sleep failed: %v", err)
+			}
 			end := clock.Now()
 
 			offset := end - (start + time)

--- a/driver/monitoring/app/app_source.go
+++ b/driver/monitoring/app/app_source.go
@@ -88,6 +88,6 @@ func (s *periodicAppDataSource[T]) AfterApplicationCreation(app driver.Applicati
 		return
 	}
 	if err = s.AddSubject(mon.App(label), sensor); err != nil {
-		log.Fatalf("failed to add sensor for metric %v / app %s: %v", s.GetMetric().Name, label, err)
+		log.Printf("failed to add sensor for metric %v / app %s: %v", s.GetMetric().Name, label, err)
 	}
 }

--- a/driver/monitoring/app/app_source.go
+++ b/driver/monitoring/app/app_source.go
@@ -87,5 +87,7 @@ func (s *periodicAppDataSource[T]) AfterApplicationCreation(app driver.Applicati
 			"error", err)
 		return
 	}
-	s.AddSubject(mon.App(label), sensor)
+	if err = s.AddSubject(mon.App(label), sensor); err != nil {
+		log.Fatalf("failed to add sensor for metric %v / app %s: %v", s.GetMetric().Name, label, err)
+	}
 }

--- a/driver/monitoring/app/app_source.go
+++ b/driver/monitoring/app/app_source.go
@@ -88,6 +88,9 @@ func (s *periodicAppDataSource[T]) AfterApplicationCreation(app driver.Applicati
 		return
 	}
 	if err = s.AddSubject(mon.App(label), sensor); err != nil {
-		log.Printf("failed to add sensor for metric %v / app %s: %v", s.GetMetric().Name, label, err)
+		slog.Error("failed to add sensor for metric",
+			"metric", s.GetMetric().Name,
+			"app", label,
+			"error", err)
 	}
 }

--- a/driver/monitoring/monitor_test.go
+++ b/driver/monitoring/monitor_test.go
@@ -79,7 +79,9 @@ func TestMonitor_RegisterAndRetrievalOfDataWorks(t *testing.T) {
 		TestNodeMetric,
 		func(*Monitor) Source[Node, Series[BlockNumber, int]] { return &source },
 	}
-	InstallSource[Node, Series[BlockNumber, int]](monitor, factory)
+	if err = InstallSource[Node, Series[BlockNumber, int]](monitor, factory); err != nil {
+		t.Fatalf("failed to install source: %v", err)
+	}
 
 	if !IsSupported(monitor, metric) {
 		t.Errorf("registered metric is not supported")
@@ -126,7 +128,10 @@ func TestMonitor_CsvExport(t *testing.T) {
 	content, _ := os.ReadFile(monitor.GetMeasurementFileName())
 
 	buffer := new(bytes.Buffer)
-	WriteCsvHeader(buffer)
+	err = WriteCsvHeader(buffer)
+	if err != nil {
+		t.Fatalf("failed to write csv header: %v", err)
+	}
 	if got, want := string(content), buffer.String(); got != want {
 		t.Errorf("unexpected export: %v != %v", got, want)
 	}

--- a/driver/monitoring/monitor_test.go
+++ b/driver/monitoring/monitor_test.go
@@ -80,7 +80,7 @@ func TestMonitor_RegisterAndRetrievalOfDataWorks(t *testing.T) {
 		func(*Monitor) Source[Node, Series[BlockNumber, int]] { return &source },
 	}
 	if err = InstallSource[Node, Series[BlockNumber, int]](monitor, factory); err != nil {
-		t.Fatalf("failed to install source: %v", err)
+		t.Errorf("failed to install source: %v", err)
 	}
 
 	if !IsSupported(monitor, metric) {

--- a/driver/monitoring/network/num_nodes.go
+++ b/driver/monitoring/network/num_nodes.go
@@ -18,6 +18,7 @@ package netmon
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	mon "github.com/0xsoniclabs/norma/driver/monitoring"
@@ -72,7 +73,9 @@ func newNumNodesSource(monitor *mon.Monitor, period time.Duration) mon.Source[mo
 			select {
 			case now := <-ticker.C:
 				numNodes := len(monitor.Network().GetActiveNodes())
-				res.data.Append(mon.NewTime(now), numNodes)
+				if err := res.data.Append(mon.NewTime(now), numNodes); err != nil {
+					log.Printf("failed to append number of nodes data: %v", err)
+				}
 			case <-stop:
 				return
 			}

--- a/driver/monitoring/network/num_nodes.go
+++ b/driver/monitoring/network/num_nodes.go
@@ -18,7 +18,7 @@ package netmon
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	mon "github.com/0xsoniclabs/norma/driver/monitoring"
@@ -74,7 +74,9 @@ func newNumNodesSource(monitor *mon.Monitor, period time.Duration) mon.Source[mo
 			case now := <-ticker.C:
 				numNodes := len(monitor.Network().GetActiveNodes())
 				if err := res.data.Append(mon.NewTime(now), numNodes); err != nil {
-					log.Printf("failed to append number of nodes data: %v", err)
+					slog.Error("failed to append number of nodes data",
+						"metric", NumberOfNodes.Name,
+						"error", err)
 				}
 			case <-stop:
 				return

--- a/driver/monitoring/network/num_nodes_test.go
+++ b/driver/monitoring/network/num_nodes_test.go
@@ -57,7 +57,9 @@ func TestNumNodeRetrievesNodeCount(t *testing.T) {
 	source := newNumNodesSource(monitor, 50*time.Millisecond)
 
 	time.Sleep(200 * time.Millisecond)
-	source.Shutdown()
+	if err := source.Shutdown(); err != nil {
+		t.Errorf("failed to shutdown source: %v", err)
+	}
 
 	series, exists := source.GetData(monitoring.Network{})
 	if series == nil || !exists {

--- a/driver/monitoring/network/num_nodes_test.go
+++ b/driver/monitoring/network/num_nodes_test.go
@@ -58,7 +58,7 @@ func TestNumNodeRetrievesNodeCount(t *testing.T) {
 
 	time.Sleep(200 * time.Millisecond)
 	if err := source.Shutdown(); err != nil {
-		t.Errorf("failed to shutdown source: %v", err)
+		t.Fatalf("failed to shutdown source: %v", err)
 	}
 
 	series, exists := source.GetData(monitoring.Network{})

--- a/driver/monitoring/node/block_progress_test.go
+++ b/driver/monitoring/node/block_progress_test.go
@@ -186,7 +186,9 @@ func StartTestRpcServer() (*TestRpcServer, error) {
 }
 
 func (s *TestRpcServer) Shutdown() {
-	s.server.Shutdown(context.Background())
+	if err := s.server.Shutdown(context.Background()); err != nil {
+		fmt.Printf("failed to shutdown test RPC server: %v\n", err)
+	}
 	<-s.done
 }
 
@@ -204,5 +206,5 @@ func getBlockHeight(w http.ResponseWriter, r *http.Request) {
 			"number": "0x12"
 		}
 	}`
-	io.WriteString(w, response)
+	_, _ = io.WriteString(w, response)
 }

--- a/driver/monitoring/node/node_source.go
+++ b/driver/monitoring/node/node_source.go
@@ -79,14 +79,20 @@ func (s *periodicNodeDataSource[T]) AfterNodeCreation(node driver.Node) {
 			"error", err)
 	}
 	if err := s.AddSubject(mon.Node(label), sensor); err != nil {
-		log.Printf("failed to add subject for metric %v / node %s: %v", s.GetMetric().Name, label, err)
+		slog.Error("failed to add subject for metric",
+			"metric", s.GetMetric().Name,
+			"node", label,
+			"error", err)
 	}
 }
 
 func (s *periodicNodeDataSource[T]) BeforeNodeRemoval(node driver.Node) {
 	label := node.GetLabel()
 	if err := s.RemoveSubject(mon.Node(label)); err != nil {
-		log.Printf("failed to remove subject for metric %v / node %s: %v", s.GetMetric().Name, label, err)
+		slog.Error("failed to remove subject for metric",
+			"metric", s.GetMetric().Name,
+			"node", label,
+			"error", err)
 	}
 }
 

--- a/driver/monitoring/node/node_source.go
+++ b/driver/monitoring/node/node_source.go
@@ -78,12 +78,16 @@ func (s *periodicNodeDataSource[T]) AfterNodeCreation(node driver.Node) {
 			"node", label,
 			"error", err)
 	}
-	s.AddSubject(mon.Node(label), sensor)
+	if err := s.AddSubject(mon.Node(label), sensor); err != nil {
+		log.Printf("failed to add subject for metric %v / node %s: %v", s.GetMetric().Name, label, err)
+	}
 }
 
 func (s *periodicNodeDataSource[T]) BeforeNodeRemoval(node driver.Node) {
 	label := node.GetLabel()
-	s.RemoveSubject(mon.Node(label))
+	if err := s.RemoveSubject(mon.Node(label)); err != nil {
+		log.Printf("failed to remove subject for metric %v / node %s: %v", s.GetMetric().Name, label, err)
+	}
 }
 
 func (s *periodicNodeDataSource[T]) AfterApplicationCreation(driver.Application) {

--- a/driver/monitoring/user/user_source.go
+++ b/driver/monitoring/user/user_source.go
@@ -89,9 +89,13 @@ func (s *periodicUserDataSource[T]) AfterApplicationCreation(app driver.Applicat
 				"error", err)
 			return
 		}
-		s.AddSubject(mon.User{
+		err = s.AddSubject(mon.User{
 			App: label,
 			Id:  i,
 		}, sensor)
+		if err != nil {
+			log.Printf("failed to add subject for metric %v / app %s / user %d: %v", s.GetMetric().Name, label, i, err)
+			return
+		}
 	}
 }

--- a/driver/monitoring/user/user_source.go
+++ b/driver/monitoring/user/user_source.go
@@ -94,7 +94,11 @@ func (s *periodicUserDataSource[T]) AfterApplicationCreation(app driver.Applicat
 			Id:  i,
 		}, sensor)
 		if err != nil {
-			log.Printf("failed to add subject for metric %v / app %s / user %d: %v", s.GetMetric().Name, label, i, err)
+			slog.Error("failed to add subject for metric",
+				"metric", s.GetMetric().Name,
+				"app", label,
+				"user", i,
+				"error", err)
 			return
 		}
 	}

--- a/driver/network/service_test.go
+++ b/driver/network/service_test.go
@@ -32,7 +32,9 @@ func TestGetFreePort(t *testing.T) {
 	if err != nil {
 		t.Errorf("provided port %d is not free", port)
 	}
-	listener.Close()
+	if err := listener.Close(); err != nil {
+		t.Errorf("failed to close listener: %v", err)
+	}
 }
 
 func TestGetFreePorts(t *testing.T) {

--- a/load/controller/controller_test.go
+++ b/load/controller/controller_test.go
@@ -98,7 +98,9 @@ func TestLoadGeneration_CanRealizeConstantTrafficShape(t *testing.T) {
 			done := make(chan bool)
 			go func() {
 				defer close(done)
-				controller.Run(ctx)
+				if err := controller.Run(ctx); err != nil {
+					t.Errorf("failed to run controller: %v", err)
+				}
 			}()
 
 			time.Sleep(time.Second)

--- a/load/controller/rpc_test.go
+++ b/load/controller/rpc_test.go
@@ -37,7 +37,11 @@ func TestTrafficGenerating(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
-	t.Cleanup(func() { net.Shutdown() })
+	t.Cleanup(func() {
+		if err := net.Shutdown(); err != nil {
+			t.Fatalf("failed to shut down network: %v", err)
+		}
+	})
 
 	primaryAccount, err := app.NewAccount(0, PrivateKey, FakeNetworkID)
 	if err != nil {


### PR DESCRIPTION
This PR contributes to https://github.com/0xsoniclabs/sonic-admin/issues/787

This PR is part of a series of cleanup PRs to prepare norma for golangci linter.

In this PR unhandled errors returned from different functions are returned. 
Those in tests are handled with `t.Error` or `t.Fatal`, while those outside are passed to a log.