### PR TITLE
Build docker images on demand.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,21 +18,12 @@ BUILD_DIR := $(CURDIR)/build
 
 .PHONY: all test clean
 
-# Define a list of client versions
-CLIENT_VERSIONS := \
-	v2.0 v2.0.0 v2.0.1 v2.0.2 v2.0.3 \
-	v2.1 v2.1.0 v2.1.1 v2.1.2 v2.1.6
-CLIENT_URL=https://github.com/0xsoniclabs/sonic.git
-
 all: \
     norma \
     pull-hello-world-image \
     pull-alpine-image \
     pull-prometheus-image \
-    build-r-renderer-image \
-    build-sonic-docker-image-main \
-    build-sonic-docker-image-local \
-    $(foreach version, $(CLIENT_VERSIONS), build-sonic-docker-image-$(version)) \
+	build-r-renderer-image
 
 pull-hello-world-image:
 	DOCKER_BUILDKIT=1 docker image pull hello-world
@@ -45,16 +36,6 @@ pull-prometheus-image:
 
 build-r-renderer-image:
 	DOCKER_BUILDKIT=1 docker build analysis/report/ -t norma-r-renderer
-
-build-sonic-docker-image-main:
-	DOCKER_BUILDKIT=1 docker build --build-context client-src=$(CLIENT_URL) . -t sonic
-
-build-sonic-docker-image-local:
-	DOCKER_BUILDKIT=1 docker build --build-context client-src=sonic . -t sonic:local
-
-# Build various client versions
-$(foreach version, $(CLIENT_VERSIONS), build-sonic-docker-image-$(version)):
-	DOCKER_BUILDKIT=1 docker build --build-context client-src=$(CLIENT_URL)\#$(subst build-sonic-docker-image-,,$@) . -t sonic:$(subst build-sonic-docker-image-,,$@)
 
 generate-abi: load/contracts/abi/Counter.abi load/contracts/abi/ERC20.abi load/contracts/abi/Store.abi load/contracts/abi/UniswapV2Pair.abi load/contracts/abi/UniswapRouter.abi load/contracts/abi/Helper.abi load/contracts/abi/SmartAccount.abi load/contracts/abi/EntryPoint.abi load/contracts/abi/TransientCounter.abi load/contracts/abi/SelfDestructOldContract.abi load/contracts/abi/SelfDestructNewContract.abi load/contracts/abi/EcdsaCounter.abi load/contracts/abi/LargeContract.abi load/contracts/abi/ProbabilisticFailing.abi # requires installed solc and Ethereum abigen - check README.md
 
@@ -122,9 +103,8 @@ generate-mocks: # requires installed mockgen
 norma:
 	go build -o $(BUILD_DIR)/norma ./driver/norma
 
-test: pull-hello-world-image pull-alpine-image pull-prometheus-image build-r-renderer-image build-sonic-docker-image-main
+test: pull-hello-world-image pull-alpine-image pull-prometheus-image build-r-renderer-image
 	go test ./... -v
 
 clean:
 	rm -rvf $(CURDIR)/build
-	docker image rm -f sonic sonic:local

--- a/driver/docker/images.go
+++ b/driver/docker/images.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/docker/docker/api/types/image"
 )
@@ -99,10 +100,10 @@ func EnsureImages(ctx context.Context, imageRefs []string, buildRoot string) err
 	if err != nil {
 		return err
 	}
-	slog.Info("Resolved build root", "path", buildRoot)
+	slog.Info("resolved build root", "path", buildRoot)
 
 	refs := deduplicateAndSort(imageRefs)
-	slog.Info("Checking images", "refs", refs)
+	slog.Info("checking images", "refs", refs)
 	cli, err := NewClient()
 	if err != nil {
 		return fmt.Errorf("failed to create docker client: %w", err)
@@ -114,20 +115,22 @@ func EnsureImages(ctx context.Context, imageRefs []string, buildRoot string) err
 	for _, ref := range refs {
 
 		plan := planImage(ref)
+		start := time.Now()
 		switch plan.kind {
 		case imageBuildSonicRemote, imageBuildSonicLocal:
-			slog.Info("Building image", "ref", ref, "clientSrc", plan.clientSrc)
+			slog.Info("building image", "ref", ref, "clientSrc", plan.clientSrc)
 			if err := buildImage(ctx, buildRoot, ref, plan.clientSrc); err != nil {
 				return err
 			}
 		case imageBuildNone:
-			slog.Info("Pulling image", "ref", ref)
+			slog.Info("pulling image", "ref", ref)
 			if err := pullImage(ctx, cli, ref); err != nil {
 				return err
 			}
 		default:
 			return fmt.Errorf("unsupported image plan for %q", ref)
 		}
+		slog.Info("image ready", "ref", ref, "took", time.Since(start))
 	}
 
 	return nil

--- a/driver/docker/images.go
+++ b/driver/docker/images.go
@@ -1,0 +1,264 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package docker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/docker/docker/api/types/image"
+)
+
+// sonicRepositoryURL is the canonical remote source used when building
+// non-local Sonic images on demand.
+const sonicRepositoryURL = "https://github.com/0xsoniclabs/sonic.git"
+
+// imageBuildKind describes how an image should be materialized when it is not
+// already available locally.
+type imageBuildKind int
+
+const (
+	// imageBuildNone means no local build strategy applies. In this case the
+	// image is obtained by pullImage.
+	imageBuildNone imageBuildKind = iota
+	// imageBuildSonicRemote means the image should be built from the remote
+	// Sonic repository URL (optionally pinned to a tag via #<tag>).
+	imageBuildSonicRemote
+	// imageBuildSonicLocal means the image should be built from local Sonic
+	// sources (the repository's "sonic" directory).
+	imageBuildSonicLocal
+)
+
+// imageBuildPlan captures the selected provisioning strategy for one image
+// reference.
+//
+// clientSrc is passed to docker build as the value of the "client-src" build
+// context expected by the repository Dockerfile.
+type imageBuildPlan struct {
+	kind      imageBuildKind
+	clientSrc string
+}
+
+// EnsureImages makes sure the given image refs are locally available.
+//
+// The function provides the runtime image provisioning path used by
+// scenario execution. It performs the following steps:
+//
+//  1. Normalize and deduplicate image references.
+//  2. Resolve the Norma build root (must contain Dockerfile and
+//     scripts/run_sonic.sh).
+//  3. For each image:
+//     - choose build or pull strategy via planImage;
+//     - build (Sonic-specific refs) or pull (all other refs).
+//
+// For Sonic image refs, it lazily builds from the project's Dockerfile:
+//   - sonic: from sonicRepositoryURL
+//   - sonic:local: from local ./sonic
+//   - sonic:<tag>: from sonicRepositoryURL#<tag>
+//   - sonic:<commit hash>: from sonicRepositoryURL#<commit hash>
+//
+// Other images are pulled if missing.
+//
+// The operation is idempotent with respect to already present tags, and relies
+// on Docker's own image/layer cache for repeated builds.
+func EnsureImages(ctx context.Context, imageRefs []string, buildRoot string) error {
+	if len(imageRefs) == 0 {
+		return nil
+	}
+	if buildRoot == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get working directory: %w", err)
+		}
+		buildRoot = cwd
+	}
+
+	buildRoot, err := resolveBuildRoot(buildRoot)
+	if err != nil {
+		return err
+	}
+	slog.Info("Resolved build root", "path", buildRoot)
+
+	refs := deduplicateAndSort(imageRefs)
+	slog.Info("Checking images", "refs", refs)
+	cli, err := NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create docker client: %w", err)
+	}
+	defer func() {
+		_ = cli.Close()
+	}()
+
+	for _, ref := range refs {
+
+		plan := planImage(ref)
+		switch plan.kind {
+		case imageBuildSonicRemote, imageBuildSonicLocal:
+			slog.Info("Building image", "ref", ref, "clientSrc", plan.clientSrc)
+			if err := buildImage(ctx, buildRoot, ref, plan.clientSrc); err != nil {
+				return err
+			}
+		case imageBuildNone:
+			slog.Info("Pulling image", "ref", ref)
+			if err := pullImage(ctx, cli, ref); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported image plan for %q", ref)
+		}
+	}
+
+	return nil
+}
+
+// pullImage pulls imageRef from the configured registry and consumes the entire
+// pull stream.
+//
+// Fully draining the stream ensures the pull operation completes and daemon
+// resources are released before returning.
+func pullImage(ctx context.Context, cli *Client, imageRef string) error {
+	reader, err := cli.cli.ImagePull(ctx, imageRef, image.PullOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to pull image %q: %w", imageRef, err)
+	}
+	defer func() {
+		_ = reader.Close()
+	}()
+
+	if _, err := io.Copy(io.Discard, reader); err != nil {
+		return fmt.Errorf("failed to read pull output for image %q: %w", imageRef, err)
+	}
+	return nil
+}
+
+// buildImage builds imageRef using the repository Dockerfile located under
+// buildRoot.
+//
+// The build passes "client-src=<clientSrc>" as an additional build context,
+// matching the Dockerfile convention used by Norma. BuildKit is enabled
+// explicitly via environment variable to keep behavior aligned with existing
+// developer workflows.
+//
+// On failure, the function returns the docker command error along with captured
+// combined stdout/stderr output to aid diagnostics.
+func buildImage(ctx context.Context, buildRoot, imageRef, clientSrc string) error {
+	args := []string{"build", "--build-context", fmt.Sprintf("client-src=%s", clientSrc), ".", "-t", imageRef}
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.Dir = buildRoot
+	cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to build image %q: %w\n%s", imageRef, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// planImage resolves imageRef into an internal build plan.
+//
+// Current mapping rules:
+//   - "sonic"       => remote build from sonicRepositoryURL
+//   - "sonic:local" => local build from "sonic"
+//   - "sonic:<tag>" => remote build from sonicRepositoryURL#<tag>
+//   - "sonic:<commit hash>" => remote build from sonicRepositoryURL#<commit hash>
+//   - everything else => no build strategy (pull)
+//
+// The returned plan is consumed by EnsureImages.
+func planImage(imageRef string) imageBuildPlan {
+	if imageRef == "sonic" {
+		return imageBuildPlan{kind: imageBuildSonicRemote, clientSrc: sonicRepositoryURL}
+	}
+	if imageRef == "sonic:local" {
+		return imageBuildPlan{kind: imageBuildSonicLocal, clientSrc: "sonic"}
+	}
+	if strings.HasPrefix(imageRef, "sonic:") {
+		tag := strings.TrimPrefix(imageRef, "sonic:")
+		if tag != "" {
+			return imageBuildPlan{
+				kind:      imageBuildSonicRemote,
+				clientSrc: fmt.Sprintf("%s#%s", sonicRepositoryURL, tag),
+			}
+		}
+	}
+	return imageBuildPlan{kind: imageBuildNone}
+}
+
+// deduplicateAndSort removes blank entries, deduplicates refs, and returns
+// them in lexical order.
+//
+// Sorting keeps execution deterministic and log output stable across runs.
+func deduplicateAndSort(in []string) []string {
+	set := map[string]bool{}
+	for _, imageRef := range in {
+		if strings.TrimSpace(imageRef) == "" {
+			continue
+		}
+		set[imageRef] = true
+	}
+	out := make([]string, 0, len(set))
+	for imageRef := range set {
+		out = append(out, imageRef)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// resolveBuildRoot finds the Norma repository root to execute docker builds.
+//
+// Starting from startDir, it walks up parent directories until it finds a
+// directory containing both:
+//   - Dockerfile
+//   - scripts/run_sonic.sh
+//
+// This guards against running docker build in unrelated directories while
+// keeping call sites simple.
+func resolveBuildRoot(startDir string) (string, error) {
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve build root: %w", err)
+	}
+
+	for {
+		dockerfile := filepath.Join(dir, "Dockerfile")
+		script := filepath.Join(dir, "scripts", "run_sonic.sh")
+		if fileExists(dockerfile) && fileExists(script) {
+			return dir, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	return "", errors.New("unable to locate norma build root with Dockerfile and scripts/run_sonic.sh")
+}
+
+// fileExists reports whether path exists and is a regular file-like entry
+// (i.e. not a directory).
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/driver/docker/images_test.go
+++ b/driver/docker/images_test.go
@@ -1,0 +1,279 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/docker/docker/api/types/image"
+)
+
+func TestPlanImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		imageRef string
+		want     imageBuildPlan
+	}{
+		{
+			name:     "remote main image",
+			imageRef: "sonic",
+			want: imageBuildPlan{
+				kind:      imageBuildSonicRemote,
+				clientSrc: sonicRepositoryURL,
+			},
+		},
+		{
+			name:     "local image",
+			imageRef: "sonic:local",
+			want: imageBuildPlan{
+				kind:      imageBuildSonicLocal,
+				clientSrc: "sonic",
+			},
+		},
+		{
+			name:     "tagged remote image",
+			imageRef: "sonic:v2.1.2",
+			want: imageBuildPlan{
+				kind:      imageBuildSonicRemote,
+				clientSrc: sonicRepositoryURL + "#v2.1.2",
+			},
+		},
+		{
+			name:     "non sonic image is pull-only plan",
+			imageRef: "alpine",
+			want: imageBuildPlan{
+				kind: imageBuildNone,
+			},
+		},
+		{
+			name:     "empty sonic tag falls back to pull-only",
+			imageRef: "sonic:",
+			want: imageBuildPlan{
+				kind: imageBuildNone,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := planImage(tt.imageRef)
+			if got != tt.want {
+				t.Fatalf("invalid plan, got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeduplicateAndSort(t *testing.T) {
+	input := []string{"sonic:v2.1", "", "sonic", "sonic:v2.1", "   ", "alpine"}
+	want := []string{"alpine", "sonic", "sonic:v2.1"}
+
+	got := deduplicateAndSort(input)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid refs, got %v, want %v", got, want)
+	}
+}
+
+func TestResolveBuildRoot(t *testing.T) {
+	t.Run("finds root by walking parents", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+			t.Fatalf("failed to write Dockerfile: %v", err)
+		}
+		scriptsDir := filepath.Join(root, "scripts")
+		if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+			t.Fatalf("failed to create scripts dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(scriptsDir, "run_sonic.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatalf("failed to write run_sonic.sh: %v", err)
+		}
+
+		deep := filepath.Join(root, "a", "b", "c")
+		if err := os.MkdirAll(deep, 0o755); err != nil {
+			t.Fatalf("failed to create deep directory: %v", err)
+		}
+
+		got, err := resolveBuildRoot(deep)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != root {
+			t.Fatalf("invalid root, got %q, want %q", got, root)
+		}
+	})
+
+	t.Run("fails when root markers are missing", func(t *testing.T) {
+		start := t.TempDir()
+		_, err := resolveBuildRoot(start)
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+	})
+}
+
+func TestFileExists(t *testing.T) {
+	t.Run("true for regular file", func(t *testing.T) {
+		dir := t.TempDir()
+		file := filepath.Join(dir, "f.txt")
+		if err := os.WriteFile(file, []byte("ok"), 0o644); err != nil {
+			t.Fatalf("failed to write file: %v", err)
+		}
+		if !fileExists(file) {
+			t.Fatalf("expected true for file")
+		}
+	})
+
+	t.Run("false for directory", func(t *testing.T) {
+		dir := t.TempDir()
+		if fileExists(dir) {
+			t.Fatalf("expected false for directory")
+		}
+	})
+
+	t.Run("false for missing path", func(t *testing.T) {
+		if fileExists(filepath.Join(t.TempDir(), "does-not-exist")) {
+			t.Fatalf("expected false for missing path")
+		}
+	})
+}
+
+func TestEnsureImages_EmptyRefs_NoOp(t *testing.T) {
+	if err := EnsureImages(t.Context(), nil, ""); err != nil {
+		t.Fatalf("EnsureImages should no-op for empty refs: %v", err)
+	}
+
+	if err := EnsureImages(t.Context(), []string{}, ""); err != nil {
+		t.Fatalf("EnsureImages should no-op for empty refs slice: %v", err)
+	}
+}
+
+func TestPullImage(t *testing.T) {
+	// This test assumes docker is available and configured correctly, but does
+	// not require any specific images to be present locally or remotely. Pulling
+	// "hello-world" is a simple smoke test that should succeed in a working
+	// environment and fail in a broken one.
+	ctx := t.Context()
+	cli, err := NewClient()
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+	defer func() {
+		_ = cli.Close()
+	}()
+
+	if err := pullImage(ctx, cli, "hello-world:latest"); err != nil {
+		t.Fatalf("failed to pull image: %v", err)
+	}
+}
+
+func TestBuildImage_Builds_SonicLocal(t *testing.T) {
+	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
+		t.Skipf("docker socket not available: %v", err)
+	}
+
+	buildRoot, err := resolveBuildRoot(".")
+	if err != nil {
+		t.Fatalf("failed to resolve build root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(buildRoot, "sonic")); err != nil {
+		t.Skipf("local sonic sources not available at %s: %v", filepath.Join(buildRoot, "sonic"), err)
+	}
+
+	if err := buildImage(t.Context(), buildRoot, "sonic:testlocal", "sonic"); err != nil {
+		t.Fatalf("failed to build sonic:testlocal image: %v", err)
+	}
+
+	cli, err := NewClient()
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+	defer func() {
+		// clean the image after test to avoid side effects
+		imgResponse, err := cli.cli.ImageRemove(t.Context(), "sonic:testlocal", image.RemoveOptions{})
+		if err != nil {
+			t.Errorf("failed to remove image sonic:testlocal: %v", err)
+		}
+		if len(imgResponse[0].Deleted) == 0 && len(imgResponse[0].Untagged) == 0 {
+			t.Errorf("failed to remove image sonic:testlocal: %v", imgResponse)
+		}
+		_ = cli.Close()
+	}()
+
+	if _, _, err := cli.cli.ImageInspectWithRaw(t.Context(), "sonic:testlocal"); err != nil {
+		t.Fatalf("image sonic:testlocal not found after build: %v", err)
+	}
+}
+
+func TestEnsureImages_BuildsSonicLocal(t *testing.T) {
+	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
+		t.Skipf("docker socket not available: %v", err)
+	}
+
+	buildRoot, err := resolveBuildRoot(".")
+	if err != nil {
+		t.Fatalf("failed to resolve build root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(buildRoot, "sonic")); err != nil {
+		t.Skipf("local sonic sources not available at %s: %v", filepath.Join(buildRoot, "sonic"), err)
+	}
+
+	imageRef := "sonic:local"
+	if err := EnsureImages(t.Context(), []string{imageRef}, buildRoot); err != nil {
+		t.Fatalf("failed to ensure image %s: %v", imageRef, err)
+	}
+
+	cli, err := NewClient()
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+	defer func() {
+		_ = cli.Close()
+	}()
+
+	if _, _, err := cli.cli.ImageInspectWithRaw(t.Context(), imageRef); err != nil {
+		t.Fatalf("image %s not found after EnsureImages build: %v", imageRef, err)
+	}
+}
+
+func TestEnsureImages_PullsImage(t *testing.T) {
+	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
+		t.Skipf("docker socket not available: %v", err)
+	}
+
+	buildRoot, err := resolveBuildRoot(".")
+	if err != nil {
+		t.Fatalf("failed to resolve build root: %v", err)
+	}
+
+	imageRef := "hello-world:latest"
+	if err := EnsureImages(t.Context(), []string{imageRef}, buildRoot); err != nil {
+		t.Fatalf("failed to ensure image %s: %v", imageRef, err)
+	}
+
+	cli, err := NewClient()
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+	defer func() { _ = cli.Close() }()
+
+	if _, _, err := cli.cli.ImageInspectWithRaw(t.Context(), imageRef); err != nil {
+		t.Fatalf("image %s not found after EnsureImages pull: %v", imageRef, err)
+	}
+}

--- a/driver/docker/images_test.go
+++ b/driver/docker/images_test.go
@@ -210,7 +210,9 @@ func TestBuildImage_Builds_SonicLocal(t *testing.T) {
 		if err != nil {
 			t.Errorf("failed to remove image sonic:testlocal: %v", err)
 		}
-		if len(imgResponse[0].Deleted) == 0 && len(imgResponse[0].Untagged) == 0 {
+		if len(imgResponse) == 0 {
+			t.Errorf("failed to remove image sonic:testlocal: empty response")
+		} else if len(imgResponse[0].Deleted) == 0 && len(imgResponse[0].Untagged) == 0 {
 			t.Errorf("failed to remove image sonic:testlocal: %v", imgResponse)
 		}
 		_ = cli.Close()

--- a/driver/monitoring/monitor_test.go
+++ b/driver/monitoring/monitor_test.go
@@ -162,9 +162,11 @@ func TestMonitorPrometheusLogProviderConfigured(t *testing.T) {
 func TestMonitorIntegrationPrometheusLogReceived(t *testing.T) {
 	t.Parallel()
 	ctrl := gomock.NewController(t)
-	mockNet := driver.NewMockNetwork(ctrl)
+	net := driver.NewMockNetwork(ctrl)
 
-	localNet, err := local.NewLocalNetwork(t.Context(), &driver.NetworkConfig{Validators: driver.DefaultValidators})
+	localNet, err := local.NewLocalNetwork(
+		t.Context(),
+		&driver.NetworkConfig{Validators: driver.DefaultValidators})
 	if err != nil {
 		t.Fatalf("failed to create local network: %v", err)
 	}
@@ -182,11 +184,11 @@ func TestMonitorIntegrationPrometheusLogReceived(t *testing.T) {
 	}
 
 	// simulate existing nodes
-	mockNet.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
-	mockNet.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{node})
+	net.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
+	net.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{node})
 
 	outDir := t.TempDir()
-	monitor, err := NewMonitor(mockNet, MonitorConfig{OutputDir: outDir})
+	monitor, err := NewMonitor(net, MonitorConfig{OutputDir: outDir})
 	if err != nil {
 		t.Fatalf("failed to create monitor instance: %v", err)
 	}
@@ -199,10 +201,12 @@ func TestMonitorIntegrationPrometheusLogReceived(t *testing.T) {
 	done := make(chan bool)
 	listener := NewMockTimeLogListener(ctrl)
 	// expected to be called
-	listener.EXPECT().OnLog(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Do(func(Node, Time, float64) {
-		once.Do(func() { close(done) })
-	})
-	monitor.PrometheusLogProvider().RegisterLogListener(NewPrometheusNameKey("chain_block_age"), listener)
+	listener.EXPECT().OnLog(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
+		Do(func(Node, Time, float64) {
+			once.Do(func() { close(done) })
+		})
+	monitor.PrometheusLogProvider().
+		RegisterLogListener(NewPrometheusNameKey("chain_block_age"), listener)
 
 	<-done
 }

--- a/driver/monitoring/monitor_test.go
+++ b/driver/monitoring/monitor_test.go
@@ -23,8 +23,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/norma/driver"
-	"github.com/0xsoniclabs/norma/driver/docker"
-	opera "github.com/0xsoniclabs/norma/driver/node"
+	"github.com/0xsoniclabs/norma/driver/network/local"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/exp/slices"
 )
@@ -163,33 +162,31 @@ func TestMonitorPrometheusLogProviderConfigured(t *testing.T) {
 func TestMonitorIntegrationPrometheusLogReceived(t *testing.T) {
 	t.Parallel()
 	ctrl := gomock.NewController(t)
-	net := driver.NewMockNetwork(ctrl)
+	mockNet := driver.NewMockNetwork(ctrl)
 
-	client, err := docker.NewClient()
+	localNet, err := local.NewLocalNetwork(t.Context(), &driver.NetworkConfig{Validators: driver.DefaultValidators})
 	if err != nil {
-		t.Fatalf("failed to create a docker client: %v", err)
+		t.Fatalf("failed to create local network: %v", err)
 	}
 	t.Cleanup(func() {
-		_ = client.Close()
+		if err := localNet.Shutdown(); err != nil {
+			t.Fatalf("failed to shutdown local network: %v", err)
+		}
 	})
-	node, err := opera.StartOperaDockerNode(t.Context(), client, nil, &opera.OperaNodeConfig{
-		Label:         "test",
-		Image:         driver.DefaultClientDockerImageName,
-		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
+	node, err := localNet.CreateNode(&driver.NodeConfig{
+		Name:  "test",
+		Image: driver.DefaultClientDockerImageName,
 	})
 	if err != nil {
-		t.Fatalf("failed to create an Opera node on Docker: %v", err)
+		t.Fatalf("failed to create a node on local network: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = node.Cleanup()
-	})
 
 	// simulate existing nodes
-	net.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
-	net.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{node})
+	mockNet.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
+	mockNet.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{node})
 
 	outDir := t.TempDir()
-	monitor, err := NewMonitor(net, MonitorConfig{OutputDir: outDir})
+	monitor, err := NewMonitor(mockNet, MonitorConfig{OutputDir: outDir})
 	if err != nil {
 		t.Fatalf("failed to create monitor instance: %v", err)
 	}

--- a/driver/monitoring/node/cpu_profile_test.go
+++ b/driver/monitoring/node/cpu_profile_test.go
@@ -21,29 +21,28 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/norma/driver"
-	"github.com/0xsoniclabs/norma/driver/docker"
-	opera "github.com/0xsoniclabs/norma/driver/node"
+	"github.com/0xsoniclabs/norma/driver/network/local"
 )
 
 func TestCanCollectCpuProfileDateFromOperaNode(t *testing.T) {
-	docker, err := docker.NewClient()
+	net, err := local.NewLocalNetwork(
+		t.Context(),
+		&driver.NetworkConfig{Validators: driver.DefaultValidators})
 	if err != nil {
-		t.Fatalf("failed to create a docker client: %v", err)
+		t.Fatalf("failed to create local network: %v", err)
 	}
 	t.Cleanup(func() {
-		_ = docker.Close()
+		if err := net.Shutdown(); err != nil {
+			t.Fatalf("failed to shut down network: %v", err)
+		}
 	})
-	node, err := opera.StartOperaDockerNode(t.Context(), docker, nil, &opera.OperaNodeConfig{
-		Label:         "test",
-		Image:         driver.DefaultClientDockerImageName,
-		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
+	node, err := net.CreateNode(&driver.NodeConfig{
+		Name:  "test",
+		Image: driver.DefaultClientDockerImageName,
 	})
 	if err != nil {
-		t.Fatalf("failed to create an Opera node on Docker: %v", err)
+		t.Fatalf("failed to create node: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = node.Cleanup()
-	})
 	data, err := GetPprofData(node, time.Second)
 	if err != nil {
 		t.Errorf("failed to collect pprof data from node: %v", err)

--- a/driver/monitoring/node/prom_log_source_test.go
+++ b/driver/monitoring/node/prom_log_source_test.go
@@ -23,9 +23,8 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/norma/driver"
-	"github.com/0xsoniclabs/norma/driver/docker"
 	"github.com/0xsoniclabs/norma/driver/monitoring"
-	opera "github.com/0xsoniclabs/norma/driver/node"
+	"github.com/0xsoniclabs/norma/driver/network/local"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/exp/slices"
 )
@@ -87,24 +86,24 @@ func TestLogsIntegrationGetRealMetric(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	net := driver.NewMockNetwork(ctrl)
 
-	client, err := docker.NewClient()
+	localNet, err := local.NewLocalNetwork(
+		t.Context(),
+		&driver.NetworkConfig{Validators: driver.DefaultValidators})
 	if err != nil {
-		t.Fatalf("failed to create a docker client: %v", err)
+		t.Fatalf("failed to create local network: %v", err)
 	}
 	t.Cleanup(func() {
-		_ = client.Close()
+		if err := localNet.Shutdown(); err != nil {
+			t.Fatalf("failed to shut down local network: %v", err)
+		}
 	})
-	node, err := opera.StartOperaDockerNode(t.Context(), client, nil, &opera.OperaNodeConfig{
-		Label:         "test",
-		Image:         driver.DefaultClientDockerImageName,
-		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
+	node, err := localNet.CreateNode(&driver.NodeConfig{
+		Name:  "test",
+		Image: driver.DefaultClientDockerImageName,
 	})
 	if err != nil {
-		t.Fatalf("failed to create an Opera node on Docker: %v", err)
+		t.Fatalf("failed to create node on local network: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = node.Cleanup()
-	})
 
 	// simulate existing nodes
 	net.EXPECT().RegisterListener(gomock.Any()).AnyTimes()

--- a/driver/monitoring/prometheus/prometheus_test.go
+++ b/driver/monitoring/prometheus/prometheus_test.go
@@ -124,7 +124,9 @@ func createLocalNetwork(t *testing.T) *local.LocalNetwork {
 		t.Fatalf("error: %v", err)
 	}
 	t.Cleanup(func() {
-		_ = net.Shutdown()
+		if err := net.Shutdown(); err != nil {
+			t.Fatalf("failed to shutdown local network: %v", err)
+		}
 	})
 	return net
 }

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand"
+	"sort"
 	"sync"
 	"sync/atomic"
 
@@ -76,6 +77,10 @@ type LocalNetwork struct {
 }
 
 func NewLocalNetwork(ctx context.Context, config *driver.NetworkConfig) (*LocalNetwork, error) {
+	if err := docker.EnsureImages(ctx, collectValidatorImages(config.Validators), ""); err != nil {
+		return nil, fmt.Errorf("failed to ensure validator images: %w", err)
+	}
+
 	client, err := docker.NewClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create docker client; %v", err)
@@ -190,11 +195,19 @@ func (n *LocalNetwork) createNode(ctx context.Context, nodeConfig *node.OperaNod
 
 // CreateNode creates nodes in the network during run.
 func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error) {
+	image := config.Image
+	if image == "" {
+		image = driver.DefaultClientDockerImageName
+	}
+	if err := docker.EnsureImages(context.Background(), []string{image}, ""); err != nil {
+		return nil, fmt.Errorf("failed to ensure image %q: %w", image, err)
+	}
+
 	if config.Cheater {
 		_, err := n.createNode(context.Background(), &node.OperaNodeConfig{
 			Label:          "cheater-" + config.Name,
 			Failing:        config.Failing,
-			Image:          config.Image,
+			Image:          image,
 			NetworkConfig:  &n.config,
 			ValidatorId:    config.ValidatorId,
 			ExtraArguments: config.ExtraArguments,
@@ -213,12 +226,30 @@ func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error
 	return n.createNode(context.Background(), &node.OperaNodeConfig{
 		Label:          config.Name,
 		Failing:        config.Failing,
-		Image:          config.Image,
+		Image:          image,
 		NetworkConfig:  &n.config,
 		ValidatorId:    config.ValidatorId,
 		MountDataDir:   datadir,
 		ExtraArguments: config.ExtraArguments,
 	})
+}
+
+func collectValidatorImages(validators driver.Validators) []string {
+	images := map[string]bool{}
+	for _, validator := range validators {
+		image := validator.ImageName
+		if image == "" {
+			image = driver.DefaultClientDockerImageName
+		}
+		images[image] = true
+	}
+
+	result := make([]string, 0, len(images))
+	for image := range images {
+		result = append(result, image)
+	}
+	sort.Strings(result)
+	return result
 }
 
 func (n *LocalNetwork) RemoveNode(node driver.Node) error {

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -32,7 +32,6 @@ import (
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/docker"
 	"github.com/0xsoniclabs/norma/driver/network/rpc"
-	"github.com/0xsoniclabs/norma/driver/node"
 	rpcdriver "github.com/0xsoniclabs/norma/driver/rpc"
 	"github.com/0xsoniclabs/norma/load/app"
 	"github.com/0xsoniclabs/norma/load/controller"
@@ -50,7 +49,7 @@ type LocalNetwork struct {
 
 	// nodes provide a register for all nodes in the network, including
 	// validator nodes created during startup.
-	nodes map[driver.NodeID]*node.OperaNode
+	nodes map[driver.NodeID]*operaNode
 
 	// nodesMutex synchronizes access to the list of nodes.
 	nodesMutex sync.Mutex
@@ -103,7 +102,7 @@ func NewLocalNetwork(ctx context.Context, config *driver.NetworkConfig) (*LocalN
 		network:        dn,
 		config:         *config,
 		primaryAccount: primaryAccount,
-		nodes:          map[driver.NodeID]*node.OperaNode{},
+		nodes:          map[driver.NodeID]*operaNode{},
 		apps:           []driver.Application{},
 		listeners:      map[driver.NetworkListener]bool{},
 		rpcWorkerPool:  rpc.NewRpcWorkerPool(),
@@ -124,7 +123,7 @@ func NewLocalNetwork(ctx context.Context, config *driver.NetworkConfig) (*LocalN
 			go func(idx int) {
 				defer wg.Done()
 				validatorId := idx + 1
-				nodeConfig := node.OperaNodeConfig{
+				nodeConfig := operaNodeConfig{
 					ValidatorId:    &validatorId,
 					Failing:        validator.Failing,
 					Image:          image,
@@ -158,7 +157,7 @@ func NewLocalNetwork(ctx context.Context, config *driver.NetworkConfig) (*LocalN
 }
 
 // addNodeIntoNetwork connects the node with other nodes in the network, adds it into the list of nodes.
-func (n *LocalNetwork) addNodeIntoNetwork(node *node.OperaNode) error {
+func (n *LocalNetwork) addNodeIntoNetwork(node *operaNode) error {
 	n.nodesMutex.Lock()
 	defer n.nodesMutex.Unlock()
 
@@ -177,8 +176,8 @@ func (n *LocalNetwork) addNodeIntoNetwork(node *node.OperaNode) error {
 
 // createNode is an internal version of CreateNode enabling the creation
 // of validator and non-validator nodes in the network.
-func (n *LocalNetwork) createNode(ctx context.Context, nodeConfig *node.OperaNodeConfig) (*node.OperaNode, error) {
-	node, err := node.StartOperaDockerNode(ctx, n.docker, n.network, nodeConfig)
+func (n *LocalNetwork) createNode(ctx context.Context, nodeConfig *operaNodeConfig) (*operaNode, error) {
+	node, err := startOperaDockerNode(ctx, n.docker, n.network, nodeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start opera docker; %v", err)
 	}
@@ -204,7 +203,7 @@ func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error
 	}
 
 	if config.Cheater {
-		_, err := n.createNode(context.Background(), &node.OperaNodeConfig{
+		_, err := n.createNode(context.Background(), &operaNodeConfig{
 			Label:          "cheater-" + config.Name,
 			Failing:        config.Failing,
 			Image:          image,
@@ -223,7 +222,7 @@ func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error
 		*datadir = fmt.Sprintf("%s/%s", n.config.OutputDir, *config.DataVolume)
 	}
 
-	return n.createNode(context.Background(), &node.OperaNodeConfig{
+	return n.createNode(context.Background(), &operaNodeConfig{
 		Label:          config.Name,
 		Failing:        config.Failing,
 		Image:          image,
@@ -473,7 +472,7 @@ func (n *LocalNetwork) Shutdown() error {
 			errs = append(errs, err)
 		}
 	}
-	n.nodes = map[driver.NodeID]*node.OperaNode{}
+	n.nodes = map[driver.NodeID]*operaNode{}
 
 	// Third, shut down the docker network.
 	if n.network != nil {

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -42,6 +42,15 @@ func TestLocalNetworkIsNetwork(t *testing.T) {
 	var _ driver.Network = &net
 }
 
+func cleanupNetwork(t *testing.T, net *LocalNetwork) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := net.Shutdown(); err != nil {
+			t.Fatalf("failed to shut down network: %v", err)
+		}
+	})
+}
+
 func TestLocalNetwork_CanStartNodesAndShutThemDown(t *testing.T) {
 	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
 	for _, N := range []int{1, 3} {
@@ -51,9 +60,7 @@ func TestLocalNetwork_CanStartNodesAndShutThemDown(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
 			}
-			t.Cleanup(func() {
-				_ = net.Shutdown()
-			})
+			cleanupNetwork(t, net)
 
 			nodes := []driver.Node{}
 			for i := 0; i < N; i++ {
@@ -94,9 +101,7 @@ func TestLocalNetwork_CanEnforceNetworkLatency(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
 			}
-			t.Cleanup(func() {
-				_ = net.Shutdown()
-			})
+			cleanupNetwork(t, net)
 
 			// measure latency between nodes
 			nodes := net.GetActiveNodes()
@@ -127,9 +132,7 @@ func TestLocalNetwork_CanStartApplicationsAndShutThemDown(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
 			}
-			t.Cleanup(func() {
-				_ = net.Shutdown()
-			})
+			cleanupNetwork(t, net)
 
 			apps := []driver.Application{}
 			for i := 0; i < N; i++ {
@@ -170,9 +173,7 @@ func TestLocalNetwork_CanPerformNetworkShutdown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = net.Shutdown()
-	})
+	cleanupNetwork(t, net)
 
 	for i := 0; i < N; i++ {
 		_, err := net.CreateNode(&driver.NodeConfig{
@@ -206,9 +207,7 @@ func TestLocalNetwork_Shutdown_Graceful(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = net.Shutdown()
-	})
+	cleanupNetwork(t, net)
 
 	done := make(chan bool, N)
 
@@ -271,9 +270,7 @@ func TestLocalNetwork_CanRunWithMultipleValidators(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
 			}
-			t.Cleanup(func() {
-				_ = net.Shutdown()
-			})
+			cleanupNetwork(t, net)
 
 			app, err := net.CreateApplication(&driver.ApplicationConfig{
 				Name: "TestApp",
@@ -332,9 +329,7 @@ func TestLocalNetwork_NotifiesListenersOnNodeStartup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = net.Shutdown()
-	})
+	cleanupNetwork(t, net)
 
 	activeNodes := net.GetActiveNodes()
 	if got, want := len(activeNodes), config.Validators.GetNumValidators(); got != want {
@@ -368,9 +363,7 @@ func TestLocalNetwork_NotifiesListenersOnAppStartup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = net.Shutdown()
-	})
+	cleanupNetwork(t, net)
 
 	net.RegisterListener(listener)
 	listener.EXPECT().AfterApplicationCreation(gomock.Any())
@@ -393,9 +386,7 @@ func TestLocalNetwork_CanRemoveNode(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
 			}
-			t.Cleanup(func() {
-				_ = net.Shutdown()
-			})
+			cleanupNetwork(t, net)
 
 			ctrl := gomock.NewController(t)
 			listener := driver.NewMockNetworkListener(ctrl)
@@ -476,9 +467,7 @@ func TestLocalNetwork_Can_Run_Multiple_Client_Images_LatestVersions(t *testing.T
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = net.Shutdown()
-	})
+	cleanupNetwork(t, net)
 
 	images := []string{"sonic", "sonic:local"}
 	checksum := make(chan string)
@@ -517,9 +506,7 @@ func TestLocalNetwork_Can_Run_Multiple_Client_Images_TaggedVersions(t *testing.T
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = net.Shutdown()
-	})
+	cleanupNetwork(t, net)
 
 	images := []string{"sonic:v2.0.3", "sonic:v2.0.2", "sonic:v2.0.1", "sonic:v2.0.0"}
 	checksum := make(chan string)

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/0xsoniclabs/norma/driver/parser"
 
 	"github.com/0xsoniclabs/norma/driver"
-	"github.com/0xsoniclabs/norma/driver/node"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"go.uber.org/mock/gomock"
 )
@@ -108,7 +107,7 @@ func TestLocalNetwork_CanEnforceNetworkLatency(t *testing.T) {
 			if got, want := len(nodes), 2; got != want {
 				t.Fatalf("invalid number of active nodes, got %d, want %d", got, want)
 			}
-			got, err := nodes[0].(*node.OperaNode).GetRoundTripTime(nodes[1].Hostname())
+			got, err := nodes[0].(*operaNode).GetRoundTripTime(nodes[1].Hostname())
 			if err != nil {
 				t.Errorf("failed to measure network delay: %v", err)
 			}

--- a/driver/network/local/opera.go
+++ b/driver/network/local/opera.go
@@ -29,6 +29,7 @@ import (
 
 	"golang.org/x/exp/maps"
 
+	"github.com/0xsoniclabs/norma/driver/node"
 	rpcdriver "github.com/0xsoniclabs/norma/driver/rpc"
 	"github.com/0xsoniclabs/norma/genesistools/genesis"
 
@@ -37,38 +38,6 @@ import (
 	"github.com/0xsoniclabs/norma/driver/network"
 	"github.com/ethereum/go-ethereum/rpc"
 )
-
-var OperaRpcService = network.ServiceDescription{
-	Name:     "OperaRPC",
-	Port:     18545,
-	Protocol: "http",
-}
-
-var OperaWsService = network.ServiceDescription{
-	Name:     "OperaWs",
-	Port:     18546,
-	Protocol: "ws",
-}
-
-var OperaDebugService = network.ServiceDescription{
-	Name:     "OperaPprof",
-	Port:     6060,
-	Protocol: "http",
-}
-
-var operaServices = network.ServiceGroup{}
-
-func init() {
-	if err := operaServices.RegisterService(&OperaRpcService); err != nil {
-		panic(err)
-	}
-	if err := operaServices.RegisterService(&OperaWsService); err != nil {
-		panic(err)
-	}
-	if err := operaServices.RegisterService(&OperaDebugService); err != nil {
-		panic(err)
-	}
-}
 
 // operaNode implements the driver's Node interface by running a go-opera
 // client on a generic host.
@@ -116,13 +85,13 @@ func startOperaDockerNode(ctx context.Context, client *docker.Client, dn *docker
 	}
 
 	host, err := network.RetryReturn(ctx, network.DefaultRetryAttempts, 1*time.Second, func() (*docker.Container, error) {
-		ports, err := network.GetFreePorts(len(operaServices.Services()))
+		ports, err := network.GetFreePorts(len(node.OperaServices.Services()))
 		if err != nil {
 			return nil, err
 		}
 
 		portForwarding := make(map[network.Port]network.Port, len(ports))
-		for i, service := range operaServices.Services() {
+		for i, service := range node.OperaServices.Services() {
 			portForwarding[service.Port] = ports[i]
 		}
 
@@ -256,7 +225,7 @@ func (n *operaNode) GetServiceUrl(service *network.ServiceDescription) *driver.U
 }
 
 func (n *operaNode) GetNodeID() (driver.NodeID, error) {
-	url := n.GetServiceUrl(&OperaRpcService)
+	url := n.GetServiceUrl(&node.OperaRpcService)
 	if url == nil {
 		return "", fmt.Errorf("node does not export an RPC server")
 	}
@@ -291,7 +260,7 @@ func (n *operaNode) Cleanup() error {
 }
 
 func (n *operaNode) DialRpc() (rpcdriver.Client, error) {
-	url := n.GetServiceUrl(&OperaRpcService)
+	url := n.GetServiceUrl(&node.OperaRpcService)
 	if url == nil {
 		return nil, fmt.Errorf("node %s does not export an RPC server", n.GetLabel())
 	}

--- a/driver/network/local/opera.go
+++ b/driver/network/local/opera.go
@@ -298,7 +298,7 @@ func (n *operaNode) RemovePeer(id driver.NodeID) error {
 	})
 }
 
-// Kill sends a SigKill singal to node.
+// Kill sends a SigKill signal to node.
 func (n *operaNode) Kill() error {
 	return n.container.SendSignal(docker.SigKill)
 }

--- a/driver/network/local/opera.go
+++ b/driver/network/local/opera.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Norma. If not, see <http://www.gnu.org/licenses/>.
 
-package node
+package local
 
 import (
 	"bufio"
@@ -70,15 +70,15 @@ func init() {
 	}
 }
 
-// OperaNode implements the driver's Node interface by running a go-opera
+// operaNode implements the driver's Node interface by running a go-opera
 // client on a generic host.
-type OperaNode struct {
+type operaNode struct {
 	host      network.Host
 	container *docker.Container
-	config    *OperaNodeConfig
+	config    *operaNodeConfig
 }
 
-type OperaNodeConfig struct {
+type operaNodeConfig struct {
 	// The label to be used to name this node. The label should not be empty.
 	Label string
 	// Failing if true, the node is expected to fail at some point of execution.
@@ -102,8 +102,8 @@ type OperaNodeConfig struct {
 // with underscores and hyphens.
 var labelPattern = regexp.MustCompile("[A-Za-z0-9_-]+")
 
-// StartOperaDockerNode creates a new OperaNode running in a Docker container.
-func StartOperaDockerNode(ctx context.Context, client *docker.Client, dn *docker.Network, config *OperaNodeConfig) (*OperaNode, error) {
+// startOperaDockerNode creates a new operaNode running in a Docker container.
+func startOperaDockerNode(ctx context.Context, client *docker.Client, dn *docker.Network, config *operaNodeConfig) (*operaNode, error) {
 	if !labelPattern.Match([]byte(config.Label)) {
 		return nil, fmt.Errorf("invalid label for node: '%v'", config.Label)
 	}
@@ -182,13 +182,13 @@ func StartOperaDockerNode(ctx context.Context, client *docker.Client, dn *docker
 		nodeConfig.ValidatorId = new(int)
 		*nodeConfig.ValidatorId = *config.ValidatorId
 	}
-	node := &OperaNode{
+	node := &operaNode{
 		host:      host,
 		container: host,
 		config:    &nodeConfig,
 	}
 
-	// Wait until the OperaNode inside the Container is ready.
+	// Wait until the operaNode inside the Container is ready.
 	err = network.Retry(ctx, network.DefaultRetryAttempts, 1*time.Second, func() error {
 		if err := node.host.CheckRunning(); err != nil {
 			return fmt.Errorf("%w: %w", err, network.ErrPermanent)
@@ -208,9 +208,9 @@ func StartOperaDockerNode(ctx context.Context, client *docker.Client, dn *docker
 	)
 }
 
-// printLog streams and prints the logs of the given OperaNode, to debug cause of
+// printLog streams and prints the logs of the given operaNode, to debug cause of
 // startup failure.
-func printLog(node *OperaNode) error {
+func printLog(node *operaNode) error {
 	reader, err := node.StreamLog()
 	if err != nil {
 		return fmt.Errorf("cannot read node logs: %w", err)
@@ -222,31 +222,31 @@ func printLog(node *OperaNode) error {
 	return reader.Close()
 }
 
-func (n *OperaNode) GetLabel() string {
+func (n *operaNode) GetLabel() string {
 	return n.config.Label
 }
 
-func (n *OperaNode) IsExpectedFailure() bool {
+func (n *operaNode) IsExpectedFailure() bool {
 	return n.config.Failing
 }
 
 // Hostname returns the hostname of the node.
 // The hostname is accessible only inside the Docker network.
-func (n *OperaNode) Hostname() string {
+func (n *operaNode) Hostname() string {
 	return n.host.Hostname()
 }
 
 // MetricsPort returns the port on which the node exports its metrics.
 // The port is accessible only inside the Docker network.
-func (n *OperaNode) MetricsPort() int {
+func (n *operaNode) MetricsPort() int {
 	return 6060
 }
 
-func (n *OperaNode) IsRunning() bool {
+func (n *operaNode) IsRunning() bool {
 	return n.host.IsRunning()
 }
 
-func (n *OperaNode) GetServiceUrl(service *network.ServiceDescription) *driver.URL {
+func (n *operaNode) GetServiceUrl(service *network.ServiceDescription) *driver.URL {
 	addr := n.host.GetAddressForService(service)
 	if addr == nil {
 		return nil
@@ -255,7 +255,7 @@ func (n *OperaNode) GetServiceUrl(service *network.ServiceDescription) *driver.U
 	return &url
 }
 
-func (n *OperaNode) GetNodeID() (driver.NodeID, error) {
+func (n *operaNode) GetNodeID() (driver.NodeID, error) {
 	url := n.GetServiceUrl(&OperaRpcService)
 	if url == nil {
 		return "", fmt.Errorf("node does not export an RPC server")
@@ -274,23 +274,23 @@ func (n *OperaNode) GetNodeID() (driver.NodeID, error) {
 	return driver.NodeID(result.Enode), nil
 }
 
-func (n *OperaNode) GetValidatorId() *int {
+func (n *operaNode) GetValidatorId() *int {
 	return n.config.ValidatorId
 }
 
-func (n *OperaNode) StreamLog() (io.ReadCloser, error) {
+func (n *operaNode) StreamLog() (io.ReadCloser, error) {
 	return n.host.StreamLog()
 }
 
-func (n *OperaNode) Stop() error {
+func (n *operaNode) Stop() error {
 	return n.host.Stop()
 }
 
-func (n *OperaNode) Cleanup() error {
+func (n *operaNode) Cleanup() error {
 	return n.host.Cleanup()
 }
 
-func (n *OperaNode) DialRpc() (rpcdriver.Client, error) {
+func (n *operaNode) DialRpc() (rpcdriver.Client, error) {
 	url := n.GetServiceUrl(&OperaRpcService)
 	if url == nil {
 		return nil, fmt.Errorf("node %s does not export an RPC server", n.GetLabel())
@@ -305,9 +305,9 @@ func (n *OperaNode) DialRpc() (rpcdriver.Client, error) {
 	return rpcdriver.WrapRpcClient(rpcClient), nil
 }
 
-// AddPeer informs the client instance represented by the OperaNode about the
+// AddPeer informs the client instance represented by the operaNode about the
 // existence of another node, to which it may establish a connection.
-func (n *OperaNode) AddPeer(id driver.NodeID) error {
+func (n *operaNode) AddPeer(id driver.NodeID) error {
 	rpcClient, err := n.DialRpc()
 	if err != nil {
 		return err
@@ -317,9 +317,9 @@ func (n *OperaNode) AddPeer(id driver.NodeID) error {
 	})
 }
 
-// RemovePeer informs the client instance represented by the OperaNode
+// RemovePeer informs the client instance represented by the operaNode
 // that the input node is no more available in the network.
-func (n *OperaNode) RemovePeer(id driver.NodeID) error {
+func (n *operaNode) RemovePeer(id driver.NodeID) error {
 	rpcClient, err := n.DialRpc()
 	if err != nil {
 		return err
@@ -330,12 +330,12 @@ func (n *OperaNode) RemovePeer(id driver.NodeID) error {
 }
 
 // Kill sends a SigKill singal to node.
-func (n *OperaNode) Kill() error {
+func (n *operaNode) Kill() error {
 	return n.container.SendSignal(docker.SigKill)
 }
 
 // GetRoundTripTime returns the median network round-trip time to the given host.
-func (n *OperaNode) GetRoundTripTime(host string) (time.Duration, error) {
+func (n *operaNode) GetRoundTripTime(host string) (time.Duration, error) {
 	output, err := n.container.Exec([]string{"ping", "-c", "5", host})
 	if err != nil {
 		return 0, err

--- a/driver/network/local/opera_test.go
+++ b/driver/network/local/opera_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Norma. If not, see <http://www.gnu.org/licenses/>.
 
-package node
+package local
 
 import (
 	"bufio"
@@ -30,7 +30,7 @@ import (
 )
 
 func TestImplements(t *testing.T) {
-	var inst OperaNode
+	var inst operaNode
 	var _ driver.Node = &inst
 
 }
@@ -43,7 +43,7 @@ func TestOperaNode_StartAndStop(t *testing.T) {
 	t.Cleanup(func() {
 		_ = docker.Close()
 	})
-	node, err := StartOperaDockerNode(t.Context(), docker, nil, &OperaNodeConfig{
+	node, err := startOperaDockerNode(t.Context(), docker, nil, &operaNodeConfig{
 		Label:         "test",
 		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
@@ -67,7 +67,7 @@ func TestOperaNode_RpcServiceIsReadyAfterStartup(t *testing.T) {
 	t.Cleanup(func() {
 		_ = docker.Close()
 	})
-	node, err := StartOperaDockerNode(t.Context(), docker, nil, &OperaNodeConfig{
+	node, err := startOperaDockerNode(t.Context(), docker, nil, &operaNodeConfig{
 		Label:         "test",
 		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
@@ -92,7 +92,7 @@ func TestOperaNode_StreamLog(t *testing.T) {
 		_ = docker.Close()
 	})
 
-	node, err := StartOperaDockerNode(t.Context(), docker, nil, &OperaNodeConfig{
+	node, err := startOperaDockerNode(t.Context(), docker, nil, &operaNodeConfig{
 		Label:         "test",
 		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
@@ -146,7 +146,7 @@ func TestOperaNode_MetricsExposed(t *testing.T) {
 		_ = docker.Close()
 	})
 
-	node, err := StartOperaDockerNode(t.Context(), docker, nil, &OperaNodeConfig{
+	node, err := startOperaDockerNode(t.Context(), docker, nil, &operaNodeConfig{
 		Label:         "test",
 		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
@@ -192,7 +192,7 @@ func TestClient_Stop_Graceful(t *testing.T) {
 		}
 	}()
 
-	node, err := StartOperaDockerNode(t.Context(), client, nil, &OperaNodeConfig{
+	node, err := startOperaDockerNode(t.Context(), client, nil, &operaNodeConfig{
 		Label:         "test",
 		Image:         driver.DefaultClientDockerImageName,
 		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},

--- a/driver/network/local/opera_test.go
+++ b/driver/network/local/opera_test.go
@@ -7,7 +7,7 @@
 // (at your option) any later version.
 //
 // Norma is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of	 
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU lesser General Public License for more details.
 //

--- a/driver/network/local/opera_test.go
+++ b/driver/network/local/opera_test.go
@@ -7,7 +7,7 @@
 // (at your option) any later version.
 //
 // Norma is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// but WITHOUT ANY WARRANTY; without even the implied warranty of	 
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU lesser General Public License for more details.
 //
@@ -27,6 +27,7 @@ import (
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/docker"
+	opera "github.com/0xsoniclabs/norma/driver/node"
 )
 
 func TestImplements(t *testing.T) {
@@ -158,7 +159,7 @@ func TestOperaNode_MetricsExposed(t *testing.T) {
 		_ = node.Cleanup()
 	})
 
-	url := node.GetServiceUrl(&OperaDebugService)
+	url := node.GetServiceUrl(&opera.OperaDebugService)
 
 	var apiWorks bool
 	for i := 0; i < 100; i++ {

--- a/driver/network/rpc/rpc_pool.go
+++ b/driver/network/rpc/rpc_pool.go
@@ -116,7 +116,7 @@ func (wg *workerGroup) close() {
 // worker maintains one worker that sends transactions to an RPC client.
 // It listens to incoming transactions and sends them to the client.
 // The worker can be closed, and it stops listening and sending the transactions.
-// The worker is initialised (i.e. the RPC connection is established) before
+// The worker is initialized (i.e. the RPC connection is established) before
 // it starts dispatching asynchronously. This process can be interrupted by
 // closing the worker before it starts dispatching.
 type worker struct {

--- a/driver/node/opera_services.go
+++ b/driver/node/opera_services.go
@@ -1,0 +1,51 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package node
+
+import "github.com/0xsoniclabs/norma/driver/network"
+
+var OperaRpcService = network.ServiceDescription{
+	Name:     "OperaRPC",
+	Port:     18545,
+	Protocol: "http",
+}
+
+var OperaWsService = network.ServiceDescription{
+	Name:     "OperaWs",
+	Port:     18546,
+	Protocol: "ws",
+}
+
+var OperaDebugService = network.ServiceDescription{
+	Name:     "OperaPprof",
+	Port:     6060,
+	Protocol: "http",
+}
+
+var OperaServices = network.ServiceGroup{}
+
+func init() {
+	if err := OperaServices.RegisterService(&OperaRpcService); err != nil {
+		panic(err)
+	}
+	if err := OperaServices.RegisterService(&OperaWsService); err != nil {
+		panic(err)
+	}
+	if err := OperaServices.RegisterService(&OperaDebugService); err != nil {
+		panic(err)
+	}
+}

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"syscall"
 	"time"
 
@@ -33,6 +34,7 @@ import (
 
 	"github.com/0xsoniclabs/norma/analysis/report"
 	"github.com/0xsoniclabs/norma/driver"
+	"github.com/0xsoniclabs/norma/driver/docker"
 	"github.com/0xsoniclabs/norma/driver/executor"
 	"github.com/0xsoniclabs/norma/driver/monitoring"
 	_ "github.com/0xsoniclabs/norma/driver/monitoring/app"
@@ -175,6 +177,14 @@ func runScenario(ctx context.Context, path, outputDir, label string, keepPrometh
 		return err
 	}
 
+	requiredImages := collectScenarioImages(scenario)
+	if len(requiredImages) > 0 {
+		fmt.Printf("Ensuring docker images: %v\n", requiredImages)
+		if err := docker.EnsureImages(ctx, requiredImages, ""); err != nil {
+			return fmt.Errorf("failed to ensure required docker images: %w", err)
+		}
+	}
+
 	slog.Info("starting evaluation", "label", label)
 
 	// create symlink as qol (_latest => _####) where #### is the randomly generated name
@@ -298,7 +308,6 @@ func runScenario(ctx context.Context, path, outputDir, label string, keepPrometh
 }
 
 func openBrowser(s string) error {
-
 	path, err := exec.LookPath("xdg-open")
 	if err != nil {
 		return fmt.Errorf("xdg-open not found: %w", err)
@@ -306,4 +315,35 @@ func openBrowser(s string) error {
 
 	cmd := exec.Command(path, s)
 	return cmd.Start()
+}
+
+func collectScenarioImages(scenario parser.Scenario) []string {
+	images := map[string]bool{}
+
+	if len(scenario.Validators) == 0 {
+		images[driver.DefaultClientDockerImageName] = true
+	}
+
+	for _, validator := range scenario.Validators {
+		if validator.ImageName != "" {
+			images[validator.ImageName] = true
+			continue
+		}
+		images[driver.DefaultClientDockerImageName] = true
+	}
+
+	for _, node := range scenario.Nodes {
+		if node.Client.ImageName != "" {
+			images[node.Client.ImageName] = true
+			continue
+		}
+		images[driver.DefaultClientDockerImageName] = true
+	}
+
+	result := make([]string, 0, len(images))
+	for image := range images {
+		result = append(result, image)
+	}
+	sort.Strings(result)
+	return result
 }

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -25,7 +25,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"sort"
 	"syscall"
 	"time"
 
@@ -34,7 +33,6 @@ import (
 
 	"github.com/0xsoniclabs/norma/analysis/report"
 	"github.com/0xsoniclabs/norma/driver"
-	"github.com/0xsoniclabs/norma/driver/docker"
 	"github.com/0xsoniclabs/norma/driver/executor"
 	"github.com/0xsoniclabs/norma/driver/monitoring"
 	_ "github.com/0xsoniclabs/norma/driver/monitoring/app"
@@ -177,14 +175,6 @@ func runScenario(ctx context.Context, path, outputDir, label string, keepPrometh
 		return err
 	}
 
-	requiredImages := collectScenarioImages(scenario)
-	if len(requiredImages) > 0 {
-		fmt.Printf("Ensuring docker images: %v\n", requiredImages)
-		if err := docker.EnsureImages(ctx, requiredImages, ""); err != nil {
-			return fmt.Errorf("failed to ensure required docker images: %w", err)
-		}
-	}
-
 	slog.Info("starting evaluation", "label", label)
 
 	// create symlink as qol (_latest => _####) where #### is the randomly generated name
@@ -315,35 +305,4 @@ func openBrowser(s string) error {
 
 	cmd := exec.Command(path, s)
 	return cmd.Start()
-}
-
-func collectScenarioImages(scenario parser.Scenario) []string {
-	images := map[string]bool{}
-
-	if len(scenario.Validators) == 0 {
-		images[driver.DefaultClientDockerImageName] = true
-	}
-
-	for _, validator := range scenario.Validators {
-		if validator.ImageName != "" {
-			images[validator.ImageName] = true
-			continue
-		}
-		images[driver.DefaultClientDockerImageName] = true
-	}
-
-	for _, node := range scenario.Nodes {
-		if node.Client.ImageName != "" {
-			images[node.Client.ImageName] = true
-			continue
-		}
-		images[driver.DefaultClientDockerImageName] = true
-	}
-
-	result := make([]string, 0, len(images))
-	for image := range images {
-		result = append(result, image)
-	}
-	sort.Strings(result)
-	return result
 }


### PR DESCRIPTION
**Summary**
This PR introduces runtime Docker image provisioning for Norma scenarios and removes Sonic image prebuilds from `Makefile`.

**Changes**
- Added `images.go` with `EnsureImages(...)` to ensure required images on demand.
  - Image strategy:
    - `sonic` -> build from upstream Sonic repo
    - `sonic:local` -> build from local sonic sources
    - `sonic:<tag>` -> build from upstream at tag
    - `sonic:<commit hash>` -> build from upstream at commit hash
    - other images -> pull from registry

- Removed eager Sonic build targets/version matrix from `Makefile`. Why:
  - Avoid building unused images.
  - Decouple scenario execution from `Makefile` image orchestration.
  - Reduce maintenance overhead of hardcoded image build targets.
  

- [x] run  la Scala scenarios to check compatibility. 