### PR TITLE
Reduce norma memory use

### DIFF
--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -300,9 +300,9 @@ func TestLocalNetwork_CanRunWithVariousValidators(t *testing.T) {
 
 	validators := driver.NewValidators([]parser.Validator{
 		{},
-		{Name: "validator1", Instances: &three, ImageName: "sonic:v2.0.0"},
-		{Name: "validator2", Instances: &two, ImageName: "sonic:v2.0.1"},
-		{Name: "validator3", Instances: &one, ImageName: "sonic:v2.0.2"},
+		{Name: "validator1", Instances: &three, ImageName: "sonic:v2.1.6"},
+		{Name: "validator2", Instances: &two, ImageName: "sonic:local"},
+		{Name: "validator3", Instances: &one, ImageName: "sonic:latest"},
 		{Name: "validator4", ImageName: "sonic"},
 	})
 
@@ -521,7 +521,7 @@ func TestLocalNetwork_Can_Run_Multiple_Client_Images_TaggedVersions(t *testing.T
 		_ = net.Shutdown()
 	})
 
-	images := []string{"sonic:v2.0.3", "sonic:v2.0.2", "sonic:v2.0.1", "sonic:v2.0.0"}
+	images := []string{"sonic:v2.1.6", "sonic:local", "sonic:latest"}
 	checksum := make(chan string)
 	gotChecksums := make(map[string]struct{})
 	for _, image := range images {
@@ -668,8 +668,9 @@ func TestLocalNetworkAdvanceEpoch_Success(t *testing.T) {
 
 func TestLocalNetwork_FailingFlagPropagated(t *testing.T) {
 	config := driver.NetworkConfig{Validators: []driver.Validator{
-		{Name: "validator", Failing: true, Instances: 1, ImageName: driver.DefaultClientDockerImageName}},
-	}
+		{Name: "validator-ok", Failing: false, Instances: 1, ImageName: driver.DefaultClientDockerImageName},
+		{Name: "validator-failing", Failing: true, Instances: 1, ImageName: driver.DefaultClientDockerImageName},
+	}}
 	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
@@ -688,10 +689,21 @@ func TestLocalNetwork_FailingFlagPropagated(t *testing.T) {
 		t.Fatalf("failed to create node: %v", err)
 	}
 
+	var failingNodes int
+	var nonFailingNodes int
 	for _, node := range net.GetActiveNodes() {
-		if !node.IsExpectedFailure() {
-			t.Errorf("node is not failing: %s", node.GetLabel())
+		if node.IsExpectedFailure() {
+			failingNodes++
+		} else {
+			nonFailingNodes++
 		}
+	}
+
+	if got, want := failingNodes, 2; got < want {
+		t.Errorf("insufficient failing nodes, got %d, want at least %d", got, want)
+	}
+	if got, want := nonFailingNodes, 1; got < want {
+		t.Errorf("insufficient non-failing nodes, got %d, want at least %d", got, want)
 	}
 
 }

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -521,7 +521,7 @@ func TestLocalNetwork_Can_Run_Multiple_Client_Images_TaggedVersions(t *testing.T
 		_ = net.Shutdown()
 	})
 
-	images := []string{"sonic:v2.1.6", "sonic:local", "sonic:latest"}
+	images := []string{"sonic:v2.1.5", "sonic:v2.1.6", "sonic:local", "sonic:latest"}
 	checksum := make(chan string)
 	gotChecksums := make(map[string]struct{})
 	for _, image := range images {

--- a/driver/parser/parser_test.go
+++ b/driver/parser/parser_test.go
@@ -62,10 +62,10 @@ name: Small Test
 validators:
   - name: validator-1
   - name: validator-2
-    imagename: "sonic:v2.0.2"
+    imagename: "sonic:v2.1.6"
   - name: validator-3
     instances: 2
-    imagename: "sonic:v2.0.1"
+    imagename: "sonic:local"
   - name: validator-4
     instances: 3
     imagename: "sonic"

--- a/scripts/run_sonic.sh
+++ b/scripts/run_sonic.sh
@@ -16,7 +16,12 @@ datadir=$STATE_DB_DATADIR
 # Initialize datadir
 if [[ ! -d "${datadir}/chaindata" ]]; then
   mkdir -p "${datadir}"
-  ./sonictool --datadir "${datadir}" genesis json --experimental /genesis.json
+  ./sonictool \
+    --datadir "${datadir}" \
+    --statedb.livecache 1 \
+    --statedb.archivecache 1 \
+    --statedb.cache 1024 \
+    genesis json --experimental /genesis.json
 fi
 
 # Create password file for validator keystore decryption.
@@ -73,14 +78,17 @@ export GOMEMLIMIT="1GiB"
 ./sonicd \
     --datadir="${datadir}" \
     ${val_flag} \
-    --http --http.addr 0.0.0.0 --http.port 18545 --http.api admin,eth,sonic \
-    --ws --ws.addr 0.0.0.0 --ws.port 18546 --ws.api admin,eth,sonic \
+    --http --http.addr 0.0.0.0 --http.port 18545 --http.api admin,eth,sonic,txpool \
+    --ws --ws.addr 0.0.0.0 --ws.port 18546 --ws.api admin,eth,sonic,txpool \
     --pprof --pprof.addr 0.0.0.0 \
     --nat="extip:${external_ip}" \
     --metrics \
     --metrics.expensive \
     --config config.toml \
     --datadir.minfreedisk 0 \
+    --statedb.livecache 1 \
+    --statedb.archivecache 1 \
+    --statedb.cache 1024 \
     $EXTRA_ARGUMENTS
 
 # docker runs by default with root user, so any files or folders created by


### PR DESCRIPTION
This PR reduces container memory use from ~700 MB to ~350 MB. 

Old images not having access to these command line arguments are removed from testing. 