### PR TITLE
Single proposer blackout

### DIFF
--- a/driver/checking/blocks_halted.go
+++ b/driver/checking/blocks_halted.go
@@ -1,0 +1,67 @@
+package checking
+
+import (
+	"fmt"
+
+	"github.com/0xsoniclabs/norma/driver"
+	"github.com/0xsoniclabs/norma/driver/monitoring"
+)
+
+func init() {
+	RegisterNetworkCheck("blocks_halted", func(net driver.Network, monitor *monitoring.Monitor) Checker {
+		return &blocksHaltedChecker{monitor: &monitoringDataAdapter{monitor}, toleranceSamples: defaultToleranceSamples}
+	})
+}
+
+// blocksHaltedChecker verifies that no node in the network is producing blocks.
+// It checks only the most recent window of data points (tail), so historical
+// data from removed nodes does not interfere.
+type blocksHaltedChecker struct {
+	monitor          MonitoringData
+	toleranceSamples int
+}
+
+func (c *blocksHaltedChecker) Configure(config CheckerConfig) Checker {
+	if config == nil {
+		return c
+	}
+
+	tolerance := c.toleranceSamples
+	if t, exist := config["tolerance"]; exist {
+		tolerance = t.(int)
+	}
+
+	return &blocksHaltedChecker{
+		monitor:          c.monitor,
+		toleranceSamples: tolerance,
+	}
+}
+
+func (c *blocksHaltedChecker) Check() error {
+	nodes := c.monitor.GetNodes()
+	for _, node := range nodes {
+		series := c.monitor.GetBlockStatus(node)
+
+		last := series.GetLatest()
+		if last == nil {
+			continue
+		}
+
+		// Only look at the tail: the last toleranceSamples data points.
+		var from monitoring.Time
+		if last.Position >= monitoring.Time(c.toleranceSamples) {
+			from = last.Position - monitoring.Time(c.toleranceSamples) + 1
+		}
+		points := series.GetRange(from, last.Position+1)
+		if len(points) < 2 {
+			continue
+		}
+
+		first := points[0].Value.BlockHeight
+		latest := points[len(points)-1].Value.BlockHeight
+		if latest > first {
+			return fmt.Errorf("network is still producing blocks: node %s block height increased from %d to %d in the last %d samples", node, first, latest, len(points))
+		}
+	}
+	return nil
+}

--- a/driver/checking/blocks_halted_test.go
+++ b/driver/checking/blocks_halted_test.go
@@ -1,0 +1,100 @@
+package checking
+
+import (
+	"testing"
+
+	"github.com/0xsoniclabs/norma/driver/monitoring"
+	"go.uber.org/mock/gomock"
+)
+
+func TestBlocksHalted_Passes_WhenConstant(t *testing.T) {
+	tests := map[string]struct {
+		series []uint64
+	}{
+		"constant": {
+			series: []uint64{5, 5, 5, 5, 5, 5, 5, 5, 5, 5},
+		},
+		"increased-then-stopped": {
+			series: []uint64{1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5},
+		},
+		"single-point": {
+			series: []uint64{10},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			series := createBlockSeries(t, test.series)
+			ctrl := gomock.NewController(t)
+			monitor := NewMockMonitoringData(ctrl)
+			monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
+			monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
+
+			c := blocksHaltedChecker{monitor: monitor, toleranceSamples: 5}
+			if err := c.Check(); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestBlocksHalted_Fails_WhenIncreasing(t *testing.T) {
+	tests := map[string]struct {
+		series []uint64
+	}{
+		"increasing": {
+			series: []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		},
+		"increasing-at-tail": {
+			series: []uint64{5, 5, 5, 5, 5, 5, 5, 5, 9, 10},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			series := createBlockSeries(t, test.series)
+			ctrl := gomock.NewController(t)
+			monitor := NewMockMonitoringData(ctrl)
+			monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
+			monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
+
+			c := blocksHaltedChecker{monitor: monitor, toleranceSamples: 5}
+			if err := c.Check(); err == nil {
+				t.Errorf("expected error but got nil")
+			}
+		})
+	}
+}
+
+func TestBlocksHalted_Passes_WhenNoData(t *testing.T) {
+	series := createBlockSeries(t, []uint64{})
+	ctrl := gomock.NewController(t)
+	monitor := NewMockMonitoringData(ctrl)
+	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
+	monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
+
+	c := blocksHaltedChecker{monitor: monitor, toleranceSamples: 5}
+	if err := c.Check(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestBlocksHalted_Configure(t *testing.T) {
+	// With tolerance=5, this series looks halted (last 5 points: 5,5,5,5,5)
+	series := createBlockSeries(t, []uint64{1, 2, 3, 4, 5, 5, 5, 5, 5})
+	ctrl := gomock.NewController(t)
+	monitor := NewMockMonitoringData(ctrl)
+	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"}).Times(2)
+	monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series).Times(2)
+
+	c := blocksHaltedChecker{monitor: monitor, toleranceSamples: 5}
+	if err := c.Check(); err != nil {
+		t.Errorf("unexpected error with tolerance 5: %v", err)
+	}
+
+	// With tolerance=9, this series is NOT halted (first point=1, last=5)
+	configured := c.Configure(CheckerConfig{"tolerance": 9})
+	if err := configured.Check(); err == nil {
+		t.Errorf("expected error with tolerance 9 but got nil")
+	}
+}

--- a/scenarios/test/blackout_single_proposer.yaml
+++ b/scenarios/test/blackout_single_proposer.yaml
@@ -1,0 +1,76 @@
+# This scenario simulates a mid-run stoppage of 50% of the validators.
+#
+# It is an "Allegro" network, with enabled single proposer flag.
+# Initially it has 1 genesis validator. A second validator registers at start
+# and becomes active after the first natural epoch seal (~15s, MaxEpochDuration).
+#
+# At time 25, the second validator leaves (simulating a crash/blackout).
+# Since 50% of stake is offline (below 2/3 quorum), block production halts.
+#
+# At time 80, the validator rejoins (fresh, no data_volume). It syncs the
+# finalized chain via dagstream and resumes consensus with the genesis validator.
+# The network should resume block production.
+name: Single Proposer Blackout
+
+# Duration increased to 180s to allow time for:
+# - epoch seal (~15s), leave at 25s, verify halt at 55s,
+# - rejoin at 80s, node sync (~30s), verify recovery at 150s.
+duration: 180
+
+# Initial validator nodes in the network.
+validators:
+  - name: validator
+    instances: 1
+    imagename: sonic:local
+
+# Network rules to be applied to the network.
+network_rules:
+  genesis:
+    UPGRADES_SONIC: true
+    UPGRADES_ALLEGRO: true
+    UPGRADES_SINGLE_PROPOSER: true
+
+checks:
+  # Verify block production has halted after the leave.
+  # At time 55, the validator has been offline for 30s. The blocks_halted check
+  # confirms no node's block height increased in the last 10 samples.
+  - time: 55
+    check: blocks_halted
+
+  # Verify blocks are rolling after recovery (after rejoin at time 80).
+  # The check runs at time 150, giving 70s for the node to sync and resume.
+  - time: 150
+    check: blocks_rolling
+
+nodes:
+  # This validator registers at start. MaxEpochDuration=15s means it becomes
+  # active in the consensus set after the first natural epoch seal (~15-20s).
+  # It leaves at 25s, halting the network (50% stake offline = below 2/3 quorum).
+  - name: validator-before
+    start: 0
+    leave: 25
+    client:
+      type: validator
+      imagename: sonic:local
+      val_id: 2
+
+  # This validator rejoins at time 80 to restore the network.
+  # No data_volume: the node syncs all epoch events from the genesis validator
+  # via the dagstream protocol, then resumes consensus.
+  - name: validator-after
+    rejoin: 80
+    client:
+      type: validator
+      imagename: sonic:local
+      val_id: 2
+
+
+# In the network there is a single application producing constant load.
+applications:
+  - name: load
+    type: counter
+    start: 5
+    end: 180
+    users: 50
+    rate:
+      constant: 50    # Tx/s


### PR DESCRIPTION
This PR adds a minimal blackout scenario similar to release tests case 19. 
A new blocks halted check is added to ensure no more blocks are produced once the second validator is offline.