### PR TITLE
Add sending tx retry

### DIFF
--- a/driver/network/backend.go
+++ b/driver/network/backend.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -30,9 +29,10 @@ import (
 // ContractBackend is an interface for a client to interact with the network.
 type ContractBackend interface {
 	bind.ContractBackend
-	// WaitTransactionReceipt waits for the receipt of the given transaction hash to be available.
-	// The function times out after 10 seconds.
-	WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error)
+	// SendTxWithRetry broadcasts the given transaction and waits for its receipt,
+	// periodically re-broadcasting it while waiting to recover from the transaction
+	// being dropped from the txpool.
+	SendTxWithRetry(tx *types.Transaction) (*types.Receipt, error)
 }
 
 // convertContractBytecode converts a contract hex string to bytecode.

--- a/driver/network/backend_mock.go
+++ b/driver/network/backend_mock.go
@@ -163,6 +163,21 @@ func (mr *MockContractBackendMockRecorder) SendTransaction(ctx, tx any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTransaction", reflect.TypeOf((*MockContractBackend)(nil).SendTransaction), ctx, tx)
 }
 
+// SendTxWithRetry mocks base method.
+func (m *MockContractBackend) SendTxWithRetry(tx *types.Transaction) (*types.Receipt, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendTxWithRetry", tx)
+	ret0, _ := ret[0].(*types.Receipt)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SendTxWithRetry indicates an expected call of SendTxWithRetry.
+func (mr *MockContractBackendMockRecorder) SendTxWithRetry(tx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTxWithRetry", reflect.TypeOf((*MockContractBackend)(nil).SendTxWithRetry), tx)
+}
+
 // SubscribeFilterLogs mocks base method.
 func (m *MockContractBackend) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
 	m.ctrl.T.Helper()
@@ -206,19 +221,4 @@ func (m *MockContractBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, e
 func (mr *MockContractBackendMockRecorder) SuggestGasTipCap(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SuggestGasTipCap", reflect.TypeOf((*MockContractBackend)(nil).SuggestGasTipCap), ctx)
-}
-
-// WaitTransactionReceipt mocks base method.
-func (m *MockContractBackend) WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitTransactionReceipt", txHash)
-	ret0, _ := ret[0].(*types.Receipt)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WaitTransactionReceipt indicates an expected call of WaitTransactionReceipt.
-func (mr *MockContractBackendMockRecorder) WaitTransactionReceipt(txHash any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitTransactionReceipt", reflect.TypeOf((*MockContractBackend)(nil).WaitTransactionReceipt), txHash)
 }

--- a/driver/network/epoch.go
+++ b/driver/network/epoch.go
@@ -38,6 +38,7 @@ func AdvanceEpoch(client rpc.Client, epochIncrement int) error {
 	// Driver owner is the first validator from the list i.e., index 1 (defined in genesis export in genesis.GenerateJsonGenesis)
 	txOpts, err := bind.NewKeyedTransactorWithChainID(evmcore.FakeKey(1), big.NewInt(int64(originalRules.NetworkID)))
 	txOpts.GasTipCap = big.NewInt(100) // tip shall facilitate emission of the transaction, bypassing other pooled txs
+	txOpts.NoSend = true               // broadcasting (with retry) is handled by SendTxWithRetry
 	if err != nil {
 		return fmt.Errorf("failed to create txOpts; %v", err)
 	}
@@ -47,7 +48,7 @@ func AdvanceEpoch(client rpc.Client, epochIncrement int) error {
 		return fmt.Errorf("failed to advance epoch; %v", err)
 	}
 
-	rec, err := client.WaitTransactionReceipt(tx.Hash())
+	rec, err := client.SendTxWithRetry(tx)
 	if err != nil {
 		return fmt.Errorf("failed to get receipt; %v", err)
 	}

--- a/driver/network/epoch_test.go
+++ b/driver/network/epoch_test.go
@@ -38,8 +38,7 @@ func TestAdvanceEpoch_Success(t *testing.T) {
 	client.EXPECT().PendingCodeAt(gomock.Any(), gomock.Any()).Return(bytecode, nil)
 	client.EXPECT().EstimateGas(gomock.Any(), gomock.Any()).Return(uint64(123), nil)
 	client.EXPECT().PendingNonceAt(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
-	client.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return(nil)
-	client.EXPECT().WaitTransactionReceipt(gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusSuccessful}, nil)
+	client.EXPECT().SendTxWithRetry(gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusSuccessful}, nil)
 
 	// Report the updated epoch after advancing.
 	client.EXPECT().Call(gomock.Any(), "eth_currentEpoch").DoAndReturn(

--- a/driver/network/host_mock.go
+++ b/driver/network/host_mock.go
@@ -40,6 +40,20 @@ func (m *MockHost) EXPECT() *MockHostMockRecorder {
 	return m.recorder
 }
 
+// CheckRunning mocks base method.
+func (m *MockHost) CheckRunning() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckRunning")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckRunning indicates an expected call of CheckRunning.
+func (mr *MockHostMockRecorder) CheckRunning() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckRunning", reflect.TypeOf((*MockHost)(nil).CheckRunning))
+}
+
 // Cleanup mocks base method.
 func (m *MockHost) Cleanup() error {
 	m.ctrl.T.Helper()

--- a/driver/network/rules.go
+++ b/driver/network/rules.go
@@ -31,6 +31,7 @@ func ApplyNetworkRules(backend ContractBackend, rules genesis.NetworkRules) erro
 	// Driver owner is the first validator from the list i.e., index 1 (defined in genesis export in genesis.GenerateJsonGenesis)
 	txOpts, err := bind.NewKeyedTransactorWithChainID(evmcore.FakeKey(1), big.NewInt(int64(originalRules.NetworkID)))
 	txOpts.GasTipCap = big.NewInt(100) // tip shall facilitate emission of the transaction, bypassing other pooled txs
+	txOpts.NoSend = true               // broadcasting (with retry) is handled by SendTxWithRetry
 	if err != nil {
 		return fmt.Errorf("failed to create txOpts; %v", err)
 	}
@@ -40,7 +41,7 @@ func ApplyNetworkRules(backend ContractBackend, rules genesis.NetworkRules) erro
 		return fmt.Errorf("failed to update network rules; %v", err)
 	}
 
-	rec, err := backend.WaitTransactionReceipt(tx.Hash())
+	rec, err := backend.SendTxWithRetry(tx)
 	if err != nil {
 		return fmt.Errorf("failed to get receipt; %v", err)
 	}

--- a/driver/network/rules_test.go
+++ b/driver/network/rules_test.go
@@ -29,8 +29,7 @@ func TestApplyNetworkRules_Success(t *testing.T) {
 	backend.EXPECT().PendingCodeAt(gomock.Any(), gomock.Any()).Return(bytecode, nil)
 	backend.EXPECT().EstimateGas(gomock.Any(), gomock.Any()).Return(uint64(123), nil)
 	backend.EXPECT().PendingNonceAt(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
-	backend.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return(nil)
-	backend.EXPECT().WaitTransactionReceipt(gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusSuccessful}, nil)
+	backend.EXPECT().SendTxWithRetry(gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusSuccessful}, nil)
 
 	const fee = 456
 	rules := genesis.NetworkRules{}

--- a/driver/network/validator.go
+++ b/driver/network/validator.go
@@ -35,6 +35,7 @@ func RegisterValidatorNode(backend ContractBackend) (int, error) {
 	privateKeyECDSA := evmcore.FakeKey(uint32(newValId))
 	txOpts, err := bind.NewKeyedTransactorWithChainID(privateKeyECDSA, big.NewInt(int64(opera.FakeNetRules(opera.GetSonicUpgrades()).NetworkID)))
 	txOpts.GasTipCap = big.NewInt(100) // tip shall facilitate emission of the transaction, bypassing other pooled txs
+	txOpts.NoSend = true               // broadcasting (with retry) is handled by SendTxWithRetry
 	if err != nil {
 		return 0, fmt.Errorf("failed to create txOpts; %v", err)
 	}
@@ -51,7 +52,7 @@ func RegisterValidatorNode(backend ContractBackend) (int, error) {
 		return 0, fmt.Errorf("failed to create validator; %v", err)
 	}
 
-	receipt, err := backend.WaitTransactionReceipt(tx.Hash())
+	receipt, err := backend.SendTxWithRetry(tx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create validator, receipt error: %v", err)
 	}
@@ -80,6 +81,7 @@ func UnregisterValidatorNode(client rpc.Client, validatorId int) error {
 	key := evmcore.FakeKey(uint32(validatorId))
 	txOpts, err := bind.NewKeyedTransactorWithChainID(key, big.NewInt(int64(opera.FakeNetRules(opera.GetSonicUpgrades()).NetworkID)))
 	txOpts.GasTipCap = big.NewInt(100) // tip shall facilitate emission of the transaction, bypassing other pooled txs
+	txOpts.NoSend = true               // broadcasting (with retry) is handled by SendTxWithRetry
 	if err != nil {
 		return fmt.Errorf("failed to create txOpts; %v", err)
 	}
@@ -93,7 +95,7 @@ func UnregisterValidatorNode(client rpc.Client, validatorId int) error {
 		return fmt.Errorf("failed to undelegate validator stake; %v", err)
 	}
 
-	receipt, err := client.WaitTransactionReceipt(tx.Hash())
+	receipt, err := client.SendTxWithRetry(tx)
 	if err != nil {
 		return fmt.Errorf("failed to unregister validator, receipt error: %v", err)
 	}

--- a/driver/network/validator_test.go
+++ b/driver/network/validator_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestRegisterValidatorNode_Success(t *testing.T) {
 	mockBackendForCreateValidator(t, func(backend *MockContractBackend) {
-		backend.EXPECT().WaitTransactionReceipt(gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusSuccessful}, nil)
+		backend.EXPECT().SendTxWithRetry(gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusSuccessful}, nil)
 
 		valId, err := RegisterValidatorNode(backend)
 		if err != nil {
@@ -27,7 +27,7 @@ func TestRegisterValidatorNode_Success(t *testing.T) {
 
 func TestRegisterValidatorNode_Failure(t *testing.T) {
 	mockBackendForCreateValidator(t, func(backend *MockContractBackend) {
-		backend.EXPECT().WaitTransactionReceipt(gomock.Any()).Return(nil, fmt.Errorf("failed to get receipt")).AnyTimes()
+		backend.EXPECT().SendTxWithRetry(gomock.Any()).Return(nil, fmt.Errorf("failed to get receipt")).AnyTimes()
 
 		if _, err := RegisterValidatorNode(backend); err == nil {
 			t.Errorf("expected error, got %v", err)
@@ -37,7 +37,7 @@ func TestRegisterValidatorNode_Failure(t *testing.T) {
 
 func TestRegisterValidatorNode_Failure_TransactionReverted(t *testing.T) {
 	mockBackendForCreateValidator(t, func(backend *MockContractBackend) {
-		backend.EXPECT().WaitTransactionReceipt(gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusFailed}, nil).AnyTimes()
+		backend.EXPECT().SendTxWithRetry(gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusFailed}, nil).AnyTimes()
 
 		if _, err := RegisterValidatorNode(backend); err == nil {
 			t.Errorf("expected error, got %v", err)
@@ -84,7 +84,6 @@ func mockBackendForCreateValidator(t *testing.T, test func(backend *MockContract
 	backend.EXPECT().PendingCodeAt(gomock.Any(), gomock.Any()).Return(bytecode, nil)
 	backend.EXPECT().EstimateGas(gomock.Any(), gomock.Any()).Return(uint64(123), nil)
 	backend.EXPECT().PendingNonceAt(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
-	backend.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return(nil)
 
 	test(backend)
 }

--- a/driver/rpc/rpc.go
+++ b/driver/rpc/rpc.go
@@ -71,7 +71,7 @@ func WrapRpcClient(rpcClient *rpc.Client) *Impl {
 		ethRpcClient:     ethclient.NewClient(rpcClient),
 		rpcClient:        rpcClient,
 		txReceiptTimeout: 600 * time.Second,
-		txResendInterval: 30 * time.Second,
+		txResendInterval: 5 * time.Second,
 	}
 }
 

--- a/driver/rpc/rpc.go
+++ b/driver/rpc/rpc.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"time"
 
@@ -47,6 +48,14 @@ type Client interface {
 	//  until a certain timeout is reached.
 	WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error)
 
+	// SendTxWithRetry broadcasts the given transaction and waits for its receipt.
+	// While waiting it periodically re-broadcasts the transaction to recover from it
+	// being dropped from the txpool (e.g. under load), which would otherwise make the
+	// receipt never appear and the wait time out. Callers should create the
+	// transaction with bind.TransactOpts.NoSend set to true and leave broadcasting to
+	// this method. Re-sending an already known or already mined transaction is harmless.
+	SendTxWithRetry(tx *types.Transaction) (*types.Receipt, error)
+
 	// GetBundleInfo calls sonic_getBundleInfo with the given execution plan hash.
 	// Returns nil, nil if the bundle has not been executed yet.
 	GetBundleInfo(planHash common.Hash) (*sonicapi.RPCBundleInfo, error)
@@ -62,6 +71,7 @@ func WrapRpcClient(rpcClient *rpc.Client) *Impl {
 		ethRpcClient:     ethclient.NewClient(rpcClient),
 		rpcClient:        rpcClient,
 		txReceiptTimeout: 600 * time.Second,
+		txResendInterval: 30 * time.Second,
 	}
 }
 
@@ -85,18 +95,58 @@ type Impl struct {
 	ethRpcClient
 	rpcClient
 	txReceiptTimeout time.Duration
+	// txResendInterval is how often a transaction is re-broadcast while waiting for
+	// its receipt in SendTxWithRetry.
+	txResendInterval time.Duration
 }
 
 func (r Impl) Call(result interface{}, method string, args ...interface{}) error {
 	return r.rpcClient.Call(result, method, args...)
 }
 
+// WaitTransactionReceipt polls for the receipt of txHash with exponential backoff
+// until txReceiptTimeout is reached.
 func (r Impl) WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error) {
 	// Wait for the response with some exponential backoff.
 	const maxDelay = 5 * time.Second
 	begin := time.Now()
 	delay := time.Millisecond
 	for time.Since(begin) < r.txReceiptTimeout {
+		receipt, err := r.transactionReceipt(txHash)
+		if errors.Is(err, ethereum.NotFound) {
+			time.Sleep(delay)
+			delay = 2 * delay
+			if delay > maxDelay {
+				delay = maxDelay
+			}
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to get transaction receipt: %w", err)
+		}
+		return receipt, nil
+	}
+	return nil, fmt.Errorf("failed to get transaction receipt: timeout")
+}
+
+// SendTxWithRetry broadcasts tx and then polls for its receipt, just like
+// WaitTransactionReceipt, but periodically re-broadcasts tx while waiting. This
+// recovers from the transaction being dropped from the txpool, which would
+// otherwise make the receipt never appear and the wait time out.
+func (r Impl) SendTxWithRetry(tx *types.Transaction) (*types.Receipt, error) {
+	txHash := tx.Hash()
+	const maxDelay = 5 * time.Second
+	begin := time.Now()
+	delay := time.Millisecond
+	var lastSend time.Time
+	for time.Since(begin) < r.txReceiptTimeout {
+		if time.Since(lastSend) >= r.txResendInterval {
+			if err := r.SendTransaction(context.Background(), tx); err != nil {
+				slog.Debug("re-broadcasting transaction failed", "tx", txHash, "error", err)
+			}
+			lastSend = time.Now()
+		}
+
 		receipt, err := r.transactionReceipt(txHash)
 		if errors.Is(err, ethereum.NotFound) {
 			time.Sleep(delay)

--- a/driver/rpc/rpc.go
+++ b/driver/rpc/rpc.go
@@ -135,11 +135,23 @@ func (r Impl) WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error)
 // otherwise make the receipt never appear and the wait time out.
 func (r Impl) SendTxWithRetry(tx *types.Transaction) (*types.Receipt, error) {
 	txHash := tx.Hash()
+
+	// Broadcast the transaction. A failure of the initial submission is
+	// authoritative (e.g. the transaction was rejected as underpriced or with a
+	// wrong nonce), so it is reported to the caller rather than polling for a
+	// receipt that will never arrive.
+	if err := r.SendTransaction(context.Background(), tx); err != nil {
+		return nil, fmt.Errorf("failed to send transaction: %w", err)
+	}
+
 	const maxDelay = 5 * time.Second
 	begin := time.Now()
+	lastSend := begin
 	delay := time.Millisecond
-	var lastSend time.Time
 	for time.Since(begin) < r.txReceiptTimeout {
+		// Re-broadcast periodically in case the transaction was dropped from the
+		// txpool. Re-sending an already known or already mined transaction is
+		// harmless, so re-send errors are only logged.
 		if time.Since(lastSend) >= r.txResendInterval {
 			if err := r.SendTransaction(context.Background(), tx); err != nil {
 				slog.Debug("re-broadcasting transaction failed", "tx", txHash, "error", err)

--- a/driver/rpc/rpc_mock.go
+++ b/driver/rpc/rpc_mock.go
@@ -60,6 +60,21 @@ func (mr *MockClientMockRecorder) BalanceAt(ctx, account, blockNumber any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BalanceAt", reflect.TypeOf((*MockClient)(nil).BalanceAt), ctx, account, blockNumber)
 }
 
+// BlockNumber mocks base method.
+func (m *MockClient) BlockNumber(ctx context.Context) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BlockNumber", ctx)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BlockNumber indicates an expected call of BlockNumber.
+func (mr *MockClientMockRecorder) BlockNumber(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockNumber", reflect.TypeOf((*MockClient)(nil).BlockNumber), ctx)
+}
+
 // Call mocks base method.
 func (m *MockClient) Call(result any, method string, args ...any) error {
 	m.ctrl.T.Helper()
@@ -92,21 +107,6 @@ func (m *MockClient) CallContract(ctx context.Context, call ethereum.CallMsg, bl
 func (mr *MockClientMockRecorder) CallContract(ctx, call, blockNumber any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CallContract", reflect.TypeOf((*MockClient)(nil).CallContract), ctx, call, blockNumber)
-}
-
-// BlockNumber mocks base method.
-func (m *MockClient) BlockNumber(ctx context.Context) (uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockNumber", ctx)
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// BlockNumber indicates an expected call of BlockNumber.
-func (mr *MockClientMockRecorder) BlockNumber(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockNumber", reflect.TypeOf((*MockClient)(nil).BlockNumber), ctx)
 }
 
 // ChainID mocks base method.
@@ -179,6 +179,21 @@ func (m *MockClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]
 func (mr *MockClientMockRecorder) FilterLogs(ctx, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterLogs", reflect.TypeOf((*MockClient)(nil).FilterLogs), ctx, q)
+}
+
+// GetBundleInfo mocks base method.
+func (m *MockClient) GetBundleInfo(planHash common.Hash) (*sonicapi.RPCBundleInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBundleInfo", planHash)
+	ret0, _ := ret[0].(*sonicapi.RPCBundleInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBundleInfo indicates an expected call of GetBundleInfo.
+func (mr *MockClientMockRecorder) GetBundleInfo(planHash any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundleInfo", reflect.TypeOf((*MockClient)(nil).GetBundleInfo), planHash)
 }
 
 // HeaderByNumber mocks base method.
@@ -255,6 +270,21 @@ func (mr *MockClientMockRecorder) SendTransaction(ctx, tx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTransaction", reflect.TypeOf((*MockClient)(nil).SendTransaction), ctx, tx)
 }
 
+// SendTxWithRetry mocks base method.
+func (m *MockClient) SendTxWithRetry(tx *types.Transaction) (*types.Receipt, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendTxWithRetry", tx)
+	ret0, _ := ret[0].(*types.Receipt)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SendTxWithRetry indicates an expected call of SendTxWithRetry.
+func (mr *MockClientMockRecorder) SendTxWithRetry(tx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTxWithRetry", reflect.TypeOf((*MockClient)(nil).SendTxWithRetry), tx)
+}
+
 // SubscribeFilterLogs mocks base method.
 func (m *MockClient) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
 	m.ctrl.T.Helper()
@@ -315,21 +345,6 @@ func (mr *MockClientMockRecorder) WaitForBundleInfo(ctx, planHash any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForBundleInfo", reflect.TypeOf((*MockClient)(nil).WaitForBundleInfo), ctx, planHash)
 }
 
-// GetBundleInfo mocks base method.
-func (m *MockClient) GetBundleInfo(planHash common.Hash) (*sonicapi.RPCBundleInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBundleInfo", planHash)
-	ret0, _ := ret[0].(*sonicapi.RPCBundleInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBundleInfo indicates an expected call of GetBundleInfo.
-func (mr *MockClientMockRecorder) GetBundleInfo(planHash any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundleInfo", reflect.TypeOf((*MockClient)(nil).GetBundleInfo), planHash)
-}
-
 // WaitTransactionReceipt mocks base method.
 func (m *MockClient) WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error) {
 	m.ctrl.T.Helper()
@@ -384,21 +399,6 @@ func (mr *MockethRpcClientMockRecorder) BalanceAt(ctx, account, blockNumber any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BalanceAt", reflect.TypeOf((*MockethRpcClient)(nil).BalanceAt), ctx, account, blockNumber)
 }
 
-// CallContract mocks base method.
-func (m *MockethRpcClient) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CallContract", ctx, call, blockNumber)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CallContract indicates an expected call of CallContract.
-func (mr *MockethRpcClientMockRecorder) CallContract(ctx, call, blockNumber any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CallContract", reflect.TypeOf((*MockethRpcClient)(nil).CallContract), ctx, call, blockNumber)
-}
-
 // BlockNumber mocks base method.
 func (m *MockethRpcClient) BlockNumber(ctx context.Context) (uint64, error) {
 	m.ctrl.T.Helper()
@@ -412,6 +412,21 @@ func (m *MockethRpcClient) BlockNumber(ctx context.Context) (uint64, error) {
 func (mr *MockethRpcClientMockRecorder) BlockNumber(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockNumber", reflect.TypeOf((*MockethRpcClient)(nil).BlockNumber), ctx)
+}
+
+// CallContract mocks base method.
+func (m *MockethRpcClient) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CallContract", ctx, call, blockNumber)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CallContract indicates an expected call of CallContract.
+func (mr *MockethRpcClientMockRecorder) CallContract(ctx, call, blockNumber any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CallContract", reflect.TypeOf((*MockethRpcClient)(nil).CallContract), ctx, call, blockNumber)
 }
 
 // ChainID mocks base method.

--- a/driver/rpc/rpc_test.go
+++ b/driver/rpc/rpc_test.go
@@ -85,6 +85,62 @@ func TestRpcClientImpl_WaitTransactionReceipt_Timeout(t *testing.T) {
 	}
 }
 
+func TestRpcClientImpl_SendTxWithRetry_ReBroadcastsUntilReceipt(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	rpcMock := NewMockrpcClient(ctrl)
+	ethMock := NewMockethRpcClient(ctrl)
+	client := Impl{
+		ethRpcClient:     ethMock,
+		rpcClient:        rpcMock,
+		txReceiptTimeout: time.Second,
+		txResendInterval: 10 * time.Millisecond,
+	}
+
+	tx := types.NewTx(&types.LegacyTx{Nonce: 1})
+
+	// The receipt is not found for the first few polls, then becomes available.
+	polls := 0
+	rpcMock.EXPECT().
+		Call(gomock.Any(), "eth_getTransactionReceipt", gomock.Any()).
+		DoAndReturn(func(result interface{}, method string, args ...interface{}) error {
+			resultPtr, ok := result.(*map[string]any)
+			if !ok {
+				t.Fatalf("result type is not *map[string]any")
+			}
+			polls++
+			if polls < 5 {
+				*resultPtr = nil // ethereum.NotFound
+				return nil
+			}
+			*resultPtr = map[string]any{
+				"cumulativeGasUsed": "0x0",
+				"logsBloom":         "0x" + strings.Repeat("00", 256),
+				"logs":              []map[string]any{},
+				"transactionHash":   "0x" + strings.Repeat("00", 32),
+				"gasUsed":           "0x0",
+			}
+			return nil
+		}).
+		AnyTimes()
+
+	// While waiting, the transaction must be (re-)broadcast more than once.
+	ethMock.EXPECT().
+		SendTransaction(gomock.Any(), gomock.Any()).
+		Return(nil).
+		MinTimes(2)
+
+	receipt, err := client.SendTxWithRetry(tx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if receipt == nil {
+		t.Fatalf("expected a receipt, got nil")
+	}
+}
+
 func TestRpcClientImpl_WaitTransactionReceipt_Error(t *testing.T) {
 	t.Parallel()
 

--- a/driver/rpc/rpc_test.go
+++ b/driver/rpc/rpc_test.go
@@ -141,6 +141,90 @@ func TestRpcClientImpl_SendTxWithRetry_ReBroadcastsUntilReceipt(t *testing.T) {
 	}
 }
 
+func TestRpcClientImpl_SendTxWithRetry_InitialSendErrorIsFatal(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	rpcMock := NewMockrpcClient(ctrl)
+	ethMock := NewMockethRpcClient(ctrl)
+	client := Impl{
+		ethRpcClient:     ethMock,
+		rpcClient:        rpcMock,
+		txReceiptTimeout: time.Hour, // would block for an hour if it wrongly polled
+		txResendInterval: 10 * time.Millisecond,
+	}
+
+	tx := types.NewTx(&types.LegacyTx{Nonce: 1})
+
+	injectedError := errors.New("transaction underpriced")
+	ethMock.EXPECT().
+		SendTransaction(gomock.Any(), gomock.Any()).
+		Return(injectedError).
+		Times(1)
+
+	// The receipt must never be polled when the initial broadcast fails: no
+	// Call expectation is registered, so any poll would fail the test.
+
+	if _, err := client.SendTxWithRetry(tx); !errors.Is(err, injectedError) {
+		t.Fatalf("expected the initial send error, got %v", err)
+	}
+}
+
+func TestRpcClientImpl_SendTxWithRetry_IgnoresReBroadcastErrors(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	rpcMock := NewMockrpcClient(ctrl)
+	ethMock := NewMockethRpcClient(ctrl)
+	client := Impl{
+		ethRpcClient:     ethMock,
+		rpcClient:        rpcMock,
+		txReceiptTimeout: time.Second,
+		txResendInterval: 10 * time.Millisecond,
+	}
+
+	tx := types.NewTx(&types.LegacyTx{Nonce: 1})
+
+	// The initial broadcast succeeds; subsequent re-broadcasts fail (e.g. the tx is
+	// already known) and must be ignored.
+	gomock.InOrder(
+		ethMock.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return(nil),
+		ethMock.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).
+			Return(errors.New("already known")).AnyTimes(),
+	)
+
+	polls := 0
+	rpcMock.EXPECT().
+		Call(gomock.Any(), "eth_getTransactionReceipt", gomock.Any()).
+		DoAndReturn(func(result interface{}, method string, args ...interface{}) error {
+			resultPtr := result.(*map[string]any)
+			polls++
+			if polls < 4 {
+				*resultPtr = nil // ethereum.NotFound
+				return nil
+			}
+			*resultPtr = map[string]any{
+				"cumulativeGasUsed": "0x0",
+				"logsBloom":         "0x" + strings.Repeat("00", 256),
+				"logs":              []map[string]any{},
+				"transactionHash":   "0x" + strings.Repeat("00", 32),
+				"gasUsed":           "0x0",
+			}
+			return nil
+		}).
+		AnyTimes()
+
+	receipt, err := client.SendTxWithRetry(tx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if receipt == nil {
+		t.Fatalf("expected a receipt, got nil")
+	}
+}
+
 func TestRpcClientImpl_WaitTransactionReceipt_Error(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Seems txs registering node/advancing epoch/etc are sometime lost from the txpool:
```
ERROR[01-01|00:02:48.672] event execution failed time=115.6 name="[node-latest-validator-0] Creating node" event_time=60.0 error="failed to register validator node; failed to register validator node; failed to create validator, receipt error: failed to get transaction receipt: timeout" duration=53.239s
```
This PR adds automatic retry while waiting for the tx receipt.