### PR TITLE
Increase total supply to allow more tx generating users

### DIFF
--- a/genesis/genesis/genesis.go
+++ b/genesis/genesis/genesis.go
@@ -74,7 +74,7 @@ func GenerateJsonGenesis(jsonFile string, validatorStakes []uint64, rules *opera
 
 	// Create the validator account and provide tokens, pre-init a maximal limit of validators.
 	const maxValidators = 100
-	totalSupply := utils.ToFtm(1000_000_000)
+	totalSupply := utils.ToFtm(1_000_000_000_000_000)
 	validators := makefakegenesis.GetFakeValidators(idx.Validator(maxValidators))
 	supplyEach := new(big.Int).Div(totalSupply, big.NewInt(int64(len(validators))))
 	for _, validator := range validators {

--- a/genesis/genesis/genesis_test.go
+++ b/genesis/genesis/genesis_test.go
@@ -76,7 +76,7 @@ func TestGenerateJsonGenesis(t *testing.T) {
 
 			// add validators to expected accounts
 			validators := makefakegenesis.GetFakeValidators(MaxValidatorsCount)
-			totalSupply := utils.ToFtm(1000_000_000)
+			totalSupply := utils.ToFtm(1_000_000_000_000_000)
 			supplyEach := new(big.Int).Div(totalSupply, big.NewInt(int64(len(validators))))
 			for _, validator := range validators {
 				expectedAccounts = append(expectedAccounts, makefakegenesis.Account{


### PR DESCRIPTION
This should resolve following error, caused by insufficient balance in the treasury (validator 1 balance):
```
failed to create users for app; mix: failed to create users for app 13: failed to fund sponsor accounts: failed to distribute funds: insufficient funds for transfer
```