### PR TITLE
Unify logger

### DIFF
--- a/driver/docker/docker_test.go
+++ b/driver/docker/docker_test.go
@@ -19,7 +19,6 @@ package docker
 import (
 	"bufio"
 	"io"
-	"log"
 	"os"
 	"strings"
 	"testing"
@@ -112,7 +111,7 @@ func TestContainer_SaveLogTo(t *testing.T) {
 
 	files, err := os.ReadDir(tmp)
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	var numOfFiles int

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -19,7 +19,6 @@ package executor
 import (
 	"context"
 	"fmt"
-	"log"
 	"log/slog"
 	"time"
 
@@ -71,7 +70,7 @@ func run(
 			scheduleAdvanceEpochEvents(scenario.Duration+1, 2, queue, network)
 			// Schedule default consistency checks 2 seconds after the scenario end (after the epoch sealing).
 			queue.add(toSingleEvent(Seconds(scenario.Duration+2), "consistency check", func() error {
-				log.Printf("Checking network consistency ...\n")
+				slog.Info("Checking network consistency ...")
 				return checks.Check()
 			}))
 		} else {
@@ -227,7 +226,7 @@ func (q *eventQueue) addAll(events []event) {
 func (q *eventQueue) getNext() event {
 	res, err := q.queue.Pop()
 	if err != nil {
-		log.Printf("Warning: event queue error encountered: %v", err)
+		slog.Warn("event queue error encountered", "warning", err)
 		return nil
 	}
 	return res.(event)

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -226,7 +226,7 @@ func (q *eventQueue) addAll(events []event) {
 func (q *eventQueue) getNext() event {
 	res, err := q.queue.Pop()
 	if err != nil {
-		slog.Warn("event queue error encountered", "warning", err)
+		slog.Warn("event queue error encountered", "error", err)
 		return nil
 	}
 	return res.(event)

--- a/driver/monitoring/app/app_source.go
+++ b/driver/monitoring/app/app_source.go
@@ -17,7 +17,7 @@
 package appmon
 
 import (
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/0xsoniclabs/norma/driver/monitoring/utils"
@@ -81,7 +81,10 @@ func (s *periodicAppDataSource[T]) AfterApplicationCreation(app driver.Applicati
 	label := app.Config().Name
 	sensor, err := s.factory.CreateSensor(app)
 	if err != nil {
-		log.Printf("failed to create sensor for metric %v / app %s: %v", s.GetMetric().Name, label, err)
+		slog.Error("failed to create sensor for metric",
+			"metric", s.GetMetric().Name,
+			"app", label,
+			"error", err)
 		return
 	}
 	s.AddSubject(mon.App(label), sensor)

--- a/driver/monitoring/logreader.go
+++ b/driver/monitoring/logreader.go
@@ -20,7 +20,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"regexp"
 	"strconv"
 	"strings"
@@ -45,7 +45,7 @@ func NewLogReader(reader io.Reader) <-chan Block {
 	go func() {
 		defer close(ch)
 		if err := readBlocks(reader, ch); err != nil {
-			log.Printf("error: %s", err)
+			slog.Error("error reading blocks", "error", err)
 		}
 	}()
 

--- a/driver/monitoring/network/block_metrics.go
+++ b/driver/monitoring/network/block_metrics.go
@@ -18,7 +18,7 @@ package netmon
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/0xsoniclabs/norma/driver/monitoring"
 	"github.com/0xsoniclabs/norma/driver/monitoring/utils"
@@ -154,7 +154,7 @@ func (s *BlockNetworkMetricSource[T]) Shutdown() error {
 func (s *BlockNetworkMetricSource[T]) OnBlock(_ monitoring.Node, block monitoring.Block) {
 	if block.Height > s.lastBlock {
 		if err := s.series.Append(monitoring.BlockNumber(block.Height), s.getBlockProperty(block)); err != nil {
-			log.Printf("error to add to the series: %s", err)
+			slog.Error("error to add to the series", "error", err)
 		}
 		s.lastBlock = block.Height
 	}

--- a/driver/monitoring/node/node_source.go
+++ b/driver/monitoring/node/node_source.go
@@ -17,7 +17,7 @@
 package nodemon
 
 import (
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/0xsoniclabs/norma/driver/monitoring/utils"
@@ -73,7 +73,10 @@ func (s *periodicNodeDataSource[T]) AfterNodeCreation(node driver.Node) {
 	label := node.GetLabel()
 	sensor, err := s.factory.CreateSensor(node)
 	if err != nil {
-		log.Printf("failed to create sensor for metric %v / node %s: %v", s.GetMetric().Name, label, err)
+		slog.Error("failed to create sensor for metric",
+			"metric", s.GetMetric().Name,
+			"node", label,
+			"error", err)
 	}
 	s.AddSubject(mon.Node(label), sensor)
 }

--- a/driver/monitoring/node/prom_log_source.go
+++ b/driver/monitoring/node/prom_log_source.go
@@ -18,7 +18,7 @@ package nodemon
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/0xsoniclabs/norma/driver/monitoring"
 	"github.com/0xsoniclabs/norma/driver/monitoring/utils"
@@ -83,7 +83,7 @@ func NewPromLogSource(monitor *monitoring.Monitor, prometheusMetric monitoring.P
 func (p *PromLogSource) OnLog(node monitoring.Node, time monitoring.Time, value float64) {
 	series := p.GetOrAddSubject(node)
 	if err := series.Append(time, value); err != nil {
-		log.Printf("cannot add to series: %s", err)
+		slog.Error("cannot add to series", "error", err)
 	}
 }
 

--- a/driver/monitoring/node/transactions_throughput.go
+++ b/driver/monitoring/node/transactions_throughput.go
@@ -18,7 +18,7 @@ package nodemon
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/0xsoniclabs/norma/driver/monitoring"
@@ -82,7 +82,7 @@ func (s *TransactionsThroughputSource) OnBlock(node monitoring.Node, block monit
 		txs := float64(block.Txs) * 1e9 / float64(timeDiff)
 		series := s.GetOrAddSubject(node)
 		if err := series.Append(monitoring.BlockNumber(block.Height), float32(txs)); err != nil {
-			log.Printf("error to add to the series: %s", err)
+			slog.Error("error to add to the series", "error", err)
 		}
 	}
 }

--- a/driver/monitoring/node_log_provider.go
+++ b/driver/monitoring/node_log_provider.go
@@ -19,7 +19,7 @@ package monitoring
 import (
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"sync"
 
@@ -117,7 +117,9 @@ func (n *NodeLogDispatcher) AfterNodeCreation(node driver.Node) {
 	// Start a goroutine parsing the log and dispatching block information.
 	logStream, err := node.StreamLog()
 	if err != nil {
-		log.Printf("failed to obtain logs of node, will not be able to track blocks: %v", err)
+		slog.Error(
+			"failed to obtain logs of node, will not be able to track blocks",
+			"error", err)
 		return // do not start dispatch on error
 	}
 	n.wg.Add(1)
@@ -153,27 +155,34 @@ func (n *NodeLogDispatcher) runLogCollector(node driver.Node) {
 	label := node.GetLabel()
 	in, err := node.StreamLog()
 	if err != nil {
-		log.Printf("failed to obtain logs of node %v, log is not captured: %v", label, err)
+		slog.Error("failed to obtain logs of node, log is not captured",
+			"node", label,
+			"error", err)
 		return
 	}
 	defer func() {
 		if err := in.Close(); err != nil {
-			log.Printf("failed to close log stream for node %v: %v", label, err)
+			slog.Error("failed to close log stream for node",
+				"node", label,
+				"error", err)
 		}
 	}()
 	file := n.logDir + "/" + label + ".log"
 	out, err := os.Create(file)
 	if err != nil {
-		log.Printf("failed to create log file %v for node %v, log is not captured: %v", file, label, err)
+		slog.Error("failed to create log file for node, log is not captured",
+			"file", file,
+			"node", label,
+			"error", err)
 		return
 	}
 	defer func() {
 		if err := out.Close(); err != nil {
-			log.Printf("failed to close log file for node %v: %v", label, err)
+			slog.Error("failed to close log file for node", "node", label, "error", err)
 		}
 	}()
 	_, err = io.Copy(out, in)
 	if err != nil {
-		log.Printf("failed to capture log for node %v: %v", label, err)
+		slog.Error("failed to capture log for node", "node", label, "error", err)
 	}
 }

--- a/driver/monitoring/prom_log_provider.go
+++ b/driver/monitoring/prom_log_provider.go
@@ -18,7 +18,7 @@ package monitoring
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -170,12 +170,12 @@ func (n *PrometheusLogDispatcher) Shutdown() {
 	if n.stopped {
 		return
 	}
-	log.Printf("closing prometheus log parser")
+	slog.Info("closing prometheus log parser")
 	n.stopped = true
 	n.ticker.Stop()
 	close(n.done)
 	n.wg.Wait()
-	log.Printf("prometheus log parser closed")
+	slog.Info("prometheus log parser closed")
 }
 
 func (n *PrometheusLogDispatcher) RegisterLogListener(key PrometheusLogKey, listener TimeLogListener) {
@@ -283,7 +283,7 @@ func (n *PrometheusLogDispatcher) startNodeLogsDispatch(nodeId Node, url *driver
 				n.nodesLock.Lock()
 				// report only errors occurred before shutdown
 				if _, exists := n.nodes[node]; exists {
-					log.Printf("monitoring: failed to parse log: %s", err)
+					slog.Error("monitoring: failed to parse log", "error", err)
 				}
 				n.nodesLock.Unlock()
 			}

--- a/driver/monitoring/prometheus/prometheus.go
+++ b/driver/monitoring/prometheus/prometheus.go
@@ -19,7 +19,7 @@ package prometheusmon
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -90,7 +90,7 @@ func Start(net driver.Network, dn *docker.Network) (*Prometheus, error) {
 		}
 		return err
 	}); err == nil {
-		log.Printf("started Prometheus on %s", prometheus.GetUrl())
+		slog.Info("started Prometheus", "url", prometheus.GetUrl())
 
 		// listen for new Nodes
 		net.RegisterListener(prometheus)
@@ -136,7 +136,9 @@ func (p *Prometheus) GetUrl() string {
 
 func (p *Prometheus) AfterNodeCreation(node driver.Node) {
 	if err := p.AddNode(node); err != nil {
-		log.Printf("failed to add node %s to Prometheus: %s", node.Hostname(), err)
+		slog.Error("failed to add node to Prometheus",
+			"node", node.Hostname(),
+			"error", err)
 	}
 }
 

--- a/driver/monitoring/sma_series.go
+++ b/driver/monitoring/sma_series.go
@@ -17,7 +17,7 @@
 package monitoring
 
 import (
-	"log"
+	"log/slog"
 
 	"golang.org/x/exp/constraints"
 )
@@ -78,7 +78,7 @@ func (s *SmaSeries[K, T]) calculate() {
 				avr := sum / count
 				s.endKey = point.Position
 				if err := s.output.Append(s.endKey, avr); err != nil {
-					log.Printf("err: %v", err)
+					slog.Error("failed to append SMA value", "error", err)
 				}
 			}
 		}

--- a/driver/monitoring/user/user_source.go
+++ b/driver/monitoring/user/user_source.go
@@ -17,7 +17,7 @@
 package user
 
 import (
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/0xsoniclabs/norma/driver/monitoring/utils"
@@ -82,7 +82,11 @@ func (s *periodicUserDataSource[T]) AfterApplicationCreation(app driver.Applicat
 	for i := 0; i < app.Config().Users; i++ {
 		sensor, err := s.factory.CreateSensor(app, i)
 		if err != nil {
-			log.Printf("failed to create sensor for metric %v / app %s / user %d: %v", s.GetMetric().Name, label, i, err)
+			slog.Error("failed to create sensor for metric",
+				"metric", s.GetMetric().Name,
+				"app", label,
+				"user", i,
+				"error", err)
 			return
 		}
 		s.AddSubject(mon.User{

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -310,7 +310,7 @@ func (a *localApplication) Start() error {
 		defer a.done.Done()
 		err := a.controller.Run(ctx)
 		if err != nil {
-			log.Printf("Failed to run load app: %v", err)
+			slog.Error("Failed to run load app", "error", err)
 		}
 	}()
 	return nil
@@ -321,9 +321,9 @@ func (a *localApplication) Stop() error {
 		a.cancel()
 	}
 	a.cancel = nil
-	log.Printf("waiting for application to stop: %s", a.name)
+	slog.Info("waiting for application to stop", "app", a.name)
 	a.done.Wait()
-	log.Printf("application has stopped: %s", a.name)
+	slog.Info("application has stopped", "app", a.name)
 	return nil
 }
 

--- a/driver/network/rpc/rpc_pool.go
+++ b/driver/network/rpc/rpc_pool.go
@@ -18,7 +18,7 @@ package rpc
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -80,11 +80,11 @@ func (p *RpcWorkerPool) Close() error {
 		return nil
 	}
 	p.cancel()
-	log.Printf("waiting for worker pool to close")
+	slog.Info("waiting for worker pool to close")
 	for _, wg := range p.workers {
 		wg.close()
 	}
-	log.Printf("worker pool has closed")
+	slog.Info("worker pool has closed")
 	close(p.txs)
 	return nil
 }
@@ -140,7 +140,7 @@ func newWorker(rpcUrl driver.URL, txs chan *types.Transaction) *worker {
 
 	go func() {
 		if err := w.runRpcSenderLoop(); err != nil {
-			log.Printf("failed to open RPC connection; %v", err)
+			slog.Error("failed to open RPC connection", "error", err)
 			return
 		}
 	}()
@@ -172,7 +172,7 @@ func (p *worker) runRpcSenderLoop() error {
 		case tx := <-p.txs:
 			err := rpcClient.SendTransaction(context.Background(), tx)
 			if err != nil {
-				log.Printf("failed to send tx; %v", err)
+				slog.Error("failed to send tx", "error", err)
 			}
 		case <-p.ctx.Done():
 			return nil

--- a/driver/network/service.go
+++ b/driver/network/service.go
@@ -19,7 +19,7 @@ package network
 import (
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"strconv"
 	"strings"
@@ -78,7 +78,7 @@ func GetFreePorts(num int) (ports []Port, err error) {
 		for i := 0; !found && i < 10; i++ {
 			listener, err := net.Listen("tcp", "")
 			if err != nil {
-				log.Printf("failed to create a new listening port")
+				slog.Error("failed to create a new listening port", "error", err)
 				continue
 			}
 			// make sure to close the listener in case of an error
@@ -87,21 +87,21 @@ func GetFreePorts(num int) (ports []Port, err error) {
 			port := listener.Addr().String()
 			columnPos := strings.LastIndex(port, ":")
 			if columnPos < 0 {
-				log.Printf("invalid port format: %s", port)
+				slog.Error("invalid port format", "port", port)
 				continue
 			}
 			port = port[columnPos+1:]
 
 			res, err := strconv.ParseUint(port, 10, 16)
 			if err != nil {
-				log.Printf("invalid port format: %s, err: %v", port, err)
+				slog.Error("invalid port format", "port", port, "error", err)
 				continue
 			}
 
 			// close the listener, if it fails, we will not be able to use the port,
 			// because it is bound
 			if err := listener.Close(); err != nil {
-				log.Printf("failed to close listener: %v", err)
+				slog.Error("failed to close listener", "error", err)
 				continue
 			}
 

--- a/driver/norma/progress.go
+++ b/driver/norma/progress.go
@@ -166,5 +166,11 @@ func getLastValAsString[K constraints.Ordered, T any](exists bool, series monito
 	if point == nil {
 		return "N/A"
 	}
+	// if the value is a duration less than a millisecond, format it in
+	// milliseconds with 3 decimal places, this is because printing mu for
+	// micro seconds messes with the logger.
+	if d, ok := any(point.Value).(time.Duration); ok && d < time.Millisecond {
+		return fmt.Sprintf("%.3fms", float64(d)/float64(time.Millisecond))
+	}
 	return fmt.Sprintf("%v", point.Value)
 }

--- a/driver/norma/progress.go
+++ b/driver/norma/progress.go
@@ -172,11 +172,5 @@ func getLastValAsString[K constraints.Ordered, T any](exists bool, series monito
 	if point == nil {
 		return "N/A"
 	}
-	// if the value is a duration less than a millisecond, format it in
-	// milliseconds with 3 decimal places, this is because printing mu for
-	// micro seconds messes with the logger.
-	if d, ok := any(point.Value).(time.Duration); ok && d < time.Millisecond {
-		return fmt.Sprintf("%.3fms", float64(d)/float64(time.Millisecond))
-	}
 	return fmt.Sprintf("%v", point.Value)
 }

--- a/driver/norma/progress.go
+++ b/driver/norma/progress.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"sort"
 	"sync"
 	"time"
@@ -98,7 +98,13 @@ func logState(monitor *monitoring.Monitor, nodes *activeNodes) {
 	gas := getGasUsed(monitor)
 	processingTimes := getBlockProcessingTimes(monitor, nodes)
 
-	log.Printf("Nodes: %s, epc/blk heights: %v, tx/s: %v, txs: %v, gas: %s, blk processing: %v", numNodes, blockStatuses, txPers, txs, gas, processingTimes)
+	slog.Info("State",
+		"Nodes", numNodes,
+		"epc/blk heights", blockStatuses,
+		"tx/s", txPers,
+		"txs", txs,
+		"gas", gas,
+		"blk processing", processingTimes)
 }
 
 func getNumNodes(monitor *monitoring.Monitor) string {

--- a/load/controller/controller.go
+++ b/load/controller/controller.go
@@ -19,7 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -46,12 +46,12 @@ func NewAppController(application app.Application, shaper shaper.Shaper, numUser
 	trigger := make(chan struct{}, 100)
 
 	// create users for this application
-	log.Printf("starting initialization of %d users\n", numUsers)
+	slog.Info("starting initialization of users", "numUsers", numUsers)
 	users, err := application.CreateUsers(context, numUsers)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create users for app; %v", err)
 	}
-	log.Printf("completed initialization of %d users\n", numUsers)
+	slog.Info("completed initialization of users", "numUsers", numUsers)
 
 	return &AppController{
 		shaper:      shaper,

--- a/load/controller/controller.go
+++ b/load/controller/controller.go
@@ -46,12 +46,12 @@ func NewAppController(application app.Application, shaper shaper.Shaper, numUser
 	trigger := make(chan struct{}, 100)
 
 	// create users for this application
-	slog.Info("starting initialization of users", "numUsers", numUsers)
+	slog.Info("starting initialization of users", "num_users", numUsers)
 	users, err := application.CreateUsers(context, numUsers)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create users for app; %v", err)
 	}
-	slog.Info("completed initialization of users", "numUsers", numUsers)
+	slog.Info("completed initialization of users", "num_users", numUsers)
 
 	return &AppController{
 		shaper:      shaper,

--- a/load/controller/generator.go
+++ b/load/controller/generator.go
@@ -17,7 +17,7 @@
 package controller
 
 import (
-	"log"
+	"log/slog"
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/load/app"
@@ -27,7 +27,7 @@ func runGeneratorLoop(user app.User, trigger <-chan struct{}, network driver.Net
 	for range trigger {
 		tx, err := user.GenerateTx()
 		if err != nil {
-			log.Printf("failed to generate tx; %v", err)
+			slog.Error("failed to generate tx", "error", err)
 		} else {
 			network.SendTransaction(tx)
 		}

--- a/load/shaper/auto.go
+++ b/load/shaper/auto.go
@@ -17,7 +17,7 @@
 package shaper
 
 import (
-	"log"
+	"log/slog"
 	"time"
 )
 
@@ -75,12 +75,14 @@ func (s *autoShaper) GetNumMessagesInInterval(start time.Time, duration time.Dur
 func getProcessingGap(info LoadInfoSource) uint64 {
 	sent, err := info.GetSentTransactions()
 	if err != nil {
-		log.Printf("autoShaper: failed to fetch number of sent transactions: %v", err)
+		slog.Error("autoShaper: failed to fetch number of sent transactions",
+			"error", err)
 		return 0
 	}
 	received, err := info.GetReceivedTransactions()
 	if err != nil {
-		log.Printf("autoShaper: failed to fetch number of received transactions: %v", err)
+		slog.Error("autoShaper: failed to fetch number of received transactions",
+			"error", err)
 		return 0
 	}
 	return sent - received


### PR DESCRIPTION
This PR fixes https://github.com/0xsoniclabs/sonic-admin/issues/788. 

This PR addresses logging inconsistencies across the codebase by unifying the logging library used and resolving a formatting issue where microsecond durations caused unexpected quotation marks to appear in logs.

- Unifies logger usage: Before some files used `slog` while others used `log`. This PR ensures all files use slog with the corresponding `Info`, `Warn` or `Error`.