### PR TITLE
Remove container before test

### DIFF
--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -440,6 +440,25 @@ func (c *Client) ContainerExists(name string) (bool, error) {
 	return len(containers) > 0, nil
 }
 
+// ForceRemoveContainer force-removes a container with the given name if it
+// exists. This is useful for cleaning up leaked containers from previous test
+// runs before starting a new container with the same name.
+func (c *Client) ForceRemoveContainer(name string) error {
+	containers, err := c.cli.ContainerList(context.Background(), container.ListOptions{
+		All:     true,
+		Filters: filters.NewArgs(filters.Arg("name", fmt.Sprintf("^/%s$", name))),
+	})
+	if err != nil {
+		return err
+	}
+	for _, cont := range containers {
+		if err := c.cli.ContainerRemove(context.Background(), cont.ID, container.RemoveOptions{Force: true}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // listContainers returns a list of all containers on the Docker host filtered by label.
 func (c *Client) listContainers() ([]types.Container, error) {
 	return c.cli.ContainerList(context.Background(), container.ListOptions{})

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"math/rand"
 	"os"
 	"strings"
@@ -452,6 +453,7 @@ func (c *Client) ForceRemoveContainer(name string) error {
 		return err
 	}
 	for _, cont := range containers {
+		slog.Warn("force-removing container", "name", name, "id", cont.ID)
 		if err := c.cli.ContainerRemove(context.Background(), cont.ID, container.RemoveOptions{Force: true}); err != nil {
 			return err
 		}

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -163,12 +163,10 @@ func StartOperaDockerNode(ctx context.Context, client *docker.Client, dn *docker
 		return nil, fmt.Errorf("invalid label for node: '%v'", config.Label)
 	}
 
-	exists, err := client.ContainerExists(config.Label)
-	if err != nil {
-		return nil, fmt.Errorf("failed to start docker node: %w", err)
-	}
-	if exists {
-		return nil, fmt.Errorf("failed to start docker node: container %q already running", config.Label)
+	// Force-remove any existing container with the same name from a previous
+	// run that may have leaked (e.g. due to test timeout or crash).
+	if err := client.ForceRemoveContainer(config.Label); err != nil {
+		return nil, fmt.Errorf("failed to remove existing container %q: %w", config.Label, err)
 	}
 
 	image := driver.ResolveClientImageName(config.Image)


### PR DESCRIPTION
When a unit test or scenario needs to start a new docker container with a sonic instance, `StartOperaDockerNode` checks whether the name is available and if not it fails. This was assumed as a safe method for debugging scenarios, but it assumed that docker runtime is clean, and that whichever test/scenario started a container, had the proper cleanup configured to remove it. 
This is not always the case when tests get interrupted or scenarios fails.

Hence this PR replaces the previously introduced check for existing containers with the name, for a force remove of the container, so that the new instance can start fresh.