### PR TITLE
Add generator name to transaction send log.

### DIFF
--- a/driver/network.go
+++ b/driver/network.go
@@ -85,7 +85,9 @@ type Network interface {
 	// any potential other resources.
 	Shutdown() error
 
-	SendTransaction(tx *types.Transaction)
+	// SendTransaction sends a transaction to the network.
+	// The source parameter is used for logging and debugging purposes.
+	SendTransaction(tx *types.Transaction, source string)
 
 	// Create a connection to a random node on the network. May fail if there
 	// is no node on the network with a ErrorEmptyNetwork error.

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -286,8 +286,8 @@ func (n *LocalNetwork) RemoveNode(node driver.Node) error {
 	return nil
 }
 
-func (n *LocalNetwork) SendTransaction(tx *types.Transaction) {
-	n.rpcWorkerPool.SendTransaction(tx)
+func (n *LocalNetwork) SendTransaction(tx *types.Transaction, source string) {
+	n.rpcWorkerPool.SendTransaction(tx, source)
 }
 
 func (n *LocalNetwork) DialRandomRpc() (rpcdriver.Client, error) {

--- a/driver/network/rpc/rpc_pool.go
+++ b/driver/network/rpc/rpc_pool.go
@@ -30,7 +30,7 @@ import (
 )
 
 type RpcWorkerPool struct {
-	txs     chan *types.Transaction
+	txs     chan transactionWithSource
 	workers map[driver.Node]*workerGroup
 	ctx     context.Context
 	cancel  context.CancelFunc
@@ -40,15 +40,15 @@ func NewRpcWorkerPool() *RpcWorkerPool {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &RpcWorkerPool{
-		txs:     make(chan *types.Transaction),
+		txs:     make(chan transactionWithSource, 100),
 		workers: make(map[driver.Node]*workerGroup, 10),
 		ctx:     ctx,
 		cancel:  cancel,
 	}
 }
 
-func (p *RpcWorkerPool) SendTransaction(tx *types.Transaction) {
-	p.txs <- tx
+func (p *RpcWorkerPool) SendTransaction(tx *types.Transaction, source string) {
+	p.txs <- transactionWithSource{tx: tx, source: source}
 }
 
 func (p *RpcWorkerPool) AfterNodeCreation(newNode driver.Node) {
@@ -63,7 +63,7 @@ func (p *RpcWorkerPool) AfterNodeCreation(newNode driver.Node) {
 	wg := workerGroup{}
 	p.workers[newNode] = &wg
 	for i := 0; i < 150; i++ {
-		wg.add(*rpcUrl, p.txs)
+		wg.add(newNode.GetLabel(), *rpcUrl, p.txs)
 	}
 }
 
@@ -95,8 +95,8 @@ func (p *RpcWorkerPool) Close() error {
 // When the group is closed, it should not be re-used and should be forgotten.
 type workerGroup []*worker
 
-func (wg *workerGroup) add(rpcUrl driver.URL, txs chan *types.Transaction) {
-	w := newWorker(rpcUrl, txs)
+func (wg *workerGroup) add(nodeName string, rpcUrl driver.URL, txs chan transactionWithSource) {
+	w := newWorker(nodeName, rpcUrl, txs)
 	*wg = append(*wg, w)
 }
 
@@ -120,27 +120,29 @@ func (wg *workerGroup) close() {
 // it starts dispatching asynchronously. This process can be interrupted by
 // closing the worker before it starts dispatching.
 type worker struct {
-	rpcUrl driver.URL
-	done   chan bool
-	txs    chan *types.Transaction
-	ctx    context.Context
-	cancel context.CancelFunc
+	nodeName string
+	rpcUrl   driver.URL
+	done     chan bool
+	txs      chan transactionWithSource
+	ctx      context.Context
+	cancel   context.CancelFunc
 }
 
-func newWorker(rpcUrl driver.URL, txs chan *types.Transaction) *worker {
+func newWorker(nodeName string, rpcUrl driver.URL, txs chan transactionWithSource) *worker {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	w := &worker{
-		rpcUrl: rpcUrl,
-		done:   make(chan bool),
-		txs:    txs,
-		ctx:    ctx,
-		cancel: cancel,
+		nodeName: nodeName,
+		rpcUrl:   rpcUrl,
+		done:     make(chan bool),
+		txs:      txs,
+		ctx:      ctx,
+		cancel:   cancel,
 	}
 
 	go func() {
 		if err := w.runRpcSenderLoop(); err != nil {
-			slog.Error("failed to open RPC connection", "error", err)
+			slog.Error("failed to open RPC connection", "error", err, "node", nodeName)
 			return
 		}
 	}()
@@ -158,9 +160,13 @@ func (p *worker) close() {
 
 func (p *worker) runRpcSenderLoop() error {
 	defer close(p.done)
-	rpcClient, err := network.RetryReturn(p.ctx, network.DefaultRetryAttempts, 1*time.Second, func() (*ethclient.Client, error) {
-		return ethclient.Dial(string(p.rpcUrl))
-	})
+	rpcClient, err := network.RetryReturn(
+		p.ctx,
+		network.DefaultRetryAttempts,
+		1*time.Second,
+		func() (*ethclient.Client, error) {
+			return ethclient.Dial(string(p.rpcUrl))
+		})
 
 	if rpcClient == nil || err != nil {
 		return err
@@ -170,12 +176,22 @@ func (p *worker) runRpcSenderLoop() error {
 	for {
 		select {
 		case tx := <-p.txs:
-			err := rpcClient.SendTransaction(context.Background(), tx)
+			err := rpcClient.SendTransaction(context.Background(), tx.tx)
 			if err != nil {
-				slog.Error("failed to send tx", "error", err)
+				slog.Warn("failed to send tx", "node", p.nodeName, "source", tx.source, "error", err)
 			}
 		case <-p.ctx.Done():
 			return nil
 		}
 	}
+}
+
+// transactionWithSource is a struct that holds a transaction and its source.
+// It is used to provide feedback about the origin of the transaction in case
+// of an error when sending it to the RPC client.
+type transactionWithSource struct {
+	tx *types.Transaction
+	// source is a string describing the origin of the transaction,
+	// e.g. the load generator that created it.
+	source string
 }

--- a/driver/network/rpc/rpc_pool_test.go
+++ b/driver/network/rpc/rpc_pool_test.go
@@ -29,8 +29,8 @@ func TestRetryRpcReturnGracefully(t *testing.T) {
 	t.Parallel()
 
 	start := time.Now()
-	txs := make(chan *types.Transaction)
-	w := newWorker("wrong", txs)
+	txs := make(chan transactionWithSource)
+	w := newWorker("test", "wrong", txs)
 
 	time.Sleep(6 * time.Second)
 	w.close()
@@ -58,7 +58,7 @@ func TestClosePool(t *testing.T) {
 	var tx types.Transaction
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
-		pool.SendTransaction(&tx)
+		pool.SendTransaction(&tx, "test")
 	}
 
 	wg.Wait()
@@ -80,16 +80,16 @@ func TestClosePool(t *testing.T) {
 }
 
 func TestCloseWorkerStartStop(t *testing.T) {
-	txs := make(chan *types.Transaction)
-	w := newWorker("wrong", txs)
+	txs := make(chan transactionWithSource)
+	w := newWorker("test", "wrong", txs)
 	w.close()
 }
 
 func TestCloseWorkerGroupStartStop(t *testing.T) {
-	txs := make(chan *types.Transaction)
+	txs := make(chan transactionWithSource)
 	wg := workerGroup{}
 	for i := 0; i < 150; i++ {
-		wg.add("wrong", txs)
+		wg.add("test", "wrong", txs)
 	}
 	wg.close()
 }

--- a/driver/network_mock.go
+++ b/driver/network_mock.go
@@ -169,15 +169,15 @@ func (mr *MockNetworkMockRecorder) RemoveNode(arg0 any) *gomock.Call {
 }
 
 // SendTransaction mocks base method.
-func (m *MockNetwork) SendTransaction(tx *types.Transaction) {
+func (m *MockNetwork) SendTransaction(tx *types.Transaction, source string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SendTransaction", tx)
+	m.ctrl.Call(m, "SendTransaction", tx, source)
 }
 
 // SendTransaction indicates an expected call of SendTransaction.
-func (mr *MockNetworkMockRecorder) SendTransaction(tx any) *gomock.Call {
+func (mr *MockNetworkMockRecorder) SendTransaction(tx, source any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTransaction", reflect.TypeOf((*MockNetwork)(nil).SendTransaction), tx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTransaction", reflect.TypeOf((*MockNetwork)(nil).SendTransaction), tx, source)
 }
 
 // Shutdown mocks base method.

--- a/load/controller/controller_test.go
+++ b/load/controller/controller_test.go
@@ -58,7 +58,7 @@ func TestLoadGeneration_CanRealizeConstantTrafficShape(t *testing.T) {
 			check := NewRateCheck(float64(rate))
 			var count atomic.Int32
 			net.EXPECT().DialRandomRpc().AnyTimes().Return(rpcClient, nil)
-			net.EXPECT().SendTransaction(gomock.Any(), "").AnyTimes().Do(func(any) {
+			net.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).AnyTimes().Do(func(any, any) {
 				check.NewEvent()
 				count.Add(1)
 			})

--- a/load/controller/controller_test.go
+++ b/load/controller/controller_test.go
@@ -58,7 +58,7 @@ func TestLoadGeneration_CanRealizeConstantTrafficShape(t *testing.T) {
 			check := NewRateCheck(float64(rate))
 			var count atomic.Int32
 			net.EXPECT().DialRandomRpc().AnyTimes().Return(rpcClient, nil)
-			net.EXPECT().SendTransaction(gomock.Any()).AnyTimes().Do(func(any) {
+			net.EXPECT().SendTransaction(gomock.Any(), "").AnyTimes().Do(func(any) {
 				check.NewEvent()
 				count.Add(1)
 			})

--- a/load/controller/generator.go
+++ b/load/controller/generator.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"log/slog"
+	"reflect"
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/load/app"
@@ -29,7 +30,8 @@ func runGeneratorLoop(user app.User, trigger <-chan struct{}, network driver.Net
 		if err != nil {
 			slog.Error("failed to generate tx", "error", err)
 		} else {
-			network.SendTransaction(tx)
+			sourceApp := reflect.TypeOf(user).Elem().Name()
+			network.SendTransaction(tx, sourceApp)
 		}
 	}
 }

--- a/load/controller/mocked_test.go
+++ b/load/controller/mocked_test.go
@@ -52,7 +52,7 @@ func TestMockedTrafficGenerating(t *testing.T) {
 	// app should be called 10-times to generate 10 txs
 	mockUser.EXPECT().GenerateTx().Return(&demoTx, nil).MinTimes(5).MaxTimes(11)
 	// network should be called 10-times to send 10 txs
-	mockedNetwork.EXPECT().SendTransaction(&demoTx).MinTimes(5).MaxTimes(11)
+	mockedNetwork.EXPECT().SendTransaction(&demoTx, gomock.Any()).MinTimes(5).MaxTimes(11)
 
 	// use constant shaper
 	constantShaper := shaper.NewConstantShaper(100) // 100 txs/sec


### PR DESCRIPTION
This PR helps debugging failing transactions by providing the name of the causing generator in the log message