### PR TITLE
Fix reusable mount test.

### DIFF
--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -724,15 +724,7 @@ func TestLocalNetwork_MountDataDir_Can_Be_Reused(t *testing.T) {
 	// jenkins uses different access privileges for docker
 	// i.e. we need to create a temporary directory in /tmp for docker mount
 	// as the test cleanup cannot delete the directory if the mount is in the subdirectory of this test.
-	temp, err := os.MkdirTemp("/tmp", fmt.Sprintf("%s-docker-volume-*", t.Name()))
-	if err != nil {
-		t.Fatalf("failed to create temporary directory: %v", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(temp); err != nil {
-			t.Fatalf("failed to remove temporary directory: %v", err)
-		}
-	}()
+	temp := t.TempDir()
 
 	config := driver.NetworkConfig{Validators: driver.DefaultValidators, OutputDir: temp}
 	net, err := NewLocalNetwork(t.Context(), &config)

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -729,7 +729,9 @@ func TestLocalNetwork_MountDataDir_Can_Be_Reused(t *testing.T) {
 		t.Fatalf("failed to create temporary directory: %v", err)
 	}
 	defer func() {
-		os.RemoveAll(temp)
+		if err := os.RemoveAll(temp); err != nil {
+			t.Fatalf("failed to remove temporary directory: %v", err)
+		}
 	}()
 
 	config := driver.NetworkConfig{Validators: driver.DefaultValidators, OutputDir: temp}
@@ -776,6 +778,13 @@ func TestLocalNetwork_MountDataDir_Can_Be_Reused(t *testing.T) {
 	if prevModTime == nil {
 		t.Fatalf("directory does not contain database files: %v", prevVisitedDirs)
 	}
+	if !slices.ContainsFunc(
+		prevVisitedDirs,
+		func(s string) bool { return strings.Contains(s, temp) }) {
+		t.Errorf(
+			"expected at least one visited directory to contain %s, but visited %v",
+			temp, prevVisitedDirs)
+	}
 
 	// stop the node
 	if err := net.RemoveNode(node); err != nil {
@@ -805,8 +814,12 @@ func TestLocalNetwork_MountDataDir_Can_Be_Reused(t *testing.T) {
 	if got, want := *currModTime, *prevModTime; got.Equal(want) {
 		t.Errorf("got modification time %v, wanted modification time %v", got, want)
 	}
-	if got, want := currVisitedDirs, prevVisitedDirs; !slices.Equal(got, want) {
-		t.Errorf("got visited dirs %v, wanted visited dirs %v", got, want)
+	if !slices.ContainsFunc(
+		currVisitedDirs,
+		func(s string) bool { return strings.Contains(s, temp) }) {
+		t.Errorf(
+			"expected at least one visited directory to contain %s, but visited %v",
+			temp, currVisitedDirs)
 	}
 
 }

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -721,9 +721,6 @@ func TestLocalNetwork_FailingFlagPropagated(t *testing.T) {
 func TestLocalNetwork_MountDataDir_Can_Be_Reused(t *testing.T) {
 	t.Parallel()
 
-	// jenkins uses different access privileges for docker
-	// i.e. we need to create a temporary directory in /tmp for docker mount
-	// as the test cleanup cannot delete the directory if the mount is in the subdirectory of this test.
 	temp := t.TempDir()
 
 	config := driver.NetworkConfig{Validators: driver.DefaultValidators, OutputDir: temp}

--- a/scripts/run_sonic.sh
+++ b/scripts/run_sonic.sh
@@ -93,5 +93,5 @@ export GOMEMLIMIT="1GiB"
     --datadir.minfreedisk 0 \
     $EXTRA_ARGUMENTS
 
-
+# datadir folder needs be erasable by any user to enable cleanups.
 chmod -R 777 "${datadir}"

--- a/scripts/run_sonic.sh
+++ b/scripts/run_sonic.sh
@@ -93,3 +93,5 @@ export GOMEMLIMIT="1GiB"
     --datadir.minfreedisk 0 \
     $EXTRA_ARGUMENTS
 
+
+chmod -R 777 "${datadir}"

--- a/scripts/run_sonic.sh
+++ b/scripts/run_sonic.sh
@@ -93,5 +93,8 @@ export GOMEMLIMIT="1GiB"
     --datadir.minfreedisk 0 \
     $EXTRA_ARGUMENTS
 
-# datadir folder needs be erasable by any user to enable cleanups.
+# docker runs by default with root user, so any files or folders created by
+# it would not have permissions to be deleted by non-root users doing cleanup
+# once the test is done. So we change the  datadir folder permissions to enable
+# all users to run clean up.
 chmod -R 777 "${datadir}"


### PR DESCRIPTION
**The Problem**
Docker by default runs containers as root user. The test [TestLocalNetwork_MountDataDir_Can_Be_Reused](https://github.com/0xsoniclabs/norma/blob/main/driver/network/local/local_test.go#L721) runs the following steps which produce the test to fail:

- The host runner creates a temporary directory owned by the non-root host user.
- The directory is bind-mounted into the container.
- The containerized process writes files into this mount point. Because the container runs as root,
   these files inherit root:root ownership.
- When the test finishes, the host runner attempts to delete the temporary directory but fails with 
   a Permission Denied error because it does not have privileges to remove root-owned files.
   
**The Solution**
Give full permisions (`chmod -r 777`) to the `datadir` folder at the end of the `run_sonic.sh` scrip.
This does not change semantics for any tests and enables any test that wants to do its own cleanup or have a custom datadir to do so, without any extra steps.