### PR TITLE
Add bls-add scenario to validate allegro

### DIFF
--- a/load/app/bls12_add_app.go
+++ b/load/app/bls12_add_app.go
@@ -1,0 +1,136 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"sync"
+	"sync/atomic"
+
+	"github.com/0xsoniclabs/norma/driver/rpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// NewBls12AddApplication creates a new application that sends transactions to
+// the BLS12-381 G1 addition precompile (address 0x0b). The precompile performs
+// elliptic curve point addition on the BLS12-381 curve.
+// This precompile has been introduced in Prague and is available in Sonic starting with Allegro.
+func NewBls12AddApplication(ctxt AppContext, feederId, appId uint32) (Application, error) {
+	client := ctxt.GetClient()
+	chainId, err := client.ChainID(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get chain ID; %w", err)
+	}
+
+	accountFactory, err := NewAccountFactory(chainId, feederId, appId)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Bls12AddApplication{
+		contractAddress: common.HexToAddress("0x0b"),
+		accountFactory:  accountFactory,
+	}, nil
+}
+
+// Bls12AddApplication exercises the BLS12-381 G1 addition precompile at address 0x0b.
+type Bls12AddApplication struct {
+	contractAddress common.Address
+	accountFactory  *AccountFactory
+	mu              sync.Mutex       // guards userAddresses
+	userAddresses   []common.Address // tracks accounts to query nonces from
+}
+
+// CreateUsers creates the specified number of users, each with a unique funded
+// account, to send BLS12 addition transactions concurrently.
+func (app *Bls12AddApplication) CreateUsers(appContext AppContext, numUsers int) ([]User, error) {
+	users := make([]User, numUsers)
+	addresses := make([]common.Address, numUsers)
+	for i := 0; i < numUsers; i++ {
+		// Generate a new account for each worker - avoid account nonces related bottlenecks
+		workerAccount, err := app.accountFactory.CreateAccount(appContext.GetClient())
+		if err != nil {
+			return nil, err
+		}
+		users[i] = &Bls12AddUser{
+			sender:   workerAccount,
+			contract: app.contractAddress,
+		}
+		addresses[i] = workerAccount.address
+	}
+
+	fundsPerUser := big.NewInt(1_000)
+	fundsPerUser = new(big.Int).Mul(fundsPerUser, big.NewInt(1_000_000_000_000_000_000)) // to wei
+	err := appContext.FundAccounts(addresses, fundsPerUser)
+
+	app.mu.Lock()
+	app.userAddresses = append(app.userAddresses, addresses...)
+	app.mu.Unlock()
+
+	return users, err
+}
+
+// GetReceivedTransactions returns the total number of transactions processed
+// by summing the on-chain nonces of all user accounts. Each successful
+// transaction increments the sender's nonce, so the sum across all users
+// equals the total number of received transactions.
+func (app *Bls12AddApplication) GetReceivedTransactions(rpcClient rpc.Client) (uint64, error) {
+	app.mu.Lock()
+	addresses := make([]common.Address, len(app.userAddresses))
+	copy(addresses, app.userAddresses)
+	app.mu.Unlock()
+
+	var total uint64
+	for _, addr := range addresses {
+		nonce, err := rpcClient.NonceAt(context.Background(), addr, nil)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get nonce for %v; %w", addr, err)
+		}
+		total += nonce
+	}
+	return total, nil
+}
+
+// Bls12AddUser generates transactions that invoke the BLS12-381 G1 addition
+// precompile with a valid pair of curve points.
+type Bls12AddUser struct {
+	sender   *Account
+	contract common.Address
+	sentTxs  atomic.Uint64
+}
+
+// GenerateTx creates a transaction calling the BLS12-381 G1 addition
+// precompile with two valid G1 points encoded as ABI-style calldata.
+func (g *Bls12AddUser) GenerateTx() (*types.Transaction, error) {
+	// Valid example input for bls12 addition
+	data := common.FromHex("0x0000000000000000000000000000000017f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb0000000000000000000000000000000008b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e100000000000000000000000000000000112b98340eee2777cc3c14163dea3ec97977ac3dc5c70da32e6e87578f44912e902ccef9efe28d4a78b8999dfbca942600000000000000000000000000000000186b28d92356c4dfec4b5201ad099dbdede3781f8998ddf929b4cd7756192185ca7b8f4ef7088f813270ac3d48868a21")
+
+	const gasLimit = 45_000 // add extra gas for data floor gas
+	tx, err := createTx(g.sender, g.contract, big.NewInt(0), data, gasLimit)
+	if err == nil {
+		g.sentTxs.Add(1)
+	}
+	return tx, err
+}
+
+// GetSentTransactions returns the number of transactions this user has sent.
+func (g *Bls12AddUser) GetSentTransactions() uint64 {
+	return g.sentTxs.Load()
+}

--- a/load/app/bls12_add_app_test.go
+++ b/load/app/bls12_add_app_test.go
@@ -1,0 +1,121 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package app_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/0xsoniclabs/norma/driver"
+	"github.com/0xsoniclabs/norma/driver/network"
+	"github.com/0xsoniclabs/norma/driver/network/local"
+	"github.com/0xsoniclabs/norma/load/app"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// TestBls12AddApplication verifies that the BLS12-381 G1 addition precompile
+// application can generate and process transactions on an Allegro network.
+func TestBls12AddApplication(t *testing.T) {
+	rules := map[string]string{
+		"UPGRADES_SONIC":   "true",
+		"UPGRADES_ALLEGRO": "true",
+	}
+	net, err := local.NewLocalNetwork(t.Context(), &driver.NetworkConfig{
+		Validators:   driver.DefaultValidators,
+		NetworkRules: rules,
+	})
+	if err != nil {
+		t.Fatalf("failed to create local network: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := net.Shutdown(); err != nil {
+			t.Fatalf("failed to shutdown network: %v", err)
+		}
+	})
+
+	primaryAccount, err := app.NewAccount(0, PrivateKey, FakeNetworkID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctxt, err := app.NewContext(net, primaryAccount, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ctxt.Close()
+
+	application, err := app.NewBls12AddApplication(ctxt, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	users, err := application.CreateUsers(ctxt, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(users) != 1 {
+		t.Fatalf("unexpected number of users created, wanted 1, got %d", len(users))
+	}
+	user := users[0]
+
+	rpcClient := ctxt.GetClient()
+	numTransactions := 10
+	transactions := []*types.Transaction{}
+	for range numTransactions {
+		tx, err := user.GenerateTx()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tx == nil {
+			t.Fatal("generated transaction is nil")
+		}
+		if err := rpcClient.SendTransaction(t.Context(), tx); err != nil {
+			t.Fatal(err)
+		}
+		transactions = append(transactions, tx)
+	}
+
+	// wait for the transactions to be processed
+	for _, tx := range transactions {
+		receipt, err := ctxt.GetReceipt(tx.Hash())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if receipt.Status != types.ReceiptStatusSuccessful {
+			t.Fatalf("transaction failed, receipt status: %v (gas limit %d used %d)", receipt.Status, tx.Gas(), receipt.GasUsed)
+		}
+	}
+
+	if got, want := user.GetSentTransactions(), numTransactions; got != uint64(want) {
+		t.Errorf("invalid number of sent transactions reported, wanted %d, got %d", want, got)
+	}
+
+	err = network.Retry(t.Context(), network.DefaultRetryAttempts, 1*time.Second, func() error {
+		received, err := application.GetReceivedTransactions(rpcClient)
+		if err != nil {
+			return fmt.Errorf("unable to get amount of received txs; %v", err)
+		}
+		if received != uint64(numTransactions) {
+			return fmt.Errorf("unexpected amount of txs in chain, wanted %d, got %d", numTransactions, received)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/load/app/factory.go
+++ b/load/app/factory.go
@@ -68,6 +68,8 @@ func getFactory(appType string) appFactoryFunc {
 		return NewFailingBundleApplication
 	case "duplicatedbundle":
 		return NewDuplicatedBundleApplication
+	case "bls12add":
+		return NewBls12AddApplication
 	case "mix":
 		return NewMixApplication
 	}

--- a/scenarios/bls_add_allegro.yml
+++ b/scenarios/bls_add_allegro.yml
@@ -1,0 +1,40 @@
+# This scenario ensures that sonic versions starting from 2.1.x support the bls12_add precompile,
+# which has been added in Allegro.
+
+# The name of the scenario
+name: BLS12-Add Precompile AllegroUpgrade
+
+# The duration of the scenario's runtime, in seconds.
+duration: 60
+
+validators:
+  - name: validator-local
+    imagename: "sonic:local"
+    instances: 2
+
+  - name: validator-v216
+    imagename: "sonic:v2.1.6"
+
+  - name: validator-v203
+    imagename: "sonic:v2.0.3"
+    failing: true
+
+network_rules:
+  genesis:
+    UPGRADES_SONIC: true
+    UPGRADES_ALLEGRO: false
+    UPGRADES_BRIO: false
+  updates:
+    # Upgrade to Allegro
+    - time: 30
+      rules:
+        UPGRADES_ALLEGRO: true
+
+# In the network there is a single application producing constant load.
+applications:
+  - name: load
+    type: bls12add
+    start: 10          # start time
+    end: 50            # termination time
+    rate:
+      constant: 200    # Tx/s


### PR DESCRIPTION
This PR adds a new app and scenario that calls the bls12-addition pre-compile with a valid input. Versions that do not support this pre-compiled contract which has been introduced in Allegro produce a different block hash.