### PR TITLE
Use slog or t.log instead of fmt.print.

### DIFF
--- a/driver/checking/block_height.go
+++ b/driver/checking/block_height.go
@@ -18,11 +18,13 @@ package checking
 
 import (
 	"fmt"
-	"github.com/0xsoniclabs/norma/driver"
-	"github.com/0xsoniclabs/norma/driver/monitoring"
+	"log/slog"
 	"maps"
 	"strconv"
 	"strings"
+
+	"github.com/0xsoniclabs/norma/driver"
+	"github.com/0xsoniclabs/norma/driver/monitoring"
 )
 
 // allow block height to fall short by this amount
@@ -60,7 +62,7 @@ func (c *blockHeightChecker) Configure(config CheckerConfig) Checker {
 
 func (c *blockHeightChecker) Check() error {
 	nodes := c.net.GetActiveNodes()
-	fmt.Printf("checking block heights for %d nodes\n", len(nodes))
+	slog.Info("checking block heights for nodes", "count", len(nodes))
 	heights := make([]int64, len(nodes))
 	maxHeight := int64(0)
 	expectedFailures := make(map[string]struct{})

--- a/driver/checking/blocks_hashes.go
+++ b/driver/checking/blocks_hashes.go
@@ -18,12 +18,14 @@ package checking
 
 import (
 	"fmt"
+	"log/slog"
+	"maps"
+
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/monitoring"
 	"github.com/0xsoniclabs/norma/driver/rpc"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"maps"
 )
 
 func init() {
@@ -44,7 +46,7 @@ func (c *blocksHashesChecker) Configure(config CheckerConfig) Checker {
 
 func (c *blocksHashesChecker) Check() (err error) {
 	nodes := c.net.GetActiveNodes()
-	fmt.Printf("checking hashes for %d nodes\n", len(nodes))
+	slog.Info("checking hashes for nodes", "count", len(nodes))
 
 	rpcClients := make([]rpc.Client, len(nodes))
 	defer func() {

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -91,7 +91,7 @@ func run(
 			}
 		}
 	} else {
-		fmt.Printf("Network checks skipped\n")
+		slog.Info("Network checks skipped")
 	}
 
 	// Schedule all operations listed in the scenario.

--- a/driver/executor/executor_test.go
+++ b/driver/executor/executor_test.go
@@ -327,7 +327,7 @@ func TestExecutor_TestUserAbort(t *testing.T) {
 
 	// In this scenario, a node is created, after which the context is cancelled.
 	net.EXPECT().CreateNode(gomock.Any()).Do(func(_ any) {
-		fmt.Printf("Cancelling context to simulate user abort ..\n")
+		t.Log("Cancelling context to simulate user abort ..")
 		cancel()
 	}).Return(node, nil)
 

--- a/driver/monitoring/node/block_progress_test.go
+++ b/driver/monitoring/node/block_progress_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"math"
 	"net"
 	"net/http"
@@ -176,7 +177,7 @@ func StartTestRpcServer() (*TestRpcServer, error) {
 		}
 		ready <- nil
 		if err := server.Serve(ln); err != http.ErrServerClosed {
-			fmt.Printf("server failed: %v\n", err)
+			slog.Error("server failed", "error", err)
 		}
 	}()
 	if err := <-ready; err != nil {
@@ -187,7 +188,7 @@ func StartTestRpcServer() (*TestRpcServer, error) {
 
 func (s *TestRpcServer) Shutdown() {
 	if err := s.server.Shutdown(context.Background()); err != nil {
-		fmt.Printf("failed to shutdown test RPC server: %v\n", err)
+		slog.Error("failed to shutdown test RPC server", "error", err)
 	}
 	<-s.done
 }

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"regexp"
 	"slices"
@@ -213,11 +214,11 @@ func StartOperaDockerNode(ctx context.Context, client *docker.Client, dn *docker
 func printLog(node *OperaNode) error {
 	reader, err := node.StreamLog()
 	if err != nil {
-		return fmt.Errorf("cannot read node logs: %e", err)
+		return fmt.Errorf("cannot read node logs: %w", err)
 	}
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
-		fmt.Printf("[Opera Node %s] %s\n", node.GetLabel(), scanner.Text())
+		slog.Info("[Opera Node]", "label", node.GetLabel(), "message", scanner.Text())
 	}
 	return reader.Close()
 }

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"regexp"
 	"slices"
@@ -218,7 +217,7 @@ func printLog(node *OperaNode) error {
 	}
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
-		slog.Info("[Opera Node]", "label", node.GetLabel(), "message", scanner.Text())
+		fmt.Printf("[Opera Node %s] %s\n", node.GetLabel(), scanner.Text())
 	}
 	return reader.Close()
 }

--- a/driver/norma/check.go
+++ b/driver/norma/check.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/0xsoniclabs/norma/driver/parser"
 	"github.com/urfave/cli/v2"
@@ -39,7 +40,7 @@ func check(ctx *cli.Context) (err error) {
 	}
 
 	path := args.First()
-	fmt.Printf("Trying to parse '%s' ...\n", path)
+	slog.Info("Trying to parse", "path", path)
 
 	scenario, err := parser.ParseFile(path)
 	if err != nil {
@@ -50,6 +51,6 @@ func check(ctx *cli.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("All checks passed!\n")
+	slog.Info("All checks passed!", "path", path)
 	return nil
 }

--- a/driver/norma/diff.go
+++ b/driver/norma/diff.go
@@ -19,6 +19,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/0xsoniclabs/norma/analysis/report"
@@ -69,6 +70,6 @@ func diff(ctx *cli.Context) (err error) {
 		return err
 	}
 
-	fmt.Printf("Generated report at file://%s/%s\n", currentDir, result)
+	slog.Info("Generated diff report at", "path", fmt.Sprintf("file://%s/%s", currentDir, result))
 	return nil
 }

--- a/driver/norma/purge.go
+++ b/driver/norma/purge.go
@@ -17,7 +17,7 @@
 package main
 
 import (
-	"fmt"
+	"log/slog"
 
 	"github.com/0xsoniclabs/norma/driver/docker"
 	"github.com/urfave/cli/v2"
@@ -32,11 +32,11 @@ var purgeCommand = cli.Command{
 }
 
 func purge(_ *cli.Context) error {
-	fmt.Printf("Purging all resources...\n")
+	slog.Info("Purging all resources...")
 	err := docker.Purge()
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Done.\n")
+	slog.Info("Done.")
 	return nil
 }

--- a/driver/norma/render.go
+++ b/driver/norma/render.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/0xsoniclabs/norma/analysis/report"
@@ -48,6 +49,6 @@ func render(ctx *cli.Context) error {
 		return err
 	}
 
-	fmt.Printf("Generated report at file://%s/%s\n", currentDir, result)
+	slog.Info("Rendered report at", "path", fmt.Sprintf("file://%s/%s", currentDir, result))
 	return nil
 }

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -108,7 +109,7 @@ func run(ctx *cli.Context) (err error) {
 	defer stop()
 	go func() {
 		<-stoppableCtx.Done()
-		fmt.Printf("Stopping...\n")
+		slog.Info("Stopping...")
 		stop() // second Ctrl+C will force-kill
 	}()
 
@@ -157,7 +158,7 @@ func runScenario(ctx context.Context, path, outputDir, label string, keepPrometh
 		return fmt.Errorf("couldn't create temp dir for output; %w", err)
 	}
 
-	fmt.Printf("Reading '%s' ...\n", path)
+	slog.Info("Reading scenario file", "path", path)
 	scenario, err := parser.ParseFile(path)
 	if err != nil {
 		return err
@@ -167,7 +168,7 @@ func runScenario(ctx context.Context, path, outputDir, label string, keepPrometh
 		return err
 	}
 
-	fmt.Printf("Starting evaluation %s\n", label)
+	slog.Info("Starting evaluation", "label", label)
 
 	// create symlink as qol (_latest => _####) where #### is the randomly generated name
 	symlink := filepath.Join(filepath.Dir(outputDir), fmt.Sprintf("norma_data_%s_latest", label))
@@ -180,7 +181,7 @@ func runScenario(ctx context.Context, path, outputDir, label string, keepPrometh
 		return fmt.Errorf("failed to create _latest symlink: %w", err)
 	}
 
-	fmt.Printf("Monitoring data is written to %v\n", outputDir)
+	slog.Info("Monitoring data is written", "output", outputDir)
 
 	// Copy scenario yml to outputDir as well to provide context
 	data, err := os.ReadFile(path)
@@ -195,9 +196,9 @@ func runScenario(ctx context.Context, path, outputDir, label string, keepPrometh
 	clock := executor.NewWallTimeClock()
 
 	// Startup network.
-	fmt.Printf("Network RoundTripTime: %v\n", scenario.GetRoundTripTime())
+	slog.Info("Network RoundTripTime", "value", scenario.GetRoundTripTime())
 	for k, v := range scenario.NetworkRules.Genesis {
-		fmt.Printf("Network Rule: %s: %s\n", k, v)
+		slog.Info("Network Rule", "key", k, "value", v)
 	}
 
 	net, err := local.NewLocalNetwork(ctx, &driver.NetworkConfig{
@@ -210,9 +211,9 @@ func runScenario(ctx context.Context, path, outputDir, label string, keepPrometh
 		return err
 	}
 	defer func() {
-		fmt.Printf("Shutting down network ...\n")
+		slog.Info("Shutting down network ...")
 		if err := net.Shutdown(); err != nil {
-			fmt.Printf("error during network shutdown:\n%v", err)
+			slog.Error("error during network shutdown", "error", err)
 		}
 	}()
 
@@ -225,23 +226,23 @@ func runScenario(ctx context.Context, path, outputDir, label string, keepPrometh
 		return err
 	}
 	defer func() {
-		fmt.Printf("Shutting down data monitor ...\n")
+		slog.Info("Shutting down data monitor ...")
 		if err := monitor.Shutdown(); err != nil {
-			fmt.Printf("error during monitor shutdown:\n%v\n", err)
+			slog.Error("error during monitor shutdown", "error", err)
 		}
-		fmt.Printf("Monitoring data was written to %v\n", outputDir)
-		fmt.Printf("Raw data was exported to %s\n", monitor.GetMeasurementFileName())
+		slog.Info("Monitoring data was written", "output", outputDir)
+		slog.Info("Raw data was exported", "file", monitor.GetMeasurementFileName())
 
 		if !skipReportRendering && ctx.Err() == nil {
-			fmt.Printf("Rendering summary report (may take a few minutes the first time if R packages need to be installed) ...\n")
+			slog.Info("Rendering summary report (may take a few minutes the first time if R packages need to be installed) ...")
 			if file, err := report.SingleEvalReport.Render(monitor.GetMeasurementFileName(), outputDir); err != nil {
-				fmt.Printf("Report generation failed:\n%v\n", err)
+				slog.Error("Report generation failed", "error", err)
 			} else {
-				fmt.Printf("Summary report was exported to file://%s/%s\n", outputDir, file)
+				slog.Info("Summary report was exported", "file", fmt.Sprintf("file://%s/%s", outputDir, file))
 			}
 		} else {
-			fmt.Printf("Report rendering skipped\n")
-			fmt.Printf("To render report run `norma render %s`\n", monitor.GetMeasurementFileName())
+			slog.Info("Report rendering skipped")
+			slog.Info(fmt.Sprintf("To render report run `norma render %s`", monitor.GetMeasurementFileName()))
 		}
 	}()
 
@@ -251,16 +252,16 @@ func runScenario(ctx context.Context, path, outputDir, label string, keepPrometh
 	}
 
 	// Run prometheus.
-	fmt.Printf("Starting Prometheus ...\n")
+	slog.Info("Starting Prometheus ...")
 	prom, err := prometheusmon.Start(net, net.GetDockerNetwork())
 	if err != nil {
-		fmt.Printf("error starting Prometheus:\n%v", err)
+		slog.Error("error starting Prometheus", "error", err)
 	}
 	defer func() {
 		if !keepPrometheusRunning && prom != nil {
-			fmt.Printf("Shutting down Prometheus ...\n")
+			slog.Info("Shutting down Prometheus ...")
 			if err := prom.Shutdown(); err != nil {
-				fmt.Printf("error during Prometheus shutdown:\n%v", err)
+				slog.Error("error during Prometheus shutdown", "error", err)
 			}
 		}
 	}()
@@ -272,14 +273,14 @@ func runScenario(ctx context.Context, path, outputDir, label string, keepPrometh
 	}
 
 	// Run scenario.
-	fmt.Printf("Running '%s' ...\n", path)
+	slog.Info("Running scenario", "path", path)
 	logger := startProgressLogger(monitor, net)
 	defer logger.shutdown()
 	err = executor.Run(ctx, clock, net, &scenario, checks)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Execution completed successfully!\n")
+	slog.Info("Execution completed successfully")
 
 	return nil
 }

--- a/driver/parser/check_test.go
+++ b/driver/parser/check_test.go
@@ -17,7 +17,6 @@
 package parser
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -495,8 +494,7 @@ func TestScenario_CheatIssuesAreDetected(t *testing.T) {
 		},
 	}
 	if err := scenario.Check(); err == nil || !strings.Contains(err.Error(), "start time must be <= scenario duration") {
-		fmt.Println(err)
-		t.Errorf("cheat issue was not detected")
+		t.Errorf("cheat issue was not detected: %v", err)
 	}
 }
 

--- a/genesis/app/validator.go
+++ b/genesis/app/validator.go
@@ -131,10 +131,11 @@ func generateValidatorFrom(ctx *cli.Context) (err error) {
 
 	// Print it out for user
 	// <pubkey> <pub address> <path-to-secret>
-	slog.Info("Generated validator key",
-		"pubkey", publicKey.String(),
-		"address", crypto.PubkeyToAddress(privateKeyECDSA.PublicKey),
-		"secretFile", pathSecretFile)
+	fmt.Printf("%s %s %s",
+		publicKey.String(),
+		crypto.PubkeyToAddress(privateKeyECDSA.PublicKey),
+		pathSecretFile,
+	)
 
 	return nil
 }

--- a/genesis/app/validator.go
+++ b/genesis/app/validator.go
@@ -20,6 +20,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"log/slog"
 	"path"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
@@ -75,7 +76,7 @@ var validatorCommand = cli.Command{
 func generateValidatorFrom(ctx *cli.Context) (err error) {
 	datadir := ctx.String("data-directory")
 	if datadir == "" {
-		fmt.Println("--data-directory unset; skipping secret file generation.")
+		slog.Info("--data-directory unset; skipping secret file generation.")
 	}
 
 	id := ctx.Int("validator-id")
@@ -130,11 +131,10 @@ func generateValidatorFrom(ctx *cli.Context) (err error) {
 
 	// Print it out for user
 	// <pubkey> <pub address> <path-to-secret>
-	fmt.Printf("%s %s %s",
-		publicKey.String(),
-		crypto.PubkeyToAddress(privateKeyECDSA.PublicKey),
-		pathSecretFile,
-	)
+	slog.Info("Generated validator key",
+		"pubkey", publicKey.String(),
+		"address", crypto.PubkeyToAddress(privateKeyECDSA.PublicKey),
+		"secretFile", pathSecretFile)
 
 	return nil
 }

--- a/load/app/bundle_app_test.go
+++ b/load/app/bundle_app_test.go
@@ -97,7 +97,7 @@ func testBundleGenerator(t *testing.T, application app.Application, ctxt app.App
 			// DuplicatedBundle intentionally re-sends the same plan after it has been
 			// committed, so ErrBundleAlreadyProcessed is expected in that case.
 			if strings.Contains(err.Error(), "already been processed") {
-				fmt.Printf("bundle %d: plan already processed, skipping wait\n", i)
+				t.Logf("bundle already processed, skipping wait (bundle %d)", i)
 				continue
 			}
 			t.Fatal(err)
@@ -108,7 +108,7 @@ func testBundleGenerator(t *testing.T, application app.Application, ctxt app.App
 			t.Fatalf("failed to open bundle envelope: %v", err)
 		}
 		planHash := txBundle.Plan.Hash()
-		fmt.Printf("Sent bundle %d (plan %s)\n", i, planHash)
+		t.Log("Sent bundle", "bundle", i, "plan", planHash)
 
 		// Wait for this bundle to execute before sending the next one so that
 		// the pending nonce of the inner-transaction accounts is up to date.
@@ -118,7 +118,12 @@ func testBundleGenerator(t *testing.T, application app.Application, ctxt app.App
 		if err != nil {
 			t.Fatalf("bundle %d (plan %s) not executed: %v", i, planHash, err)
 		}
-		fmt.Printf("bundle %d (plan %s) executed: block=%d position=%d count=%d\n", i, planHash, info.Block, info.Position, info.Count)
+		t.Log("Bundle executed",
+			"bundle", i,
+			"plan", planHash,
+			"block", info.Block,
+			"position", info.Position,
+			"count", info.Count)
 	}
 
 	err = network.Retry(t.Context(), network.DefaultRetryAttempts, 1*time.Second, func() error {
@@ -160,10 +165,10 @@ func testRpcNonceBundleGenerator(t *testing.T, application app.Application, ctxt
 		}
 
 		if err := rpcClient.SendTransaction(t.Context(), tx); err != nil {
-			fmt.Printf("eth_sendRawTransaction failed for randomly failing bundle (expected): %v\n", err)
+			t.Logf("eth_sendRawTransaction failed for randomly failing bundle (expected): %v\n", err)
 			continue
 		}
-		fmt.Printf("Sent bundle %d\n", i)
+		t.Logf("Sent bundle %d\n", i)
 
 		// wait for tx to be processed (necessary because of nonce loading in GenerateTx())
 		_ = network.Retry(t.Context(), 5, 1*time.Second, func() error {
@@ -172,7 +177,7 @@ func testRpcNonceBundleGenerator(t *testing.T, application app.Application, ctxt
 				return fmt.Errorf("unable to get amount of received txs; %v", err)
 			}
 			if received <= lastReceived {
-				fmt.Printf("Waiting for received txs increase before sending next tx (received %d)\n", received)
+				t.Logf("Waiting for received txs increase before sending next tx (received %d)\n", received)
 				return fmt.Errorf("not enough bundled txs received, received %d", received)
 			}
 			lastReceived = received


### PR DESCRIPTION
This PR replaces uses of `fmt.Println` or `fmt.Printf` and replaces with either `slog.` or `t.Logf` as better fitting to each location.
The aim of these changes is to get a more homogenous log when running scenarios with Norma. 