### PR TITLE
Add optional NonRoot docker runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build make genesistools
 #
 FROM debian:trixie
 
+WORKDIR /sonic-client
+
 RUN apt-get update && \
     apt-get install iproute2 iputils-ping -y
 
@@ -84,5 +86,7 @@ COPY scripts/run_sonic.sh ./run_sonic.sh
 RUN ./sonictool --version
 RUN ./sonicd version
 
+# in case this docker runs with a non-root user, we need to make the binaries and datadir writable
+RUN chmod 777 /sonic-client
 
 CMD ["./run_sonic.sh"]

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -80,6 +80,7 @@ type ContainerConfig struct {
 	Entrypoint      []string // Entrypoint to run when starting the container. Optional.
 	Network         *Network // Docker network to join, nil to join bridge network
 	DataDirBinding  *string  // mount client datadir to this path on host
+	NonRootUser     bool
 }
 
 // NewClient creates a new client facilitating the creation of Docker
@@ -162,7 +163,8 @@ func (c *Client) Start(config *ContainerConfig) (*Container, error) {
 
 	init := true
 	stopTimeout := int(config.ShutdownTimeout.Seconds())
-	resp, err := c.cli.ContainerCreate(context.Background(), &container.Config{
+
+	containerConfig := container.Config{
 		Image:      config.ImageName,
 		Tty:        false,
 		Env:        envVars,
@@ -171,12 +173,20 @@ func (c *Client) Start(config *ContainerConfig) (*Container, error) {
 			objectsLabel: "true",
 		},
 		StopTimeout: &stopTimeout,
-	}, &container.HostConfig{
-		PortBindings: portMapping,
-		Init:         &init,
-		CapAdd:       []string{"NET_ADMIN"},
-		Binds:        binds,
-	}, nil, nil, "")
+	}
+	if config.NonRootUser {
+		containerConfig.User = fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
+	}
+
+	resp, err := c.cli.ContainerCreate(
+		context.Background(),
+		&containerConfig,
+		&container.HostConfig{
+			PortBindings: portMapping,
+			Init:         &init,
+			CapAdd:       []string{"NET_ADMIN"},
+			Binds:        binds,
+		}, nil, nil, "")
 	if err != nil {
 		return nil, err
 	}

--- a/driver/network.go
+++ b/driver/network.go
@@ -122,6 +122,7 @@ type NodeConfig struct {
 	Image          string
 	DataVolume     *string
 	ExtraArguments string
+	NonRootUser    bool
 }
 
 type ApplicationConfig struct {

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -198,6 +198,7 @@ func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error
 			NetworkConfig:  &n.config,
 			ValidatorId:    config.ValidatorId,
 			ExtraArguments: config.ExtraArguments,
+			NonRootUser:    config.NonRootUser,
 		})
 		if err != nil {
 			return nil, err
@@ -218,6 +219,7 @@ func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error
 		ValidatorId:    config.ValidatorId,
 		MountDataDir:   datadir,
 		ExtraArguments: config.ExtraArguments,
+		NonRootUser:    config.NonRootUser,
 	})
 }
 

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -724,13 +724,11 @@ func TestLocalNetwork_MountDataDir_Can_Be_Reused(t *testing.T) {
 	// jenkins uses different access privileges for docker
 	// i.e. we need to create a temporary directory in /tmp for docker mount
 	// as the test cleanup cannot delete the directory if the mount is in the subdirectory of this test.
-	temp, err := os.MkdirTemp("/tmp", fmt.Sprintf("%s-docker-volume-*", t.Name()))
+	tmp := t.TempDir()
+	temp, err := os.MkdirTemp(tmp, fmt.Sprintf("%s-docker-volume-*", t.Name()))
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %v", err)
 	}
-	defer func() {
-		os.RemoveAll(temp)
-	}()
 
 	config := driver.NetworkConfig{Validators: driver.DefaultValidators, OutputDir: temp}
 	net, err := NewLocalNetwork(t.Context(), &config)
@@ -745,9 +743,10 @@ func TestLocalNetwork_MountDataDir_Can_Be_Reused(t *testing.T) {
 
 	dataVolume := "abcd"
 	node, err := net.CreateNode(&driver.NodeConfig{
-		Name:       "node",
-		DataVolume: &dataVolume,
-		Image:      driver.DefaultClientDockerImageName,
+		Name:        "node",
+		DataVolume:  &dataVolume,
+		Image:       driver.DefaultClientDockerImageName,
+		NonRootUser: true,
 	})
 	if err != nil {
 		t.Fatalf("failed to create node: %v", err)
@@ -776,6 +775,13 @@ func TestLocalNetwork_MountDataDir_Can_Be_Reused(t *testing.T) {
 	if prevModTime == nil {
 		t.Fatalf("directory does not contain database files: %v", prevVisitedDirs)
 	}
+	if !slices.ContainsFunc(
+		prevVisitedDirs,
+		func(s string) bool { return strings.Contains(s, temp) }) {
+		t.Errorf(
+			"expected at least one visited directory to contain %s, but visited %v",
+			temp, prevVisitedDirs)
+	}
 
 	// stop the node
 	if err := net.RemoveNode(node); err != nil {
@@ -790,23 +796,29 @@ func TestLocalNetwork_MountDataDir_Can_Be_Reused(t *testing.T) {
 
 	// re-run another node on the same data volume
 	if _, err := net.CreateNode(&driver.NodeConfig{
-		Name:       "node2",
-		DataVolume: &dataVolume,
-		Image:      driver.DefaultClientDockerImageName,
+		Name:        "node2",
+		DataVolume:  &dataVolume,
+		Image:       driver.DefaultClientDockerImageName,
+		NonRootUser: true,
 	}); err != nil {
 		t.Fatalf("failed to create node: %v", err)
 	}
 
 	// the database lock should have been updated
 	currModTime, currVisitedDirs, err := getModificationTime()
+
 	if err != nil {
 		t.Fatalf("failed to get modification time: %v", err)
 	}
 	if got, want := *currModTime, *prevModTime; got.Equal(want) {
 		t.Errorf("got modification time %v, wanted modification time %v", got, want)
 	}
-	if got, want := currVisitedDirs, prevVisitedDirs; !slices.Equal(got, want) {
-		t.Errorf("got visited dirs %v, wanted visited dirs %v", got, want)
+	if !slices.ContainsFunc(
+		currVisitedDirs,
+		func(s string) bool { return strings.Contains(s, temp) }) {
+		t.Errorf(
+			"expected at least one visited directory to contain %s, but visited %v",
+			temp, currVisitedDirs)
 	}
 
 }

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -96,6 +96,8 @@ type OperaNodeConfig struct {
 	MountDataDir *string
 	// ExtraArguments are additional command line arguments to pass to the node.
 	ExtraArguments string
+	// NonRootUser indicates whether the node should run as a non-root user.
+	NonRootUser bool
 }
 
 // labelPattern restricts labels for nodes to non-empty alpha-numerical strings
@@ -146,7 +148,10 @@ func StartOperaDockerNode(ctx context.Context, client *docker.Client, dn *docker
 			"EXTRA_ARGUMENTS":   config.ExtraArguments,
 		}
 
-		const dataDir = "/datadir"
+		// in case the docker runs with a non-root user, the datadir needs
+		// to be in a location where the user has write permissions.
+		// chosen path is workdir of Dockerfile
+		const dataDir = "/sonic-client/datadir"
 		envs["STATE_DB_DATADIR"] = dataDir
 
 		// when configured, mount the datadir to the host
@@ -169,6 +174,7 @@ func StartOperaDockerNode(ctx context.Context, client *docker.Client, dn *docker
 			Environment:     envs,
 			Network:         dn,
 			DataDirBinding:  dataDirBinding,
+			NonRootUser:     config.NonRootUser,
 		})
 	})
 

--- a/scripts/run_sonic.sh
+++ b/scripts/run_sonic.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail # fail if anything fails
 
-echo "Sonic binary checksum: $(sha256sum   /sonicd | cut -d ' ' -f 1 )"
+echo "Sonic binary checksum: $(sha256sum   ./sonicd | cut -d ' ' -f 1 )"
 
 # Get the local node's IP, waiting for the network interface to be ready.
 until external_ip=$(hostname -I | awk '{print $1}') && [[ -n "$external_ip" ]]; do
@@ -18,8 +18,7 @@ echo "genesis validator count=${VALIDATORS_COUNT}"
 datadir=$STATE_DB_DATADIR
 # Initialize datadir
 if [[ ! -d "${datadir}/chaindata" ]]; then
-  mkdir -p "${datadir}"
-  ./sonictool --datadir "${datadir}" genesis json --experimental /genesis.json
+  ./sonictool --datadir "${datadir}" genesis json --experimental ./genesis.json
 fi
 
 ##


### PR DESCRIPTION
**The Problem**
	Docker by default runs containers as root user. The test [`TestLocalNetwork_MountDataDir_Can_Be_Reused`](https://github.com/0xsoniclabs/norma/blob/main/driver/network/local/local_test.go#L721) runs the following steps which produce the test to fail:

	- The host runner creates a temporary directory owned by the non-root host user.
	- The directory is bind-mounted into the container.
	- The containerized process writes files into this mount point. Because the container runs as root,
	   these files inherit root:root ownership.
	- When the test finishes, the host runner attempts to delete the temporary directory but fails with 
	   a Permission Denied error because it does not have privileges to remove root-owned files.


**The Solution**
	Run the docker using the user id and user group that is currently running the tests so that the files created inside the container are created with the same user that running the tests and can delete the temp folder at the end of the test.

**Implementation Details & Adjustments**
   - Write Permissions in Container Filesystem: Running the image as a non-root user means that all of the file/folder creations that were done in `/` now need to be done somewhere else where the non-root user has writing permission.
   - Network Simulation: Some tests need to simulate network latency, and do so by using the `tc` command. This commands needs to run as root by its very nature, so all tests cannot run with docker as a non-root user. Hence a config option is added to `ContainerConfig`, `NodeConfig` and `operaNodeCondfig`, so that the tests can specify which containers need to run as current user.
