### PR TITLE
Remove old sonic version from scenarios

### DIFF
--- a/load/app/helpers.go
+++ b/load/app/helpers.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-var gasFeeCap = big.NewInt(1e12)
+var gasFeeCap = big.NewInt(2e12)
 var gasTipCap = big.NewInt(0)
 
 func createTx(from *Account, toAddress common.Address, value *big.Int, data []byte, gasLimit uint64) (*types.Transaction, error) {

--- a/scenarios/bls_add_allegro.yml
+++ b/scenarios/bls_add_allegro.yml
@@ -15,10 +15,6 @@ validators:
   - name: validator-v216
     imagename: "sonic:v2.1.6"
 
-  - name: validator-v203
-    imagename: "sonic:v2.0.3"
-    failing: true
-
 network_rules:
   genesis:
     UPGRADES_SONIC: true

--- a/scenarios/gas_subsidies/compatible.yml
+++ b/scenarios/gas_subsidies/compatible.yml
@@ -15,8 +15,8 @@ validators:
     imagename: "sonic:local"
   - name: v2.1 # release branch
     imagename: "sonic:v2.1"
-  - name: v2.1.2 # first version with gas subsidies
-    imagename: "sonic:v2.1.2"
+  - name: v2.1.6 # first version with gas subsidies
+    imagename: "sonic:v2.1.6"
 
 applications:
 

--- a/scenarios/gas_subsidies/switch_flag.yml
+++ b/scenarios/gas_subsidies/switch_flag.yml
@@ -23,11 +23,6 @@ validators:
     imagename: "sonic:local"
   - name: release-branch
     imagename: "sonic:v2.1" # release branch
-  - name: v2.1.2
-    imagename: "sonic:v2.1.2" # first version with gas subsidies
-  - name: too-old
-    imagename: "sonic:v2.1.1" # last version before gas subsidies
-    failing: true
 
 applications:
   - name: subsidies 

--- a/scenarios/test/base_fee_add_new_client.yml
+++ b/scenarios/test/base_fee_add_new_client.yml
@@ -20,8 +20,8 @@ network_rules:
 
 # Initial validator nodes in the network.
 validators:
-  - name: validator-v2.0.2
-    imagename: "sonic:v2.0.2"
+  - name: validator-v2.1.6
+    imagename: "sonic:v2.1.6"
 
 # Append updated nodes in the network.
 nodes:

--- a/scenarios/test/base_fee_add_older_client.yml
+++ b/scenarios/test/base_fee_add_older_client.yml
@@ -7,7 +7,7 @@ name: Network Updates Base Fee
 # The duration of the scenario's runtime, in seconds.
 duration: 180
 
-# There was a min base fee behaviour update between client versions
+# There was a min base fee behavior update between client versions
 network_rules:
   genesis:
     UPGRADES_SONIC: true
@@ -25,11 +25,11 @@ validators:
 
 # Append updated nodes in the network.
 nodes:
-  - name: node-v202
+  - name: node-v216
     instances: 1
     start: 60   # will start when the base fee is already updated
     client:
-      imagename: "sonic:v2.0.2"
+      imagename: "sonic:v2.1.6"
       type: validator
 
 # In the network, there is a few applications producing the load.

--- a/scenarios/test/client_version_updates.yml
+++ b/scenarios/test/client_version_updates.yml
@@ -15,12 +15,10 @@ network_rules:
 
 # Initial validator nodes in the network.
 validators:
-  - name: validator-v2.0.2
-    imagename: "sonic:v2.0.2"
-  - name: validator-v2.0.1
-    imagename: "sonic:v2.0.1"
-  - name: validator-v2.0.0
-    imagename: "sonic:v2.0.0"
+  - name: validator-v2.1.5
+    imagename: "sonic:v2.1.5"
+  - name: validator-v2.1.6
+    imagename: "sonic:v2.1.6"
 
 # Append updated nodes in the network.
 nodes:

--- a/scenarios/test/min_base_fee_update.yml
+++ b/scenarios/test/min_base_fee_update.yml
@@ -14,8 +14,8 @@ duration: 180
 
 # Initial validator nodes in the network.
 validators:
-  - name: validator-v2.0.3
-    imagename: "sonic:v2.0.3"
+  - name: validator-v2.1.6
+    imagename: "sonic:v2.1.6"
   - name: validator-allegro
     imagename: "sonic"
 

--- a/scenarios/test/network_allegro_hardfork.yml
+++ b/scenarios/test/network_allegro_hardfork.yml
@@ -12,9 +12,9 @@ validators:
   - name: validators
     instances: 3
     imagename: "sonic:latest"
-  - name: validator-v2.0.2
+  - name: validator-v2.1.6
     failing: true
-    imagename: "sonic:v2.0.2"   # this node should stop working after the hardfork
+    imagename: "sonic:v2.1.6"   # this node should stop working after the hardfork
 
 # Start with the hardfork disabled
 # while enabling the hardfork later
@@ -29,11 +29,11 @@ network_rules:
         UPGRADES_ALLEGRO: true  # hardfork enabled
 
 nodes:
-  - name: node-v202
+  - name: node-v216
     start: 30
     failing: true
     client:
-      imagename: "sonic:v2.0.2"   # this node should stop working after the hardfork
+      imagename: "sonic:v2.1.6"   # this node should stop working after the hardfork
   - name: node-latest
     start: 30
 

--- a/scenarios/test/network_brio_hardfork.yml
+++ b/scenarios/test/network_brio_hardfork.yml
@@ -12,9 +12,9 @@ validators:
   - name: validators
     instances: 3 # 3 validators out of 4 can keep super-majority and run the network
     imagename: "sonic:latest"
-  - name: validator-v2.1.2
+  - name: validator-v2.1.6
     failing: true
-    imagename: "sonic:v2.1.2"   # this node should stop working after the hardfork
+    imagename: "sonic:v2.1.6"   # this node should stop working after the hardfork
 
 # Start with the hardfork disabled
 # while enabling the hardfork later
@@ -29,11 +29,11 @@ network_rules:
         UPGRADES_BRIO: true  # hardfork enabled
 
 nodes:
-    - name: node-v212
+    - name: node-v216
       start: 30
       failing: true
       client:
-        imagename: sonic:v2.1.2 # this node should stop working after the hardfork
+        imagename: sonic:v2.1.6 # this node should stop working after the hardfork
     - name: node-latest
       start: 30
 

--- a/scenarios/test/node_update_reuse_db.yml
+++ b/scenarios/test/node_update_reuse_db.yml
@@ -9,8 +9,8 @@ duration: 180
 
 # Initial validator nodes in the network.
 validators:
-  - name: validator-v2.0.2
-    imagename: "sonic:v2.0.0"
+  - name: validator-v2.1.6
+    imagename: "sonic:v2.1.6"
 
 # Append updated nodes in the network.
 nodes:
@@ -18,7 +18,7 @@ nodes:
     start: 30
     end: 90
     client:
-      imagename: "sonic:v2.0.0"
+      imagename: "sonic:v2.1.6"
       data_volume: "volume-A"   # the database will be mounted to this persisted volume
 
   - name: node-latest

--- a/scenarios/test/various_client_versions.yml
+++ b/scenarios/test/various_client_versions.yml
@@ -20,19 +20,19 @@ nodes:
     start: 10
     instances: 1
     client:
-      imagename: "sonic:v2.0.2"
+      imagename: "sonic:latest"
 
   - name: observer-B
     start: 10
     instances: 1
     client:
-      imagename: "sonic:v2.0.1"
+      imagename: "sonic:v2.1.6"
 
   - name: validator-A
     start: 10
     instances: 1
     client:
-      imagename: "sonic:v2.0.0"
+      imagename: "sonic:v2.1"
       type: validator
 
 # In the network, there is a few applications producing the load.

--- a/scenarios/test/various_validator_versions.yml
+++ b/scenarios/test/various_validator_versions.yml
@@ -17,11 +17,8 @@ network_rules:
 # Initial validator nodes in the network.
 validators:
   - name: validator-dev
-  - name: validator-v2.0.2
-    imagename: "sonic:v2.0.2"
-  - name: validator-v2.0.1
-    instances: 2
-    imagename: "sonic:v2.0.1"
+  - name: validator-v2.1.6
+    imagename: "sonic:v2.1.6"
   - name: validator-latest
     instances: 3
     imagename: "sonic"


### PR DESCRIPTION
Since the new parameter flag was added in https://github.com/0xsoniclabs/norma/pull/216, running scenarios with older versions fails. 
This PR removes older version sonic from testing scenarios.