### PR TITLE
Add build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ BUILD_DIR := $(CURDIR)/build
 
 all: \
     norma \
-	pull-hello-world-image \
+    pull-hello-world-image \
     pull-alpine-image \
     pull-prometheus-image \
 	build-r-renderer-image

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,22 @@ BUILD_DIR := $(CURDIR)/build
 
 all: \
     norma \
-	build-docker
+	pull-hello-world-image \
+    pull-alpine-image \
+    pull-prometheus-image \
+	build-r-renderer-image
 
-build-docker: norma
-	go run ./driver/norma build
+pull-hello-world-image:
+	DOCKER_BUILDKIT=1 docker image pull hello-world
+
+pull-alpine-image:
+	DOCKER_BUILDKIT=1 docker image pull alpine
+
+pull-prometheus-image:
+	DOCKER_BUILDKIT=1 docker image pull prom/prometheus:v2.44.0
+
+build-r-renderer-image:
+	DOCKER_BUILDKIT=1 docker build analysis/report/ -t norma-r-renderer
 
 generate-abi: load/contracts/abi/Counter.abi load/contracts/abi/ERC20.abi load/contracts/abi/Store.abi load/contracts/abi/UniswapV2Pair.abi load/contracts/abi/UniswapRouter.abi load/contracts/abi/Helper.abi load/contracts/abi/SmartAccount.abi load/contracts/abi/EntryPoint.abi load/contracts/abi/TransientCounter.abi load/contracts/abi/SelfDestructOldContract.abi load/contracts/abi/SelfDestructNewContract.abi load/contracts/abi/EcdsaCounter.abi load/contracts/abi/LargeContract.abi load/contracts/abi/ProbabilisticFailing.abi # requires installed solc and Ethereum abigen - check README.md
 

--- a/Makefile
+++ b/Makefile
@@ -20,22 +20,10 @@ BUILD_DIR := $(CURDIR)/build
 
 all: \
     norma \
-    pull-hello-world-image \
-    pull-alpine-image \
-    pull-prometheus-image \
-	build-r-renderer-image
+	build-docker
 
-pull-hello-world-image:
-	DOCKER_BUILDKIT=1 docker image pull hello-world
-
-pull-alpine-image:
-	DOCKER_BUILDKIT=1 docker image pull alpine
-
-pull-prometheus-image:
-	DOCKER_BUILDKIT=1 docker image pull prom/prometheus:v2.44.0
-
-build-r-renderer-image:
-	DOCKER_BUILDKIT=1 docker build analysis/report/ -t norma-r-renderer
+build-docker: norma
+	go run ./driver/norma build
 
 generate-abi: load/contracts/abi/Counter.abi load/contracts/abi/ERC20.abi load/contracts/abi/Store.abi load/contracts/abi/UniswapV2Pair.abi load/contracts/abi/UniswapRouter.abi load/contracts/abi/Helper.abi load/contracts/abi/SmartAccount.abi load/contracts/abi/EntryPoint.abi load/contracts/abi/TransientCounter.abi load/contracts/abi/SelfDestructOldContract.abi load/contracts/abi/SelfDestructNewContract.abi load/contracts/abi/EcdsaCounter.abi load/contracts/abi/LargeContract.abi load/contracts/abi/ProbabilisticFailing.abi # requires installed solc and Ethereum abigen - check README.md
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ make test
 ```
 To clean up a build, use `make clean`.
 
+Norma also counts with a native build command
+```
+go run ./driver/norma build
+```
+which build all the docker images needed by the scenarios in `./scenarios`. One can alternatively provide a specific path for the scenarios.
+
 ## Running
 
 To run Norma, you can run the `norma` executable created by the build process:
@@ -54,6 +60,10 @@ build/norma <cmd> <args...>
 To list the available commands, run
 ```
 build/norma
+```
+Alternatively use 
+```
+go run ./driver/norma
 ```
 
 
@@ -93,7 +103,11 @@ alternatively
 The experiments use the docker image that wraps the Sonic client. The image is built as part of
 the build process, and can be explicitly triggered:
 ```
-make build-docker-image
+make build-docker
+```
+or
+```
+go run ./driver/norma build
 ```
 
 ### Commands

--- a/README.md
+++ b/README.md
@@ -103,10 +103,6 @@ alternatively
 The experiments use the docker image that wraps the Sonic client. The image is built as part of
 the build process, and can be explicitly triggered:
 ```
-make build-docker
-```
-or
-```
 go run ./driver/norma build
 ```
 

--- a/analysis/report/Dockerfile
+++ b/analysis/report/Dockerfile
@@ -1,5 +1,8 @@
 # Dockerfile for the Norma R report renderer.
-# Build with: make build-r-renderer-image
+# Build with: 
+#    make build-docker 
+# or
+#    go run ./driver/norma build
 #
 # rocker/tidyverse already includes R, rmarkdown, knitr, pandoc, and the full
 # tidyverse (including lubridate). Only `slider` needs to be added on top.

--- a/analysis/report/Dockerfile
+++ b/analysis/report/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile for the Norma R report renderer.
 # Build with: 
-#    make build-docker 
+#    make build-r-renderer-image
 # or
 #    go run ./driver/norma build
 #

--- a/driver/docker/images.go
+++ b/driver/docker/images.go
@@ -96,13 +96,13 @@ func EnsureImages(ctx context.Context, imageRefs []string, buildRoot string) err
 		buildRoot = cwd
 	}
 
-	buildRoot, err := resolveBuildRoot(buildRoot)
+	buildRoot, err := ResolveBuildRoot(buildRoot)
 	if err != nil {
 		return err
 	}
 	slog.Info("resolved build root", "path", buildRoot)
 
-	refs := deduplicateAndSort(imageRefs)
+	refs := NormalizeImageRefs(imageRefs)
 	slog.Info("checking images", "refs", refs)
 	cli, err := NewClient()
 	if err != nil {
@@ -134,6 +134,24 @@ func EnsureImages(ctx context.Context, imageRefs []string, buildRoot string) err
 	}
 
 	return nil
+}
+
+// NormalizeImageRefs removes empty refs, deduplicates, and returns image refs
+// in lexical order.
+func NormalizeImageRefs(in []string) []string {
+	set := map[string]bool{}
+	for _, imageRef := range in {
+		if strings.TrimSpace(imageRef) == "" {
+			continue
+		}
+		set[imageRef] = true
+	}
+	out := make([]string, 0, len(set))
+	for imageRef := range set {
+		out = append(out, imageRef)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // pullImage pulls imageRef from the configured registry and consumes the entire
@@ -195,6 +213,10 @@ func planImage(imageRef string) imageBuildPlan {
 	if imageRef == "sonic:local" {
 		return imageBuildPlan{kind: imageBuildSonicLocal, clientSrc: "sonic"}
 	}
+	if imageRef == "sonic:latest" {
+		// "latest" is a Docker tag convention, not a git ref; build from repo HEAD.
+		return imageBuildPlan{kind: imageBuildSonicRemote, clientSrc: sonicRepositoryURL}
+	}
 	if strings.HasPrefix(imageRef, "sonic:") {
 		tag := strings.TrimPrefix(imageRef, "sonic:")
 		if tag != "" {
@@ -207,24 +229,23 @@ func planImage(imageRef string) imageBuildPlan {
 	return imageBuildPlan{kind: imageBuildNone}
 }
 
+// WillBuildImage reports whether EnsureImages will build (not pull) the given
+// image reference.
+//
+// This is true for Sonic image refs handled via local or remote source build
+// contexts (e.g. sonic, sonic:local, sonic:<tag-or-commit>). For all other
+// refs, EnsureImages will pull instead.
+func WillBuildImage(imageRef string) bool {
+	plan := planImage(imageRef)
+	return plan.kind == imageBuildSonicRemote || plan.kind == imageBuildSonicLocal
+}
+
 // deduplicateAndSort removes blank entries, deduplicates refs, and returns
 // them in lexical order.
 //
 // Sorting keeps execution deterministic and log output stable across runs.
 func deduplicateAndSort(in []string) []string {
-	set := map[string]bool{}
-	for _, imageRef := range in {
-		if strings.TrimSpace(imageRef) == "" {
-			continue
-		}
-		set[imageRef] = true
-	}
-	out := make([]string, 0, len(set))
-	for imageRef := range set {
-		out = append(out, imageRef)
-	}
-	sort.Strings(out)
-	return out
+	return NormalizeImageRefs(in)
 }
 
 // resolveBuildRoot finds the Norma repository root to execute docker builds.
@@ -237,6 +258,19 @@ func deduplicateAndSort(in []string) []string {
 // This guards against running docker build in unrelated directories while
 // keeping call sites simple.
 func resolveBuildRoot(startDir string) (string, error) {
+	return ResolveBuildRoot(startDir)
+}
+
+// ResolveBuildRoot finds the Norma repository root to execute docker builds.
+//
+// Starting from startDir, it walks up parent directories until it finds a
+// directory containing both:
+//   - Dockerfile
+//   - scripts/run_sonic.sh
+//
+// This guards against running docker build in unrelated directories while
+// keeping call sites simple.
+func ResolveBuildRoot(startDir string) (string, error) {
 	dir, err := filepath.Abs(startDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve build root: %w", err)

--- a/driver/network.go
+++ b/driver/network.go
@@ -33,6 +33,15 @@ const DefaultClientDockerImageName = "sonic"
 // DefaultValidators is a default configuration for a single validator.
 var DefaultValidators = NewDefaultValidators(1)
 
+// ResolveClientImageName returns imageName if set, otherwise the default client
+// image name.
+func ResolveClientImageName(imageName string) string {
+	if imageName != "" {
+		return imageName
+	}
+	return DefaultClientDockerImageName
+}
+
 const (
 	// ErrEmptyNetwork is returned when trying to connect to an empty network.
 	ErrEmptyNetwork = common.ConstError("network is empty")
@@ -156,10 +165,7 @@ func NewValidator(v parser.Validator) Validator {
 	if v.Instances != nil {
 		instances = *v.Instances
 	}
-	imageName := DefaultClientDockerImageName
-	if v.ImageName != "" {
-		imageName = v.ImageName
-	}
+	imageName := ResolveClientImageName(v.ImageName)
 
 	stake := uint64(5_000_000)
 	if v.Stake != nil {

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -162,10 +162,7 @@ func StartOperaDockerNode(ctx context.Context, client *docker.Client, dn *docker
 		return nil, fmt.Errorf("invalid label for node: '%v'", config.Label)
 	}
 
-	image := config.Image
-	if image == "" {
-		image = driver.DefaultClientDockerImageName
-	}
+	image := driver.ResolveClientImageName(config.Image)
 	if err := ensureImageAvailable(ctx, image); err != nil {
 		return nil, fmt.Errorf("failed to ensure image %q: %w", image, err)
 	}

--- a/driver/norma/build.go
+++ b/driver/norma/build.go
@@ -35,9 +35,10 @@ import (
 // Run with `go run ./driver/norma build <scenario-dir-or-file>`
 
 var buildCommand = cli.Command{
-	Action: build,
-	Name:   "build",
-	Usage:  "builds required Sonic and report renderer Docker images for scenarios",
+	Action:    build,
+	Name:      "build",
+	Usage:     "builds required Sonic and report renderer Docker images for scenarios",
+	UsageText: "norma build [--dry-run] [<scenario-dir-or-file>=scenarios]",
 	Flags: []cli.Flag{
 		&dryRun,
 	},

--- a/driver/norma/build.go
+++ b/driver/norma/build.go
@@ -1,0 +1,223 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/0xsoniclabs/norma/driver"
+	"github.com/0xsoniclabs/norma/driver/docker"
+	"github.com/0xsoniclabs/norma/driver/parser"
+	"github.com/urfave/cli/v2"
+)
+
+// Run with `go run ./driver/norma build <scenario-dir-or-file>`
+
+var buildCommand = cli.Command{
+	Action: build,
+	Name:   "build",
+	Usage:  "builds required Sonic and report renderer Docker images for scenarios",
+	Flags: []cli.Flag{
+		&dryRun,
+	},
+}
+
+var dryRun = cli.BoolFlag{
+	Name:  "dry-run",
+	Usage: "prints images and docker build commands without running them",
+}
+
+func build(ctx *cli.Context) error {
+	// by default, look for scenarios in the "scenarios" directory
+	targetPath := "scenarios"
+	if ctx.Args().Len() > 0 {
+		targetPath = ctx.Args().First()
+	}
+	runDry := ctx.Bool(dryRun.Name)
+
+	// Collect scenario files from the selected path.
+	files, err := collectScenarioFiles(targetPath)
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("no scenario files found in %q", targetPath)
+	}
+
+	// Parse scenarios and gather client image refs that EnsureImages would build.
+	images, err := collectBuildableImages(files)
+	if err != nil {
+		return err
+	}
+
+	slog.Info("build plan", "scenarioFiles", len(files), "images", len(images))
+	for _, image := range images {
+		slog.Info("build image", "image", image)
+	}
+	if runDry {
+		slog.Info("dry run enabled; no images will be built")
+	}
+
+	// Resolve repository root for docker build contexts.
+	repoRoot, err := docker.ResolveBuildRoot(".")
+	if err != nil {
+		return err
+	}
+
+	// Ensure client images (or print dry-run plan).
+	if len(images) == 0 {
+		slog.Info("no buildable client images found in selected scenarios")
+	} else if runDry {
+		slog.Info("would ensure images (build/pull via EnsureImages)", "images", strings.Join(images, ", "))
+	} else {
+		if err := docker.EnsureImages(ctx.Context, images, repoRoot); err != nil {
+			return err
+		}
+	}
+
+	for _, image := range []string{
+		"hello-world:latest",
+		"alpine:latest",
+		"prom/prometheus:v2.44.0",
+	} {
+		pullArgs := []string{"image", "pull", image}
+		if runDry {
+			slog.Info("would run docker command", "command", "docker "+strings.Join(pullArgs, " "))
+			continue
+		}
+
+		slog.Info("pulling support image", "image", image)
+		if err := runDockerCommand(ctx.Context, repoRoot, pullArgs...); err != nil {
+			return err
+		}
+	}
+
+	// Build the report renderer image (or print dry-run command).
+	rCmdArgs := []string{"build", "analysis/report/", "-t", "norma-r-renderer"}
+	if runDry {
+		slog.Info("would run docker command", "command", "docker "+strings.Join(rCmdArgs, " "))
+		slog.Info("done")
+		return nil
+	}
+
+	slog.Info("building norma-r-renderer")
+	if err := runDockerCommand(ctx.Context, repoRoot, rCmdArgs...); err != nil {
+		return err
+	}
+
+	slog.Info("done")
+	return nil
+}
+
+func collectScenarioFiles(path string) ([]string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to access %q: %w", path, err)
+	}
+
+	if !info.IsDir() {
+		if !isYAML(path) {
+			return nil, fmt.Errorf("%q is not a YAML scenario file", path)
+		}
+		return []string{path}, nil
+	}
+
+	var files []string
+	err = filepath.WalkDir(path, func(current string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if isYAML(d.Name()) {
+			files = append(files, current)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk %q: %w", path, err)
+	}
+
+	sort.Strings(files)
+	slog.Info("collected scenario files", "count", len(files))
+	return files, nil
+}
+
+// collectBuildableImages parses scenarios and returns the unique image refs
+// that are expected to be built by docker.EnsureImages.
+//
+// The helper applies scenario defaults (e.g. default client image for empty
+// node image entries) so build behavior matches runtime node startup behavior.
+func collectBuildableImages(paths []string) ([]string, error) {
+	images := map[string]struct{}{}
+	for _, path := range paths {
+		scenario, err := parser.ParseFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse scenario %q: %w", path, err)
+		}
+
+		if err := scenario.Check(); err != nil {
+			return nil, err
+		}
+
+		for _, validator := range driver.NewValidators(scenario.Validators) {
+			if docker.WillBuildImage(validator.ImageName) {
+				images[validator.ImageName] = struct{}{}
+			}
+		}
+
+		for _, node := range scenario.Nodes {
+			image := driver.ResolveClientImageName(node.Client.ImageName)
+			if docker.WillBuildImage(image) {
+				images[image] = struct{}{}
+			}
+		}
+	}
+
+	result := make([]string, 0, len(images))
+	for image := range images {
+		result = append(result, image)
+	}
+	return docker.NormalizeImageRefs(result), nil
+}
+
+// runDockerCommand executes a docker CLI command in the given working
+// directory with BuildKit enabled and inherited stdio.
+func runDockerCommand(ctx context.Context, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker %s failed: %w", strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+func isYAML(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	return ext == ".yml" || ext == ".yaml"
+}

--- a/driver/norma/build_test.go
+++ b/driver/norma/build_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/0xsoniclabs/norma/driver/docker"
+)
+
+func TestCollectScenarioFiles_Recursive(t *testing.T) {
+	tmp := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(tmp, "a.yml"), []byte("name: a\nduration: 1\n"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmp, "nested"), 0755); err != nil {
+		t.Fatalf("failed to create nested dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "nested", "b.yaml"), []byte("name: b\nduration: 1\n"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "nested", "ignore.txt"), []byte("x"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	got, err := collectScenarioFiles(tmp)
+	if err != nil {
+		t.Fatalf("collectScenarioFiles() failed: %v", err)
+	}
+
+	want := []string{
+		filepath.Join(tmp, "a.yml"),
+		filepath.Join(tmp, "nested", "b.yaml"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid files\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestCollectScenarioFiles_EmptyDir(t *testing.T) {
+	tmp := t.TempDir()
+
+	got, err := collectScenarioFiles(tmp)
+	if err != nil {
+		t.Fatalf("collectScenarioFiles() failed: %v", err)
+	}
+
+	want := []string{}
+	if !slices.Equal(got, want) {
+		t.Fatalf("invalid files\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestCollectBuildableImages(t *testing.T) {
+	tmp := t.TempDir()
+
+	scenarioA := `
+name: scenario-a
+duration: 5
+validators:
+  - name: validator-a
+    imagename: sonic:v2.1.2
+nodes:
+  - name: node-a
+    client:
+      imagename: sonic:local
+`
+	scenarioB := `
+name: scenario-b
+duration: 3
+nodes:
+  - name: node-b
+`
+
+	pathA := filepath.Join(tmp, "a.yml")
+	pathB := filepath.Join(tmp, "b.yml")
+	if err := os.WriteFile(pathA, []byte(scenarioA), 0644); err != nil {
+		t.Fatalf("failed to write scenario A: %v", err)
+	}
+	if err := os.WriteFile(pathB, []byte(scenarioB), 0644); err != nil {
+		t.Fatalf("failed to write scenario B: %v", err)
+	}
+
+	got, err := collectBuildableImages([]string{pathA, pathB})
+	if err != nil {
+		t.Fatalf("collectBuildableImages() failed: %v", err)
+	}
+
+	want := []string{"sonic", "sonic:local", "sonic:v2.1.2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid images\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestWillBuildImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		image     string
+		wantBuild bool
+	}{
+		{
+			name:      "default sonic",
+			image:     "sonic",
+			wantBuild: true,
+		},
+		{
+			name:      "local",
+			image:     "sonic:local",
+			wantBuild: true,
+		},
+		{
+			name:      "version tag",
+			image:     "sonic:v2.1.1",
+			wantBuild: true,
+		},
+		{
+			name:      "non sonic",
+			image:     "alpine:latest",
+			wantBuild: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := docker.WillBuildImage(tt.image); got != tt.wantBuild {
+				t.Fatalf("invalid build classification\ngot:  %v\nwant: %v", got, tt.wantBuild)
+			}
+		})
+	}
+}

--- a/driver/norma/main.go
+++ b/driver/norma/main.go
@@ -36,6 +36,7 @@ func main() {
 		Commands: []*cli.Command{
 			&checkCommand,
 			&runCommand,
+			&buildCommand,
 			&purgeCommand,
 			&renderCommand,
 			&diffCommand,

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/fs"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -120,39 +119,24 @@ func run(ctx *cli.Context) (err error) {
 		stop() // second Ctrl+C will force-kill
 	}()
 
-	// Check if the path is a directory
-	fileInfo, err := os.Stat(path)
+	files, err := collectScenarioFiles(path)
 	if err != nil {
-		return fmt.Errorf("failed to stat path: %w", err)
+		return fmt.Errorf("failed to collect scenario files: %w", err)
 	}
-
-	if fileInfo.IsDir() {
-		// List all YAML files in the directory and run each
-		return filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if stoppableCtx.Err() != nil {
-				return stoppableCtx.Err()
-			}
-			if !d.IsDir() && (filepath.Ext(d.Name()) == ".yaml" || filepath.Ext(d.Name()) == ".yml") {
-				// Call runScenario for each YAML file
-				label := fmt.Sprintf("eval_%d", time.Now().Unix())
-				if err := runScenario(stoppableCtx, p, outputDir, label, keepPrometheusRunning, skipChecks, skipReportRendering, openReport); err != nil {
-					return fmt.Errorf("failed to run: %s: %w", p, err)
-				}
-			}
-			return nil
-		})
-	} else {
-		// Call runScenario for the single file
+	for _, file := range files {
+		if stoppableCtx.Err() != nil {
+			return stoppableCtx.Err()
+		}
 		label := ctx.String(evalLabel.Name)
 		if label == "" {
 			label = fmt.Sprintf("eval_%d", time.Now().Unix())
 		}
-
-		return runScenario(stoppableCtx, path, outputDir, label, keepPrometheusRunning, skipChecks, skipReportRendering, openReport)
+		if err := runScenario(stoppableCtx, file, outputDir, label, keepPrometheusRunning, skipChecks, skipReportRendering, openReport); err != nil {
+			return fmt.Errorf("failed to run scenario %q: %w", file, err)
+		}
 	}
+
+	return nil
 }
 
 func runScenario(ctx context.Context, path, outputDir, label string, keepPrometheusRunning, skipChecks, skipReportRendering, openReport bool) error {


### PR DESCRIPTION
This PR adds a new `norma build` command to automate Docker image builds needed by scenarios.

**What it does**

- Scans scenario YAMLs (recursively) provided by a commandline argument, and collects required Sonic images.
Builds each required Sonic image plus `norma-r-renderer`.
Uses `scenarios` by default if no path is provided.
- Adds `--dry-run` to print planned image builds/commands without executing Docker.