### PR TITLE
Give meaningful names to containers

### DIFF
--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -73,6 +73,7 @@ type Container struct {
 
 // ContainerConfig defines parameters for running Docker Containers.
 type ContainerConfig struct {
+	Hostname        string
 	ImageName       string
 	ShutdownTimeout *time.Duration
 	PortForwarding  map[network.Port]network.Port // Container Port => Host Port
@@ -184,7 +185,7 @@ func (c *Client) Start(config *ContainerConfig) (*Container, error) {
 		Init:         &init,
 		CapAdd:       []string{"NET_ADMIN"},
 		Binds:        binds,
-	}, nil, nil, "")
+	}, nil, nil, config.Hostname)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/executor/executor_test.go
+++ b/driver/executor/executor_test.go
@@ -35,7 +35,7 @@ func TestExecutor_RunEmptyScenario(t *testing.T) {
 	clock := NewSimClock()
 	net := driver.NewMockNetwork(ctrl)
 	scenario := parser.Scenario{
-		Name:       "Test",
+		Name:       t.Name(),
 		Duration:   10,
 		Validators: []parser.Validator{{Name: "validator"}},
 	}
@@ -53,7 +53,7 @@ func TestExecutor_RunSingleNodeScenario(t *testing.T) {
 
 	clock := NewSimClock()
 	scenario := parser.Scenario{
-		Name:       "Test",
+		Name:       t.Name(),
 		Duration:   10,
 		Validators: []parser.Validator{{Name: "validator"}},
 		Nodes: []parser.Node{{
@@ -88,7 +88,7 @@ func TestExecutor_RunMultipleNodeScenario(t *testing.T) {
 
 	clock := NewSimClock()
 	scenario := parser.Scenario{
-		Name:       "Test",
+		Name:       t.Name(),
 		Duration:   10,
 		Validators: []parser.Validator{{Name: "validator"}},
 		Nodes: []parser.Node{{
@@ -131,7 +131,7 @@ func TestExecutor_Validator_StartEndRejoinLeave(t *testing.T) {
 	var two, three = 2, 3
 	clock := NewSimClock()
 	scenario := parser.Scenario{
-		Name:       "Test",
+		Name:       t.Name(),
 		Duration:   10,
 		Validators: []parser.Validator{{Name: "validator"}}, //id=1
 		Nodes: []parser.Node{
@@ -235,7 +235,7 @@ func TestExecutor_Validator_StartEndRejoinLeave(t *testing.T) {
 func TestExecutor_ObserverNodes_HaveNilValidatorID(t *testing.T) {
 	clock := NewSimClock()
 	scenario := parser.Scenario{
-		Name:       "Test",
+		Name:       t.Name(),
 		Duration:   10,
 		Validators: []parser.Validator{{Name: "validator"}},
 		Nodes: []parser.Node{
@@ -295,7 +295,7 @@ func TestExecutor_RunSingleApplicationScenario(t *testing.T) {
 
 	clock := NewSimClock()
 	scenario := parser.Scenario{
-		Name:       "Test",
+		Name:       t.Name(),
 		Duration:   10,
 		Validators: []parser.Validator{{Name: "validator"}},
 		Applications: []parser.Application{{
@@ -329,7 +329,7 @@ func TestExecutor_RunMultipleApplicationScenario(t *testing.T) {
 
 	clock := NewSimClock()
 	scenario := parser.Scenario{
-		Name:       "Test",
+		Name:       t.Name(),
 		Duration:   10,
 		Validators: []parser.Validator{{Name: "validator"}},
 		Applications: []parser.Application{{
@@ -368,7 +368,7 @@ func TestExecutor_TestUserAbort(t *testing.T) {
 
 	clock := NewWallTimeClock()
 	scenario := parser.Scenario{
-		Name:       "Test",
+		Name:       t.Name(),
 		Duration:   5,
 		Validators: []parser.Validator{{Name: "validator"}},
 		Nodes: []parser.Node{{
@@ -404,7 +404,7 @@ func TestExecutor_RunScenarioWithDefaultChecks(t *testing.T) {
 	clock := NewSimClock()
 	net := driver.NewMockNetwork(ctrl)
 	scenario := parser.Scenario{
-		Name:       "Test",
+		Name:       t.Name(),
 		Duration:   10,
 		Validators: []parser.Validator{{Name: "validator"}},
 	}
@@ -447,7 +447,7 @@ func TestExecutor_RunScenarioWithDefaultChecks(t *testing.T) {
 func TestExecutor_scheduleNetworkRulesEvents(t *testing.T) {
 	clock := NewSimClock()
 	scenario := parser.Scenario{
-		Name:     "Test",
+		Name:     t.Name(),
 		Duration: 10,
 		NetworkRules: parser.NetworkRules{
 			Updates: []parser.NetworkRulesUpdate{
@@ -497,7 +497,7 @@ func TestExecutor_scheduleAdvanceEpochEvents(t *testing.T) {
 
 	clock := NewSimClock()
 	scenario := parser.Scenario{
-		Name:     "Test",
+		Name:     t.Name(),
 		Duration: 10,
 		AdvanceEpoch: []parser.AdvanceEpoch{
 			{Time: 1, Epochs: &one},

--- a/driver/monitoring/monitor_test.go
+++ b/driver/monitoring/monitor_test.go
@@ -173,9 +173,9 @@ func TestMonitorIntegrationPrometheusLogReceived(t *testing.T) {
 		_ = client.Close()
 	})
 	node, err := opera.StartOperaDockerNode(t.Context(), client, nil, &opera.OperaNodeConfig{
-		Label:         "test",
+		Label:         t.Name(),
 		Image:         driver.DefaultClientDockerImageName,
-		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
+		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())},
 	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)

--- a/driver/monitoring/node/cpu_profile_test.go
+++ b/driver/monitoring/node/cpu_profile_test.go
@@ -34,9 +34,9 @@ func TestCanCollectCpuProfileDateFromOperaNode(t *testing.T) {
 		_ = docker.Close()
 	})
 	node, err := opera.StartOperaDockerNode(t.Context(), docker, nil, &opera.OperaNodeConfig{
-		Label:         "test",
+		Label:         t.Name(),
 		Image:         driver.DefaultClientDockerImageName,
-		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
+		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())},
 	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)

--- a/driver/monitoring/node/prom_log_source_test.go
+++ b/driver/monitoring/node/prom_log_source_test.go
@@ -97,7 +97,7 @@ func TestLogsIntegrationGetRealMetric(t *testing.T) {
 	node, err := opera.StartOperaDockerNode(t.Context(), client, nil, &opera.OperaNodeConfig{
 		Label:         "test",
 		Image:         driver.DefaultClientDockerImageName,
-		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
+		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())},
 	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)

--- a/driver/monitoring/prometheus/prometheus_test.go
+++ b/driver/monitoring/prometheus/prometheus_test.go
@@ -118,7 +118,8 @@ func startPrometheus(t *testing.T, net *local.LocalNetwork) *Prometheus {
 
 // createLocalNetwork creates a docker network and returns it.
 func createLocalNetwork(t *testing.T) *local.LocalNetwork {
-	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
+	config := driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())}
+	config.Validators[0].Name = fmt.Sprintf("validator-%s", t.Name())
 	net, err := local.NewLocalNetwork(t.Context(), &config)
 	if err != nil {
 		t.Fatalf("error: %v", err)

--- a/driver/network.go
+++ b/driver/network.go
@@ -17,6 +17,7 @@
 package driver
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/0xsoniclabs/carmen/go/common"
@@ -31,7 +32,9 @@ import (
 const DefaultClientDockerImageName = "sonic"
 
 // DefaultValidators is a default configuration for a single validator.
-var DefaultValidators = NewDefaultValidators(1)
+func DefaultValidators(name string) Validators {
+	return NewDefaultTestValidators(name, 1)
+}
 
 // ResolveClientImageName returns imageName if set, otherwise the default client
 // image name.
@@ -188,6 +191,10 @@ type Validators []Validator
 // using the default client docker image.
 func NewDefaultValidators(instances int) Validators {
 	return []Validator{{Name: "validator", Instances: instances, ImageName: DefaultClientDockerImageName}}
+}
+
+func NewDefaultTestValidators(name string, instances int) Validators {
+	return []Validator{{Name: fmt.Sprintf("validator-%s", name), Instances: instances, ImageName: DefaultClientDockerImageName}}
 }
 
 // NewValidators creates a new Validators from a parser.Validators.

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -126,7 +126,10 @@ func NewLocalNetwork(ctx context.Context, config *driver.NetworkConfig) (*LocalN
 		for j := 0; j < validator.Instances; j++ {
 			wg.Add(1)
 			image := validator.ImageName
-			label := fmt.Sprintf("%s-%d", validator.Name, j)
+			label := fmt.Sprintf("validator-%d", j)
+			if len(validator.Name) != 0 {
+				label = fmt.Sprintf("%s-%d", validator.Name, j)
+			}
 			go func(idx int) {
 				defer wg.Done()
 				validatorId := idx + 1

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -43,7 +43,7 @@ func TestLocalNetworkIsNetwork(t *testing.T) {
 }
 
 func TestLocalNetwork_CanStartNodesAndShutThemDown(t *testing.T) {
-	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
+	config := driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())}
 	for _, N := range []int{1, 3} {
 		N := N
 		t.Run(fmt.Sprintf("num_nodes=%d", N), func(t *testing.T) {
@@ -85,9 +85,9 @@ func TestLocalNetwork_CanStartNodesAndShutThemDown(t *testing.T) {
 func TestLocalNetwork_CanEnforceNetworkLatency(t *testing.T) {
 	for _, rtt := range []time.Duration{0, 100 * time.Millisecond, 200 * time.Millisecond} {
 		rtt := rtt
-		t.Run(fmt.Sprintf("rtt=%v", rtt), func(t *testing.T) {
+		t.Run(fmt.Sprintf("rtt-%v", rtt), func(t *testing.T) {
 			config := driver.NetworkConfig{
-				Validators:    driver.NewDefaultValidators(2),
+				Validators:    driver.NewDefaultTestValidators(t.Name(), 2),
 				RoundTripTime: rtt,
 			}
 			net, err := NewLocalNetwork(t.Context(), &config)
@@ -118,7 +118,8 @@ func TestLocalNetwork_CanEnforceNetworkLatency(t *testing.T) {
 }
 
 func TestLocalNetwork_CanStartApplicationsAndShutThemDown(t *testing.T) {
-	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
+	config := driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())}
+	config.Validators[0].Name = fmt.Sprintf("validator-%s", t.Name())
 	for _, N := range []int{1, 3} {
 		N := N
 		t.Run(fmt.Sprintf("num_nodes=%d", N), func(t *testing.T) {
@@ -164,7 +165,7 @@ func TestLocalNetwork_CanStartApplicationsAndShutThemDown(t *testing.T) {
 
 func TestLocalNetwork_CanPerformNetworkShutdown(t *testing.T) {
 	N := 2
-	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
+	config := driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())}
 
 	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
@@ -200,7 +201,7 @@ func TestLocalNetwork_CanPerformNetworkShutdown(t *testing.T) {
 
 func TestLocalNetwork_Shutdown_Graceful(t *testing.T) {
 	N := 3
-	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
+	config := driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())}
 
 	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
@@ -265,7 +266,7 @@ func TestLocalNetwork_Shutdown_Graceful(t *testing.T) {
 func TestLocalNetwork_CanRunWithMultipleValidators(t *testing.T) {
 	for _, N := range []int{1, 3} {
 		N := N
-		config := driver.NetworkConfig{Validators: driver.NewDefaultValidators(N)}
+		config := driver.NetworkConfig{Validators: driver.NewDefaultTestValidators(t.Name(), N)}
 		t.Run(fmt.Sprintf("num_validators=%d", N), func(t *testing.T) {
 			net, err := NewLocalNetwork(t.Context(), &config)
 			if err != nil {
@@ -300,9 +301,9 @@ func TestLocalNetwork_CanRunWithVariousValidators(t *testing.T) {
 
 	validators := driver.NewValidators([]parser.Validator{
 		{},
-		{Name: "validator1", Instances: &three, ImageName: "sonic:v2.1.6"},
-		{Name: "validator2", Instances: &two, ImageName: "sonic:local"},
-		{Name: "validator3", Instances: &one, ImageName: "sonic:latest"},
+		{Name: "validator1", Instances: &three, ImageName: "sonic:v2.1.5"},
+		{Name: "validator2", Instances: &two, ImageName: "sonic:v2.1.6"},
+		{Name: "validator3", Instances: &one, ImageName: "sonic:local"},
 		{Name: "validator4", ImageName: "sonic"},
 	})
 
@@ -324,7 +325,7 @@ func TestLocalNetwork_CanRunWithVariousValidators(t *testing.T) {
 }
 
 func TestLocalNetwork_NotifiesListenersOnNodeStartup(t *testing.T) {
-	config := driver.NetworkConfig{Validators: driver.NewDefaultValidators(2)}
+	config := driver.NetworkConfig{Validators: driver.NewDefaultTestValidators(t.Name(), 2)}
 	ctrl := gomock.NewController(t)
 	listener := driver.NewMockNetworkListener(ctrl)
 
@@ -345,7 +346,7 @@ func TestLocalNetwork_NotifiesListenersOnNodeStartup(t *testing.T) {
 	listener.EXPECT().AfterNodeCreation(gomock.Any())
 
 	_, err = net.CreateNode(&driver.NodeConfig{
-		Name:  "Test",
+		Name:  t.Name(),
 		Image: driver.DefaultClientDockerImageName,
 	})
 	if err != nil {
@@ -360,7 +361,7 @@ func TestLocalNetwork_NotifiesListenersOnNodeStartup(t *testing.T) {
 }
 
 func TestLocalNetwork_NotifiesListenersOnAppStartup(t *testing.T) {
-	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
+	config := driver.NetworkConfig{Validators: driver.NewDefaultTestValidators(t.Name(), 1)}
 	ctrl := gomock.NewController(t)
 	listener := driver.NewMockNetworkListener(ctrl)
 
@@ -384,7 +385,7 @@ func TestLocalNetwork_NotifiesListenersOnAppStartup(t *testing.T) {
 }
 
 func TestLocalNetwork_CanRemoveNode(t *testing.T) {
-	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
+	config := driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())}
 	for _, N := range []int{1, 3} {
 		N := N
 		t.Run(fmt.Sprintf("num_nodes=%d", N), func(t *testing.T) {
@@ -448,8 +449,8 @@ func TestLocalNetwork_CanRemoveNode(t *testing.T) {
 func TestLocalNetwork_Num_Validators_Started(t *testing.T) {
 	for i := 1; i < 3; i++ {
 		i := i
-		t.Run(fmt.Sprintf("num_validators=%d", i), func(t *testing.T) {
-			config := driver.NetworkConfig{Validators: driver.NewDefaultValidators(i)}
+		t.Run(fmt.Sprintf("num_validators%d", i), func(t *testing.T) {
+			config := driver.NetworkConfig{Validators: driver.NewDefaultTestValidators(t.Name(), i)}
 			net, err := NewLocalNetwork(t.Context(), &config)
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
@@ -470,7 +471,7 @@ func TestLocalNetwork_Num_Validators_Started(t *testing.T) {
 // TestLocalNetwork_Can_Run_Multiple_Client_Images_LatestVersions checks if
 // docker can create client through images called "sonic" and "sonic:local"
 func TestLocalNetwork_Can_Run_Multiple_Client_Images_LatestVersions(t *testing.T) {
-	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
+	config := driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())}
 
 	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
@@ -511,7 +512,7 @@ func TestLocalNetwork_Can_Run_Multiple_Client_Images_LatestVersions(t *testing.T
 // docker can create client through images called "sonic:<versions>"
 // The checksum of each version must be unique.
 func TestLocalNetwork_Can_Run_Multiple_Client_Images_TaggedVersions(t *testing.T) {
-	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
+	config := driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())}
 
 	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
@@ -552,7 +553,7 @@ func TestLocalNetwork_Can_Run_Multiple_Client_Images_TaggedVersions(t *testing.T
 // and extract the checksum.
 func getChecksum(net *LocalNetwork, image string) (checksum string, err error) {
 	node, err := net.CreateNode(&driver.NodeConfig{
-		Name:  fmt.Sprintf("T-%s", image),
+		Name:  fmt.Sprintf("T-%s", strings.ReplaceAll(image, ":", "-")),
 		Image: image,
 	})
 	if err != nil {
@@ -580,7 +581,7 @@ func getChecksum(net *LocalNetwork, image string) (checksum string, err error) {
 }
 
 func TestLocalNetworkApplyNetworkRules_Success(t *testing.T) {
-	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
+	config := driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())}
 	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
@@ -628,7 +629,7 @@ func TestLocalNetworkApplyNetworkRules_Success(t *testing.T) {
 }
 
 func TestLocalNetworkAdvanceEpoch_Success(t *testing.T) {
-	config := driver.NetworkConfig{Validators: driver.DefaultValidators}
+	config := driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())}
 	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
@@ -711,7 +712,7 @@ func TestLocalNetwork_FailingFlagPropagated(t *testing.T) {
 func TestLocalNetwork_MountDataDir_Can_Be_Reused(t *testing.T) {
 	temp := t.TempDir()
 
-	config := driver.NetworkConfig{Validators: driver.DefaultValidators, OutputDir: temp}
+	config := driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name()), OutputDir: temp}
 	net, err := NewLocalNetwork(t.Context(), &config)
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -26,11 +26,13 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
 	"golang.org/x/exp/maps"
 
+	"github.com/0xsoniclabs/norma/driver/parser"
 	rpcdriver "github.com/0xsoniclabs/norma/driver/rpc"
 	"github.com/0xsoniclabs/norma/genesis"
 
@@ -104,10 +106,6 @@ type OperaNodeConfig struct {
 	ExtraArguments string
 }
 
-// labelPattern restricts labels for nodes to non-empty alpha-numerical strings
-// with underscores and hyphens.
-var labelPattern = regexp.MustCompile("[A-Za-z0-9_-]+")
-
 // imageEnsureState stores the completion signal and final error for one
 // in-flight image provisioning operation.
 type imageEnsureState struct {
@@ -158,7 +156,10 @@ func ensureImageAvailable(ctx context.Context, image string) error {
 
 // StartOperaDockerNode creates a new OperaNode running in a Docker container.
 func StartOperaDockerNode(ctx context.Context, client *docker.Client, dn *docker.Network, config *OperaNodeConfig) (*OperaNode, error) {
-	if !labelPattern.Match([]byte(config.Label)) {
+	// avoid slashes and underscores in labels
+	config.Label = strings.ReplaceAll(config.Label, "/", "-")
+	config.Label = strings.ReplaceAll(config.Label, "_", "-")
+	if !parser.NamePattern.MatchString(config.Label) {
 		return nil, fmt.Errorf("invalid label for node: '%v'", config.Label)
 	}
 
@@ -269,6 +270,7 @@ func StartOperaDockerNode(ctx context.Context, client *docker.Client, dn *docker
 		maps.Copy(envs, config.NetworkConfig.NetworkRules) // put in the network rules
 
 		return client.Start(&docker.ContainerConfig{
+			Hostname:        config.Label,
 			ImageName:       image,
 			ShutdownTimeout: &shutdownTimeout,
 			PortForwarding:  portForwarding,

--- a/driver/node/opera_test.go
+++ b/driver/node/opera_test.go
@@ -68,9 +68,9 @@ func TestOperaNode_StartAndStop(t *testing.T) {
 		_ = docker.Close()
 	})
 	node, err := StartOperaDockerNode(t.Context(), docker, nil, &OperaNodeConfig{
-		Label:         "test",
+		Label:         t.Name(),
 		Image:         driver.DefaultClientDockerImageName,
-		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
+		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())},
 	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)
@@ -91,7 +91,7 @@ func TestOperaNode_Cleanup_RemovesTempDirs(t *testing.T) {
 
 	node := &OperaNode{
 		host:     cleanupHostStub{},
-		config:   &OperaNodeConfig{Label: "test"},
+		config:   &OperaNodeConfig{Label: t.Name()},
 		tempDirs: []string{tempDir},
 	}
 
@@ -117,9 +117,9 @@ func TestOperaNode_RpcServiceIsReadyAfterStartup(t *testing.T) {
 		_ = docker.Close()
 	})
 	node, err := StartOperaDockerNode(t.Context(), docker, nil, &OperaNodeConfig{
-		Label:         "test",
+		Label:         t.Name(),
 		Image:         driver.DefaultClientDockerImageName,
-		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
+		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())},
 	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)
@@ -142,9 +142,9 @@ func TestOperaNode_StreamLog(t *testing.T) {
 	})
 
 	node, err := StartOperaDockerNode(t.Context(), docker, nil, &OperaNodeConfig{
-		Label:         "test",
+		Label:         t.Name(),
 		Image:         driver.DefaultClientDockerImageName,
-		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
+		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())},
 	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)
@@ -196,9 +196,9 @@ func TestOperaNode_MetricsExposed(t *testing.T) {
 	})
 
 	node, err := StartOperaDockerNode(t.Context(), docker, nil, &OperaNodeConfig{
-		Label:         "test",
+		Label:         t.Name(),
 		Image:         driver.DefaultClientDockerImageName,
-		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
+		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())},
 	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)
@@ -242,9 +242,9 @@ func TestClient_Stop_Graceful(t *testing.T) {
 	}()
 
 	node, err := StartOperaDockerNode(t.Context(), client, nil, &OperaNodeConfig{
-		Label:         "test",
+		Label:         t.Name(),
 		Image:         driver.DefaultClientDockerImageName,
-		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators},
+		NetworkConfig: &driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())},
 	})
 	if err != nil {
 		t.Fatalf("failed to create client node: %v", err)
@@ -265,7 +265,7 @@ func TestClient_Stop_Graceful(t *testing.T) {
 		}
 	}()
 
-	done := make(chan bool)
+	done := make(chan bool, 1)
 	go func() {
 		scanner := bufio.NewScanner(reader)
 		for scanner.Scan() {

--- a/driver/parser/check.go
+++ b/driver/parser/check.go
@@ -29,7 +29,7 @@ import (
 
 const namePatternStr = `^[A-Za-z0-9-.]+$`
 
-var namePattern = regexp.MustCompile(namePatternStr)
+var NamePattern = regexp.MustCompile(namePatternStr)
 
 // Check tests semantic constraints on the configuration of a scenario.
 func (s *Scenario) Check() error {
@@ -128,7 +128,7 @@ func (s *Scenario) Check() error {
 func (v *Validator) Check(scenario *Scenario) error {
 	errs := []error{}
 
-	if len(v.Name) != 0 && !namePattern.Match([]byte(v.Name)) {
+	if len(v.Name) != 0 && !NamePattern.Match([]byte(v.Name)) {
 		errs = append(errs, fmt.Errorf("validator name must match %v, got %v", namePatternStr, v.Name))
 	}
 
@@ -146,7 +146,7 @@ func (v *Validator) Check(scenario *Scenario) error {
 // Check tests semantic constraints on the node configuration of a scenario.
 func (n *Node) Check(scenario *Scenario) error {
 	errs := []error{}
-	if !namePattern.Match([]byte(n.Name)) {
+	if !NamePattern.Match([]byte(n.Name)) {
 		errs = append(errs, fmt.Errorf("node name must match %v, got %v", namePatternStr, n.Name))
 	}
 	if n.Instances != nil && *n.Instances < 0 {
@@ -204,7 +204,7 @@ func isTypeValid(t string) error {
 func (a *Application) Check(scenario *Scenario) error {
 	errs := []error{}
 
-	if !namePattern.Match([]byte(a.Name)) {
+	if !NamePattern.Match([]byte(a.Name)) {
 		errs = append(errs, fmt.Errorf("application name must match %v, got %v", namePatternStr, a.Name))
 	}
 
@@ -237,7 +237,7 @@ func (a *Application) Check(scenario *Scenario) error {
 func (c *Cheat) Check(scenario *Scenario) error {
 	errs := []error{}
 
-	if !namePattern.Match([]byte(c.Name)) {
+	if !NamePattern.Match([]byte(c.Name)) {
 		errs = append(errs, fmt.Errorf("cheat name must match %v, got %v", namePatternStr, c.Name))
 	}
 

--- a/load/app/app_test.go
+++ b/load/app/app_test.go
@@ -113,7 +113,7 @@ func TestGenerators(t *testing.T) {
 			// run local network of one node
 			rules := getCumulativeUpgrades(upgrade)
 			net, err := local.NewLocalNetwork(t.Context(), &driver.NetworkConfig{
-				Validators:   driver.DefaultValidators,
+				Validators:   driver.DefaultValidators(t.Name()),
 				NetworkRules: rules,
 			})
 			if err != nil {
@@ -172,7 +172,7 @@ func TestGenerators_Subsidies(t *testing.T) {
 		"UPGRADES_GAS_SUBSIDIES": "true",
 	}
 	net, err := local.NewLocalNetwork(t.Context(), &driver.NetworkConfig{
-		Validators:   driver.DefaultValidators,
+		Validators:   driver.DefaultValidators(t.Name()),
 		NetworkRules: rules,
 	})
 	if err != nil {

--- a/load/app/bls12_add_app_test.go
+++ b/load/app/bls12_add_app_test.go
@@ -36,7 +36,7 @@ func TestBls12AddApplication(t *testing.T) {
 		"UPGRADES_ALLEGRO": "true",
 	}
 	net, err := local.NewLocalNetwork(t.Context(), &driver.NetworkConfig{
-		Validators:   driver.DefaultValidators,
+		Validators:   driver.DefaultValidators(t.Name()),
 		NetworkRules: rules,
 	})
 	if err != nil {

--- a/load/app/bundle_app_test.go
+++ b/load/app/bundle_app_test.go
@@ -21,7 +21,7 @@ func TestGenerators_Bundles(t *testing.T) {
 	rules["UPGRADES_TRANSACTION_BUNDLES"] = "true"
 	rules["UPGRADES_GAS_SUBSIDIES"] = "true"
 	net, err := local.NewLocalNetwork(t.Context(), &driver.NetworkConfig{
-		Validators:   driver.DefaultValidators,
+		Validators:   driver.DefaultValidators(t.Name()),
 		NetworkRules: rules,
 	})
 	if err != nil {

--- a/load/app/large_contract_app_test.go
+++ b/load/app/large_contract_app_test.go
@@ -40,7 +40,7 @@ func TestLargeContractDeploymentFailsWithoutBrio(t *testing.T) {
 		// UPGRADES_BRIO omitted intentionally - deployment of large contracts should fail
 	}
 	net, err := local.NewLocalNetwork(t.Context(), &driver.NetworkConfig{
-		Validators:   driver.DefaultValidators,
+		Validators:   driver.DefaultValidators(t.Name()),
 		NetworkRules: rules,
 	})
 	if err != nil {

--- a/load/controller/rpc_test.go
+++ b/load/controller/rpc_test.go
@@ -33,7 +33,11 @@ const FakeNetworkID = 0xfa3
 
 func TestTrafficGenerating(t *testing.T) {
 	// run local network of one node
-	net, err := local.NewLocalNetwork(t.Context(), &driver.NetworkConfig{Validators: driver.DefaultValidators})
+	net, err := local.NewLocalNetwork(t.Context(),
+		&driver.NetworkConfig{
+			Validators: driver.DefaultValidators(t.Name()),
+		},
+	)
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}


### PR DESCRIPTION
This PR forwards the scenario defined names for each instance to the docker container name.

Changes are separated into two commits, one for the changes in code and another for the changes needed in testing. 