### PR TITLE
Prioritize system intervetion transactions

### DIFF
--- a/driver/network/epoch.go
+++ b/driver/network/epoch.go
@@ -36,6 +36,7 @@ func AdvanceEpoch(client rpc.Client, epochIncrement int) error {
 	// Use Fake ID for the network
 	// Driver owner is the first validator from the list i.e., index 1 (defined in genesis export in genesis.GenerateJsonGenesis)
 	txOpts, err := bind.NewKeyedTransactorWithChainID(evmcore.FakeKey(1), big.NewInt(int64(originalRules.NetworkID)))
+	txOpts.GasTipCap = big.NewInt(100) // tip shall facilitate emission of the transaction, bypassing other pooled txs
 	if err != nil {
 		return fmt.Errorf("failed to create txOpts; %v", err)
 	}

--- a/driver/network/epoch_test.go
+++ b/driver/network/epoch_test.go
@@ -35,7 +35,6 @@ func TestAdvanceEpoch_Success(t *testing.T) {
 	)
 
 	client.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).Return(&header, nil)
-	client.EXPECT().SuggestGasTipCap(gomock.Any()).Return(&baseFee, nil)
 	client.EXPECT().PendingCodeAt(gomock.Any(), gomock.Any()).Return(bytecode, nil)
 	client.EXPECT().EstimateGas(gomock.Any(), gomock.Any()).Return(uint64(123), nil)
 	client.EXPECT().PendingNonceAt(gomock.Any(), gomock.Any()).Return(uint64(0), nil)

--- a/driver/network/rules.go
+++ b/driver/network/rules.go
@@ -2,6 +2,8 @@ package network
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/0xsoniclabs/norma/genesistools/genesis"
 	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip/contract/driverauth100"
@@ -9,7 +11,6 @@ import (
 	"github.com/0xsoniclabs/sonic/opera/contracts/driverauth"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
-	"math/big"
 )
 
 // ApplyNetworkRules updates the network rules on the network.
@@ -29,6 +30,7 @@ func ApplyNetworkRules(backend ContractBackend, rules genesis.NetworkRules) erro
 	// Use Fake ID for the network
 	// Driver owner is the first validator from the list i.e., index 1 (defined in genesis export in genesis.GenerateJsonGenesis)
 	txOpts, err := bind.NewKeyedTransactorWithChainID(evmcore.FakeKey(1), big.NewInt(int64(originalRules.NetworkID)))
+	txOpts.GasTipCap = big.NewInt(100) // tip shall facilitate emission of the transaction, bypassing other pooled txs
 	if err != nil {
 		return fmt.Errorf("failed to create txOpts; %v", err)
 	}

--- a/driver/network/rules_test.go
+++ b/driver/network/rules_test.go
@@ -26,7 +26,6 @@ func TestApplyNetworkRules_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	backend := NewMockContractBackend(ctrl)
 	backend.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).Return(&header, nil)
-	backend.EXPECT().SuggestGasTipCap(gomock.Any()).Return(&baseFee, nil)
 	backend.EXPECT().PendingCodeAt(gomock.Any(), gomock.Any()).Return(bytecode, nil)
 	backend.EXPECT().EstimateGas(gomock.Any(), gomock.Any()).Return(uint64(123), nil)
 	backend.EXPECT().PendingNonceAt(gomock.Any(), gomock.Any()).Return(uint64(0), nil)

--- a/driver/network/validator.go
+++ b/driver/network/validator.go
@@ -34,6 +34,7 @@ func RegisterValidatorNode(backend ContractBackend) (int, error) {
 
 	privateKeyECDSA := evmcore.FakeKey(uint32(newValId))
 	txOpts, err := bind.NewKeyedTransactorWithChainID(privateKeyECDSA, big.NewInt(int64(opera.FakeNetRules(opera.GetSonicUpgrades()).NetworkID)))
+	txOpts.GasTipCap = big.NewInt(100) // tip shall facilitate emission of the transaction, bypassing other pooled txs
 	if err != nil {
 		return 0, fmt.Errorf("failed to create txOpts; %v", err)
 	}
@@ -78,6 +79,7 @@ func UnregisterValidatorNode(client rpc.Client, validatorId int) error {
 
 	key := evmcore.FakeKey(uint32(validatorId))
 	txOpts, err := bind.NewKeyedTransactorWithChainID(key, big.NewInt(int64(opera.FakeNetRules(opera.GetSonicUpgrades()).NetworkID)))
+	txOpts.GasTipCap = big.NewInt(100) // tip shall facilitate emission of the transaction, bypassing other pooled txs
 	if err != nil {
 		return fmt.Errorf("failed to create txOpts; %v", err)
 	}

--- a/driver/network/validator_test.go
+++ b/driver/network/validator_test.go
@@ -2,12 +2,13 @@ package network
 
 import (
 	"fmt"
+	"math/big"
+	"testing"
+
 	"github.com/0xsoniclabs/sonic/gossip/contract/sfc100"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/core/types"
 	"go.uber.org/mock/gomock"
-	"math/big"
-	"testing"
 )
 
 func TestRegisterValidatorNode_Success(t *testing.T) {
@@ -80,7 +81,6 @@ func mockBackendForCreateValidator(t *testing.T, test func(backend *MockContract
 
 	backend.EXPECT().CallContract(gomock.Any(), gomock.Any(), gomock.Any()).Return(lastValIdPacked, nil)
 	backend.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).Return(&header, nil)
-	backend.EXPECT().SuggestGasTipCap(gomock.Any()).Return(&baseFee, nil)
 	backend.EXPECT().PendingCodeAt(gomock.Any(), gomock.Any()).Return(bytecode, nil)
 	backend.EXPECT().EstimateGas(gomock.Any(), gomock.Any()).Return(uint64(123), nil)
 	backend.EXPECT().PendingNonceAt(gomock.Any(), gomock.Any()).Return(uint64(0), nil)


### PR DESCRIPTION
This PR uses tips to improve the turn around of important transactions related to the scenario behavior. 
transactions modifying the validators set, the rules or advancing epochs are tipped to be able to overtake background load transactions. 

**Background**

Norma exhibits flaky behavior, lately this error happen:
https://scala.fantom.network/job/Norma/job/run-single-scenario/4592/

```
12:16:12  [32mINFO [0m[06-08|10:16:11.556] "Nodes: 2, epc/blk heights: [50/306 50/306], tx/s: [0.47114253 0.47214353], txs: 2, gas: 422902, blk processing: [898.275µs 832.933µs]"
12:16:12  [32mINFO [0m[06-08|10:16:12.556] "Nodes: 2, epc/blk heights: [50/306 50/306], tx/s: [0.47114253 0.47214353], txs: 2, gas: 422902, blk processing: [898.275µs 832.933µs]"
12:16:13  [32mINFO [0m[06-08|10:16:13.556] "Nodes: 2, epc/blk heights: [50/306 50/306], tx/s: [0 0], txs: 0, gas: 0, blk processing: [259.624µs 127.258µs]"
12:16:14  [31mERROR[0m[06-08|10:16:13.671] event execution failed                   [31mtime[0m=784.3 [31mname[0m="Advancing Epoch by 2"          [31mevent_time[0m=181.0 [31merror[0m="failed to get receipt; failed to get transaction receipt: timeout" [31mduration[0m=10m3.341s
12:16:14  Shutting down Prometheus ...
12:16:17  Shutting down data monitor ...
12:16:17  [32mINFO [0m[06-08|10:16:17.618] closing prometheus log parser
12:16:17  [32mINFO [0m[06-08|10:16:17.618] prometheus log parser closed
12:16:18  Monitoring data was written to /mnt/tmp-disk/norma-runs/norma_data_run-node_update_reuse_db_2073248698
12:16:18  Raw data was exported to /mnt/tmp-disk/norma-runs/norma_data_run-node_update_reuse_db_2073248698/measurements.csv
12:16:18  Rendering summary report (may take a few minutes the first time if R packages need to be installed) ...
```

The error is a timeout of the advance epoch transaction introduced at the end of the scenario execution, there is no good reason for this transaction not to be executable, but if the pool is full after attempting to run many transactions, this special transaction can get arbitrarily delayed. 
