### PR TITLE
Purge docker after tests

### DIFF
--- a/PR.jenkinsfile
+++ b/PR.jenkinsfile
@@ -1,7 +1,7 @@
 // Norma CI test norma using "make test"
 
 pipeline {
-	agent { label 'x86-8-42-m' }
+	agent { label 'rls-bare-g' }
 	
 	options {
 		timestamps ()
@@ -46,6 +46,12 @@ pipeline {
 			    sh 'cd genesis && go test ./...'
 				sh 'go test ./...  -p 2 --parallel 2 --timeout 30m'
 			}
+		}
+	}
+
+	post {
+		always {
+			sh 'go run ./driver/norma purge'
 		}
 	}
 }

--- a/PR.jenkinsfile
+++ b/PR.jenkinsfile
@@ -1,7 +1,7 @@
 // Norma CI test norma using "make test"
 
 pipeline {
-	agent { label 'rls-bare-g' }
+	agent { label 'kvm-8-32-l-1' }
 	
 	options {
 		timestamps ()

--- a/PR.jenkinsfile
+++ b/PR.jenkinsfile
@@ -1,50 +1,50 @@
 // Norma CI test norma using "make test"
 
 pipeline {
-	agent { label 'kvm-8-32-l-1' }
-	
-	options {
-		timestamps ()
-		timeout(time: 3, unit: 'HOURS')
-		disableConcurrentBuilds(abortPrevious: true)
-	}
+    agent { label 'x86-8-32-l || x86-8-32-m' }
 
-	environment {
-		GOROOT = '/usr/local/go'
-		DOCKER_API_VERSION = 1.45
-		GOMEMLIMIT = '60GiB'
-		GOCACHE = '/mnt/tmp-disk/go-cache'
-		TMPDIR = '/mnt/tmp-disk/'
-	}
+    options {
+        timestamps()
+        timeout(time: 3, unit: 'HOURS')
+        disableConcurrentBuilds(abortPrevious: true)
+    }
 
-	stages {
-		stage('Check Norma Format') {
-			steps {
-				catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
-					sh 'diff=`${GOROOT}/bin/gofmt -l \$(find . -type f -name "*.go"| grep -v "/client/")`; echo "$diff"; test -z "$diff"'
-				}
-			}
-		}
+    environment {
+        GOROOT = '/usr/local/go'
+        DOCKER_API_VERSION = 1.45
+        GOMEMLIMIT = '60GiB'
+        GOCACHE = '/mnt/tmp-disk/go-cache'
+        TMPDIR = '/mnt/tmp-disk/'
+    }
 
-		stage('Make Norma') {
-			steps {
-				sh 'make clean'
-				sh 'git submodule update --init --recursive'
-				sh 'make all'
-			}
-		}
+    stages {
+        stage('Check Norma Format') {
+            steps {
+                catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
+                    sh 'diff=`${GOROOT}/bin/gofmt -l \$(find . -type f -name "*.go"| grep -v "/client/")`; echo "$diff"; test -z "$diff"'
+                }
+            }
+        }
 
-		stage('Test Norma') {
-			steps {
-			    sh 'cd genesis && go test ./...'
-				sh 'go test ./...  -p 2 --parallel 2 --timeout 30m'
-			}
-		}
-	}
+        stage('Make Norma') {
+            steps {
+                sh 'make clean'
+                sh 'git submodule update --init --recursive'
+                sh 'make all'
+            }
+        }
 
-	post {
-		always {
-			sh 'go run ./driver/norma purge'
-		}
-	}
+        stage('Test Norma') {
+            steps {
+                sh 'cd genesis && go test ./...'
+                sh 'go test ./...  -p 2 --parallel 2 --timeout 30m'
+            }
+        }
+    }
+
+    post {
+        always {
+            sh 'go run ./driver/norma purge'
+        }
+    }
 }

--- a/PR.jenkinsfile
+++ b/PR.jenkinsfile
@@ -18,13 +18,6 @@ pipeline {
 	}
 
 	stages {
-	    stage('Prune Docker') {
-	        steps {
-	            sh 'docker builder prune -a -f'
-	            sh 'docker system prune -a -f'
-	        }
-	    }
-
 		stage('Check Norma Format') {
 			steps {
 				catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -274,6 +275,7 @@ func runScenario(ctx context.Context, path, outputDir, label string, keepPrometh
 	defer logger.shutdown()
 	err = executor.Run(ctx, clock, net, &scenario, checks)
 	if err != nil {
+		dumpNodeLogs(net)
 		return err
 	}
 	slog.Info("execution completed successfully")
@@ -290,4 +292,23 @@ func openBrowser(s string) error {
 
 	cmd := exec.Command(path, s)
 	return cmd.Start()
+}
+
+// dumpNodeLogs prints the logs of all active nodes to help diagnose failures.
+func dumpNodeLogs(net driver.Network) {
+	nodes := net.GetActiveNodes()
+	for _, node := range nodes {
+		reader, err := node.StreamLog()
+		if err != nil {
+			slog.Error("failed to stream log", "node", node.GetLabel(), "error", err)
+			continue
+		}
+		data, err := io.ReadAll(reader)
+		_ = reader.Close()
+		if err != nil {
+			slog.Error("failed to read log", "node", node.GetLabel(), "error", err)
+			continue
+		}
+		slog.Error("node log on failure", "node", node.GetLabel(), "log", string(data))
+	}
 }


### PR DESCRIPTION
**Changes**
- The existing `norma purge` is modified to only remove containers which have the label "norma:true".

**Additions**
- A mandatory post step is added to jenkins PR pipeline, which runs `norma purge` to ensure no containers are leaked, even in case of failures.