### PR TITLE
Build docker images on demand.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,21 +18,12 @@ BUILD_DIR := $(CURDIR)/build
 
 .PHONY: all test clean
 
-# Define a list of client versions
-CLIENT_VERSIONS := \
-	v2.0 v2.0.0 v2.0.1 v2.0.2 v2.0.3 \
-	v2.1 v2.1.0 v2.1.1 v2.1.2 v2.1.6
-CLIENT_URL=https://github.com/0xsoniclabs/sonic.git
-
 all: \
     norma \
     pull-hello-world-image \
     pull-alpine-image \
     pull-prometheus-image \
-    build-r-renderer-image \
-    build-sonic-docker-image-main \
-    build-sonic-docker-image-local \
-    $(foreach version, $(CLIENT_VERSIONS), build-sonic-docker-image-$(version)) \
+	build-r-renderer-image
 
 pull-hello-world-image:
 	DOCKER_BUILDKIT=1 docker image pull hello-world
@@ -45,16 +36,6 @@ pull-prometheus-image:
 
 build-r-renderer-image:
 	DOCKER_BUILDKIT=1 docker build analysis/report/ -t norma-r-renderer
-
-build-sonic-docker-image-main:
-	DOCKER_BUILDKIT=1 docker build --build-context client-src=$(CLIENT_URL) . -t sonic
-
-build-sonic-docker-image-local:
-	DOCKER_BUILDKIT=1 docker build --build-context client-src=sonic . -t sonic:local
-
-# Build various client versions
-$(foreach version, $(CLIENT_VERSIONS), build-sonic-docker-image-$(version)):
-	DOCKER_BUILDKIT=1 docker build --build-context client-src=$(CLIENT_URL)\#$(subst build-sonic-docker-image-,,$@) . -t sonic:$(subst build-sonic-docker-image-,,$@)
 
 generate-abi: load/contracts/abi/Counter.abi load/contracts/abi/ERC20.abi load/contracts/abi/Store.abi load/contracts/abi/UniswapV2Pair.abi load/contracts/abi/UniswapRouter.abi load/contracts/abi/Helper.abi load/contracts/abi/SmartAccount.abi load/contracts/abi/EntryPoint.abi load/contracts/abi/TransientCounter.abi load/contracts/abi/SelfDestructOldContract.abi load/contracts/abi/SelfDestructNewContract.abi load/contracts/abi/EcdsaCounter.abi load/contracts/abi/LargeContract.abi load/contracts/abi/ProbabilisticFailing.abi # requires installed solc and Ethereum abigen - check README.md
 
@@ -122,9 +103,8 @@ generate-mocks: # requires installed mockgen
 norma:
 	go build -o $(BUILD_DIR)/norma ./driver/norma
 
-test: pull-hello-world-image pull-alpine-image pull-prometheus-image build-r-renderer-image build-sonic-docker-image-main
+test: pull-hello-world-image pull-alpine-image pull-prometheus-image build-r-renderer-image
 	go test ./... -v
 
 clean:
 	rm -rvf $(CURDIR)/build
-	docker image rm -f sonic sonic:local

--- a/driver/docker/images.go
+++ b/driver/docker/images.go
@@ -1,0 +1,267 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package docker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/docker/docker/api/types/image"
+)
+
+// sonicRepositoryURL is the canonical remote source used when building
+// non-local Sonic images on demand.
+const sonicRepositoryURL = "https://github.com/0xsoniclabs/sonic.git"
+
+// imageBuildKind describes how an image should be materialized when it is not
+// already available locally.
+type imageBuildKind int
+
+const (
+	// imageBuildNone means no local build strategy applies. In this case the
+	// image is obtained by pullImage.
+	imageBuildNone imageBuildKind = iota
+	// imageBuildSonicRemote means the image should be built from the remote
+	// Sonic repository URL (optionally pinned to a tag via #<tag>).
+	imageBuildSonicRemote
+	// imageBuildSonicLocal means the image should be built from local Sonic
+	// sources (the repository's "sonic" directory).
+	imageBuildSonicLocal
+)
+
+// imageBuildPlan captures the selected provisioning strategy for one image
+// reference.
+//
+// clientSrc is passed to docker build as the value of the "client-src" build
+// context expected by the repository Dockerfile.
+type imageBuildPlan struct {
+	kind      imageBuildKind
+	clientSrc string
+}
+
+// EnsureImages makes sure the given image refs are locally available.
+//
+// The function provides the runtime image provisioning path used by
+// scenario execution. It performs the following steps:
+//
+//  1. Normalize and deduplicate image references.
+//  2. Resolve the Norma build root (must contain Dockerfile and
+//     scripts/run_sonic.sh).
+//  3. For each image:
+//     - choose build or pull strategy via planImage;
+//     - build (Sonic-specific refs) or pull (all other refs).
+//
+// For Sonic image refs, it lazily builds from the project's Dockerfile:
+//   - sonic: from sonicRepositoryURL
+//   - sonic:local: from local ./sonic
+//   - sonic:<tag>: from sonicRepositoryURL#<tag>
+//   - sonic:<commit hash>: from sonicRepositoryURL#<commit hash>
+//
+// Other images are pulled if missing.
+//
+// The operation is idempotent with respect to already present tags, and relies
+// on Docker's own image/layer cache for repeated builds.
+func EnsureImages(ctx context.Context, imageRefs []string, buildRoot string) error {
+	if len(imageRefs) == 0 {
+		return nil
+	}
+	if buildRoot == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get working directory: %w", err)
+		}
+		buildRoot = cwd
+	}
+
+	buildRoot, err := resolveBuildRoot(buildRoot)
+	if err != nil {
+		return err
+	}
+	slog.Info("resolved build root", "path", buildRoot)
+
+	refs := deduplicateAndSort(imageRefs)
+	slog.Info("checking images", "refs", refs)
+	cli, err := NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create docker client: %w", err)
+	}
+	defer func() {
+		_ = cli.Close()
+	}()
+
+	for _, ref := range refs {
+
+		plan := planImage(ref)
+		start := time.Now()
+		switch plan.kind {
+		case imageBuildSonicRemote, imageBuildSonicLocal:
+			slog.Info("building image", "ref", ref, "clientSrc", plan.clientSrc)
+			if err := buildImage(ctx, buildRoot, ref, plan.clientSrc); err != nil {
+				return err
+			}
+		case imageBuildNone:
+			slog.Info("pulling image", "ref", ref)
+			if err := pullImage(ctx, cli, ref); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported image plan for %q", ref)
+		}
+		slog.Info("image ready", "ref", ref, "took", time.Since(start))
+	}
+
+	return nil
+}
+
+// pullImage pulls imageRef from the configured registry and consumes the entire
+// pull stream.
+//
+// Fully draining the stream ensures the pull operation completes and daemon
+// resources are released before returning.
+func pullImage(ctx context.Context, cli *Client, imageRef string) error {
+	reader, err := cli.cli.ImagePull(ctx, imageRef, image.PullOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to pull image %q: %w", imageRef, err)
+	}
+	defer func() {
+		_ = reader.Close()
+	}()
+
+	if _, err := io.Copy(io.Discard, reader); err != nil {
+		return fmt.Errorf("failed to read pull output for image %q: %w", imageRef, err)
+	}
+	return nil
+}
+
+// buildImage builds imageRef using the repository Dockerfile located under
+// buildRoot.
+//
+// The build passes "client-src=<clientSrc>" as an additional build context,
+// matching the Dockerfile convention used by Norma. BuildKit is enabled
+// explicitly via environment variable to keep behavior aligned with existing
+// developer workflows.
+//
+// On failure, the function returns the docker command error along with captured
+// combined stdout/stderr output to aid diagnostics.
+func buildImage(ctx context.Context, buildRoot, imageRef, clientSrc string) error {
+	args := []string{"build", "--build-context", fmt.Sprintf("client-src=%s", clientSrc), ".", "-t", imageRef}
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.Dir = buildRoot
+	cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to build image %q: %w\n%s", imageRef, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// planImage resolves imageRef into an internal build plan.
+//
+// Current mapping rules:
+//   - "sonic"       => remote build from sonicRepositoryURL
+//   - "sonic:local" => local build from "sonic"
+//   - "sonic:<tag>" => remote build from sonicRepositoryURL#<tag>
+//   - "sonic:<commit hash>" => remote build from sonicRepositoryURL#<commit hash>
+//   - everything else => no build strategy (pull)
+//
+// The returned plan is consumed by EnsureImages.
+func planImage(imageRef string) imageBuildPlan {
+	if imageRef == "sonic" {
+		return imageBuildPlan{kind: imageBuildSonicRemote, clientSrc: sonicRepositoryURL}
+	}
+	if imageRef == "sonic:local" {
+		return imageBuildPlan{kind: imageBuildSonicLocal, clientSrc: "sonic"}
+	}
+	if strings.HasPrefix(imageRef, "sonic:") {
+		tag := strings.TrimPrefix(imageRef, "sonic:")
+		if tag != "" {
+			return imageBuildPlan{
+				kind:      imageBuildSonicRemote,
+				clientSrc: fmt.Sprintf("%s#%s", sonicRepositoryURL, tag),
+			}
+		}
+	}
+	return imageBuildPlan{kind: imageBuildNone}
+}
+
+// deduplicateAndSort removes blank entries, deduplicates refs, and returns
+// them in lexical order.
+//
+// Sorting keeps execution deterministic and log output stable across runs.
+func deduplicateAndSort(in []string) []string {
+	set := map[string]bool{}
+	for _, imageRef := range in {
+		if strings.TrimSpace(imageRef) == "" {
+			continue
+		}
+		set[imageRef] = true
+	}
+	out := make([]string, 0, len(set))
+	for imageRef := range set {
+		out = append(out, imageRef)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// resolveBuildRoot finds the Norma repository root to execute docker builds.
+//
+// Starting from startDir, it walks up parent directories until it finds a
+// directory containing both:
+//   - Dockerfile
+//   - scripts/run_sonic.sh
+//
+// This guards against running docker build in unrelated directories while
+// keeping call sites simple.
+func resolveBuildRoot(startDir string) (string, error) {
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve build root: %w", err)
+	}
+
+	for {
+		dockerfile := filepath.Join(dir, "Dockerfile")
+		script := filepath.Join(dir, "scripts", "run_sonic.sh")
+		if fileExists(dockerfile) && fileExists(script) {
+			return dir, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	return "", errors.New("unable to locate norma build root with Dockerfile and scripts/run_sonic.sh")
+}
+
+// fileExists reports whether path exists and is a regular file-like entry
+// (i.e. not a directory).
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/driver/docker/images_test.go
+++ b/driver/docker/images_test.go
@@ -1,0 +1,281 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/docker/docker/api/types/image"
+)
+
+func TestPlanImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		imageRef string
+		want     imageBuildPlan
+	}{
+		{
+			name:     "remote main image",
+			imageRef: "sonic",
+			want: imageBuildPlan{
+				kind:      imageBuildSonicRemote,
+				clientSrc: sonicRepositoryURL,
+			},
+		},
+		{
+			name:     "local image",
+			imageRef: "sonic:local",
+			want: imageBuildPlan{
+				kind:      imageBuildSonicLocal,
+				clientSrc: "sonic",
+			},
+		},
+		{
+			name:     "tagged remote image",
+			imageRef: "sonic:v2.1.2",
+			want: imageBuildPlan{
+				kind:      imageBuildSonicRemote,
+				clientSrc: sonicRepositoryURL + "#v2.1.2",
+			},
+		},
+		{
+			name:     "non sonic image is pull-only plan",
+			imageRef: "alpine",
+			want: imageBuildPlan{
+				kind: imageBuildNone,
+			},
+		},
+		{
+			name:     "empty sonic tag falls back to pull-only",
+			imageRef: "sonic:",
+			want: imageBuildPlan{
+				kind: imageBuildNone,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := planImage(tt.imageRef)
+			if got != tt.want {
+				t.Fatalf("invalid plan, got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeduplicateAndSort(t *testing.T) {
+	input := []string{"sonic:v2.1", "", "sonic", "sonic:v2.1", "   ", "alpine"}
+	want := []string{"alpine", "sonic", "sonic:v2.1"}
+
+	got := deduplicateAndSort(input)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid refs, got %v, want %v", got, want)
+	}
+}
+
+func TestResolveBuildRoot(t *testing.T) {
+	t.Run("finds root by walking parents", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+			t.Fatalf("failed to write Dockerfile: %v", err)
+		}
+		scriptsDir := filepath.Join(root, "scripts")
+		if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+			t.Fatalf("failed to create scripts dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(scriptsDir, "run_sonic.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatalf("failed to write run_sonic.sh: %v", err)
+		}
+
+		deep := filepath.Join(root, "a", "b", "c")
+		if err := os.MkdirAll(deep, 0o755); err != nil {
+			t.Fatalf("failed to create deep directory: %v", err)
+		}
+
+		got, err := resolveBuildRoot(deep)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != root {
+			t.Fatalf("invalid root, got %q, want %q", got, root)
+		}
+	})
+
+	t.Run("fails when root markers are missing", func(t *testing.T) {
+		start := t.TempDir()
+		_, err := resolveBuildRoot(start)
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+	})
+}
+
+func TestFileExists(t *testing.T) {
+	t.Run("true for regular file", func(t *testing.T) {
+		dir := t.TempDir()
+		file := filepath.Join(dir, "f.txt")
+		if err := os.WriteFile(file, []byte("ok"), 0o644); err != nil {
+			t.Fatalf("failed to write file: %v", err)
+		}
+		if !fileExists(file) {
+			t.Fatalf("expected true for file")
+		}
+	})
+
+	t.Run("false for directory", func(t *testing.T) {
+		dir := t.TempDir()
+		if fileExists(dir) {
+			t.Fatalf("expected false for directory")
+		}
+	})
+
+	t.Run("false for missing path", func(t *testing.T) {
+		if fileExists(filepath.Join(t.TempDir(), "does-not-exist")) {
+			t.Fatalf("expected false for missing path")
+		}
+	})
+}
+
+func TestEnsureImages_EmptyRefs_NoOp(t *testing.T) {
+	if err := EnsureImages(t.Context(), nil, ""); err != nil {
+		t.Fatalf("EnsureImages should no-op for empty refs: %v", err)
+	}
+
+	if err := EnsureImages(t.Context(), []string{}, ""); err != nil {
+		t.Fatalf("EnsureImages should no-op for empty refs slice: %v", err)
+	}
+}
+
+func TestPullImage(t *testing.T) {
+	// This test assumes docker is available and configured correctly, but does
+	// not require any specific images to be present locally or remotely. Pulling
+	// "hello-world" is a simple smoke test that should succeed in a working
+	// environment and fail in a broken one.
+	ctx := t.Context()
+	cli, err := NewClient()
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+	defer func() {
+		_ = cli.Close()
+	}()
+
+	if err := pullImage(ctx, cli, "hello-world:latest"); err != nil {
+		t.Fatalf("failed to pull image: %v", err)
+	}
+}
+
+func TestBuildImage_Builds_SonicLocal(t *testing.T) {
+	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
+		t.Skipf("docker socket not available: %v", err)
+	}
+
+	buildRoot, err := resolveBuildRoot(".")
+	if err != nil {
+		t.Fatalf("failed to resolve build root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(buildRoot, "sonic")); err != nil {
+		t.Skipf("local sonic sources not available at %s: %v", filepath.Join(buildRoot, "sonic"), err)
+	}
+
+	if err := buildImage(t.Context(), buildRoot, "sonic:testlocal", "sonic"); err != nil {
+		t.Fatalf("failed to build sonic:testlocal image: %v", err)
+	}
+
+	cli, err := NewClient()
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+	defer func() {
+		// clean the image after test to avoid side effects
+		imgResponse, err := cli.cli.ImageRemove(t.Context(), "sonic:testlocal", image.RemoveOptions{})
+		if err != nil {
+			t.Errorf("failed to remove image sonic:testlocal: %v", err)
+		}
+		if len(imgResponse) == 0 {
+			t.Errorf("failed to remove image sonic:testlocal: empty response")
+		} else if len(imgResponse[0].Deleted) == 0 && len(imgResponse[0].Untagged) == 0 {
+			t.Errorf("failed to remove image sonic:testlocal: %v", imgResponse)
+		}
+		_ = cli.Close()
+	}()
+
+	if _, _, err := cli.cli.ImageInspectWithRaw(t.Context(), "sonic:testlocal"); err != nil {
+		t.Fatalf("image sonic:testlocal not found after build: %v", err)
+	}
+}
+
+func TestEnsureImages_BuildsSonicLocal(t *testing.T) {
+	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
+		t.Skipf("docker socket not available: %v", err)
+	}
+
+	buildRoot, err := resolveBuildRoot(".")
+	if err != nil {
+		t.Fatalf("failed to resolve build root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(buildRoot, "sonic")); err != nil {
+		t.Skipf("local sonic sources not available at %s: %v", filepath.Join(buildRoot, "sonic"), err)
+	}
+
+	imageRef := "sonic:local"
+	if err := EnsureImages(t.Context(), []string{imageRef}, buildRoot); err != nil {
+		t.Fatalf("failed to ensure image %s: %v", imageRef, err)
+	}
+
+	cli, err := NewClient()
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+	defer func() {
+		_ = cli.Close()
+	}()
+
+	if _, _, err := cli.cli.ImageInspectWithRaw(t.Context(), imageRef); err != nil {
+		t.Fatalf("image %s not found after EnsureImages build: %v", imageRef, err)
+	}
+}
+
+func TestEnsureImages_PullsImage(t *testing.T) {
+	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
+		t.Skipf("docker socket not available: %v", err)
+	}
+
+	buildRoot, err := resolveBuildRoot(".")
+	if err != nil {
+		t.Fatalf("failed to resolve build root: %v", err)
+	}
+
+	imageRef := "hello-world:latest"
+	if err := EnsureImages(t.Context(), []string{imageRef}, buildRoot); err != nil {
+		t.Fatalf("failed to ensure image %s: %v", imageRef, err)
+	}
+
+	cli, err := NewClient()
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+	defer func() { _ = cli.Close() }()
+
+	if _, _, err := cli.cli.ImageInspectWithRaw(t.Context(), imageRef); err != nil {
+		t.Fatalf("image %s not found after EnsureImages pull: %v", imageRef, err)
+	}
+}

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"regexp"
 	"slices"
+	"sync"
 	"time"
 
 	"golang.org/x/exp/maps"
@@ -102,10 +103,66 @@ type OperaNodeConfig struct {
 // with underscores and hyphens.
 var labelPattern = regexp.MustCompile("[A-Za-z0-9_-]+")
 
+// imageEnsureState stores the completion signal and final error for one
+// in-flight image provisioning operation.
+type imageEnsureState struct {
+	done chan struct{}
+	err  error
+}
+
+var (
+	imageEnsureMutex sync.Mutex
+	// imageEnsureInFlight tracks in-progress image provisioning by image tag.
+	//
+	// This allows concurrent node startups using the same image to share one
+	// EnsureImages call instead of triggering duplicate pull/build operations.
+	imageEnsureInFlight = map[string]*imageEnsureState{}
+)
+
+// ensureImageAvailable ensures the given image is locally available and
+// deduplicates concurrent ensure calls for the same image.
+//
+// If another goroutine is already provisioning the same image, this function
+// waits for that operation to complete and returns its result.
+func ensureImageAvailable(ctx context.Context, image string) error {
+	imageEnsureMutex.Lock()
+	if state, found := imageEnsureInFlight[image]; found {
+		imageEnsureMutex.Unlock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-state.done:
+			return state.err
+		}
+	}
+
+	state := &imageEnsureState{done: make(chan struct{})}
+	imageEnsureInFlight[image] = state
+	imageEnsureMutex.Unlock()
+
+	err := docker.EnsureImages(ctx, []string{image}, "")
+
+	imageEnsureMutex.Lock()
+	state.err = err
+	close(state.done)
+	delete(imageEnsureInFlight, image)
+	imageEnsureMutex.Unlock()
+
+	return err
+}
+
 // StartOperaDockerNode creates a new OperaNode running in a Docker container.
 func StartOperaDockerNode(ctx context.Context, client *docker.Client, dn *docker.Network, config *OperaNodeConfig) (*OperaNode, error) {
 	if !labelPattern.Match([]byte(config.Label)) {
 		return nil, fmt.Errorf("invalid label for node: '%v'", config.Label)
+	}
+
+	image := config.Image
+	if image == "" {
+		image = driver.DefaultClientDockerImageName
+	}
+	if err := ensureImageAvailable(ctx, image); err != nil {
+		return nil, fmt.Errorf("failed to ensure image %q: %w", image, err)
 	}
 
 	shutdownTimeout := 180 * time.Second
@@ -163,7 +220,7 @@ func StartOperaDockerNode(ctx context.Context, client *docker.Client, dn *docker
 		maps.Copy(envs, config.NetworkConfig.NetworkRules) // put in the network rules
 
 		return client.Start(&docker.ContainerConfig{
-			ImageName:       config.Image,
+			ImageName:       image,
 			ShutdownTimeout: &shutdownTimeout,
 			PortForwarding:  portForwarding,
 			Environment:     envs,
@@ -178,6 +235,7 @@ func StartOperaDockerNode(ctx context.Context, client *docker.Client, dn *docker
 
 	// Use a private copy of the config to avoid modifying the original.
 	nodeConfig := *config
+	nodeConfig.Image = image
 	if config.ValidatorId != nil {
 		nodeConfig.ValidatorId = new(int)
 		*nodeConfig.ValidatorId = *config.ValidatorId
@@ -329,7 +387,7 @@ func (n *OperaNode) RemovePeer(id driver.NodeID) error {
 	})
 }
 
-// Kill sends a SigKill singal to node.
+// Kill sends a SigKill signal to node.
 func (n *OperaNode) Kill() error {
 	return n.container.SendSignal(docker.SigKill)
 }


### PR DESCRIPTION
**Summary**
This PR introduces runtime Docker image provisioning for Norma scenarios and removes Sonic image prebuilds from `Makefile`.

**Changes**
- Added `images.go` with `EnsureImages(...)` to ensure required images on demand.
  - Image strategy:
    - `sonic` -> build from upstream Sonic repo
    - `sonic:local` -> build from local sonic sources
    - `sonic:<tag>` -> build from upstream at tag
    - `sonic:<commit hash>` -> build from upstream at commit hash
    - other images -> pull from registry

- Removed eager Sonic build targets/version matrix from `Makefile`. Why:
  - Avoid building unused images.
  - Decouple scenario execution from `Makefile` image orchestration.
  - Reduce maintenance overhead of hardcoded image build targets.
  

- [x] run  la Scala scenarios to check compatibility. 