### PR TITLE
Add debugging information to timed-out transactions

### DIFF
--- a/driver/rpc/rpc.go
+++ b/driver/rpc/rpc.go
@@ -36,6 +36,16 @@ import (
 
 //go:generate mockgen -destination rpc_mock.go -package rpc . Client,ethRpcClient,rpcClient
 
+// txPoolContent is the response structure for txpool_content.
+type txPoolContent struct {
+	Pending map[string]map[string]txPoolTransaction `json:"pending"`
+	Queued  map[string]map[string]txPoolTransaction `json:"queued"`
+}
+
+type txPoolTransaction struct {
+	Hash common.Hash `json:"hash"`
+}
+
 // Client is an interface that provides a subset of the Ethereum client and RPC client interfaces.
 type Client interface {
 	ethRpcClient
@@ -46,6 +56,10 @@ type Client interface {
 	// This method retries with exponential backoff to fetch the transaction receipt,
 	//  until a certain timeout is reached.
 	WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error)
+
+	// GetTransactionPoolStatus queries the transaction pool for the given transaction hash
+	// and returns whether it is pending, queued, or not present in the pool.
+	GetTransactionPoolStatus(txHash common.Hash) (TxPoolStatus, error)
 
 	// GetBundleInfo calls sonic_getBundleInfo with the given execution plan hash.
 	// Returns nil, nil if the bundle has not been executed yet.
@@ -111,7 +125,16 @@ func (r Impl) WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error)
 		}
 		return receipt, nil
 	}
-	return nil, fmt.Errorf("failed to get transaction receipt: timeout")
+
+	status, err := r.GetTransactionPoolStatus(txHash)
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("failed to get transaction pool status: %w", err),
+			fmt.Errorf("failed to get transaction receipt: timeout"),
+		)
+	}
+
+	return nil, fmt.Errorf("failed to get transaction receipt: timeout, transaction pool status: %s", status)
 }
 
 func (r Impl) GetBundleInfo(planHash common.Hash) (*sonicapi.RPCBundleInfo, error) {
@@ -185,4 +208,49 @@ func (r Impl) transactionReceipt(txHash common.Hash) (*types.Receipt, error) {
 	}
 
 	return receipt, nil
+}
+
+// TxPoolStatus represents the presence of a transaction in the transaction pool.
+type TxPoolStatus int
+
+const (
+	// TxPoolStatusNotPresent indicates the transaction is not in the pool.
+	TxPoolStatusNotPresent TxPoolStatus = iota
+	// TxPoolStatusPending indicates the transaction is in the pending queue.
+	TxPoolStatusPending
+	// TxPoolStatusQueued indicates the transaction is in the queued (future) pool.
+	TxPoolStatusQueued
+)
+
+func (s TxPoolStatus) String() string {
+	switch s {
+	case TxPoolStatusPending:
+		return "pending"
+	case TxPoolStatusQueued:
+		return "queued"
+	default:
+		return "not present"
+	}
+}
+
+func (r Impl) GetTransactionPoolStatus(txHash common.Hash) (TxPoolStatus, error) {
+	var content txPoolContent
+	if err := r.Call(&content, "txpool_content"); err != nil {
+		return TxPoolStatusNotPresent, fmt.Errorf("failed to get txpool content: %w", err)
+	}
+	for _, txsByNonce := range content.Pending {
+		for _, tx := range txsByNonce {
+			if tx.Hash == txHash {
+				return TxPoolStatusPending, nil
+			}
+		}
+	}
+	for _, txsByNonce := range content.Queued {
+		for _, tx := range txsByNonce {
+			if tx.Hash == txHash {
+				return TxPoolStatusQueued, nil
+			}
+		}
+	}
+	return TxPoolStatusNotPresent, nil
 }

--- a/driver/rpc/rpc_mock.go
+++ b/driver/rpc/rpc_mock.go
@@ -196,6 +196,21 @@ func (mr *MockClientMockRecorder) GetBundleInfo(planHash any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundleInfo", reflect.TypeOf((*MockClient)(nil).GetBundleInfo), planHash)
 }
 
+// GetTransactionPoolStatus mocks base method.
+func (m *MockClient) GetTransactionPoolStatus(txHash common.Hash) (TxPoolStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTransactionPoolStatus", txHash)
+	ret0, _ := ret[0].(TxPoolStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTransactionPoolStatus indicates an expected call of GetTransactionPoolStatus.
+func (mr *MockClientMockRecorder) GetTransactionPoolStatus(txHash any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransactionPoolStatus", reflect.TypeOf((*MockClient)(nil).GetTransactionPoolStatus), txHash)
+}
+
 // HeaderByNumber mocks base method.
 func (m *MockClient) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
 	m.ctrl.T.Helper()

--- a/driver/rpc/rpc_test.go
+++ b/driver/rpc/rpc_test.go
@@ -2,13 +2,14 @@ package rpc
 
 import (
 	"errors"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	"go.uber.org/mock/gomock"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"go.uber.org/mock/gomock"
 )
 
 func TestRpcClientImpl_WaitTransactionReceipt_Success(t *testing.T) {
@@ -79,8 +80,11 @@ func TestRpcClientImpl_WaitTransactionReceipt_Timeout(t *testing.T) {
 			return nil
 		}).
 		AnyTimes()
+	mock.EXPECT().
+		Call(gomock.Any(), "txpool_content", gomock.Any()).
+		MinTimes(1)
 
-	if _, err := client.WaitTransactionReceipt(common.Hash{}); err == nil || err.Error() != "failed to get transaction receipt: timeout" {
+	if _, err := client.WaitTransactionReceipt(common.Hash{}); err == nil || err.Error() != "failed to get transaction receipt: timeout, transaction pool status: not present" {
 		t.Fatalf("expected timeout error, got %v", err)
 	}
 }


### PR DESCRIPTION
This change will print the status of the timed-out transaction in the pool. this being pending (is being emitted), queued(not executable) or unkown (the tx is not found in the pool)  

This helps debug the scenarios where advance epoch txs time out. 

These changes have been manually  tested by using a gapped nonce in the advance epoch tx, to force an accepted but not executable tx. 