### PR TITLE
Remove jenkins parallel limit

### DIFF
--- a/PR.jenkinsfile
+++ b/PR.jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
 		stage('Test Norma') {
 			steps {
 			    sh 'cd genesis && go test ./...'
-				sh 'go test ./...  -p 2 --parallel 2 --timeout 30m'
+				sh 'go test ./... --timeout 30m'
 			}
 		}
 	}


### PR DESCRIPTION
Since images are now smaller, tests do not parallelize apps docker instances. 
the rest of the project can be run with all available resources. 