### PR TITLE
Fix RPC client handling in load controller and lazy-deploy helper contract

### DIFF
--- a/load/app/context.go
+++ b/load/app/context.go
@@ -56,7 +56,6 @@ func NewContext(factory RpcClientFactory, treasury *Account, networkRules map[st
 		return nil, fmt.Errorf("failed to connect to network: %w", err)
 	}
 
-	// Install the helper contract used by this contract for its operations.
 	// Create a context to interact with the network.
 	res := &appContext{
 		rpcClient:    rpcClient,
@@ -64,13 +63,6 @@ func NewContext(factory RpcClientFactory, treasury *Account, networkRules map[st
 		networkRules: networkRules,
 	}
 
-	// Install a helper contract on the network to perform operations.
-	helper, _, err := DeployContract(res, contract.DeployHelper)
-	if err != nil {
-		return nil, fmt.Errorf("failed to deploy helper contract: %w", err)
-	}
-
-	res.helper = helper
 	return res, nil
 }
 
@@ -130,8 +122,7 @@ func (c *appContext) GetTransactOptions(account *Account) (*bind.TransactOpts, e
 	return txOpts, nil
 }
 
-// GetReceipt waits for the receipt of the given transaction hash to be available.
-// The function times out after 10 seconds.
+// GetReceipt blocks until the receipt is available or the RPC client times out.
 func (c *appContext) GetReceipt(txHash common.Hash) (*types.Receipt, error) {
 	return c.rpcClient.WaitTransactionReceipt(txHash)
 }
@@ -162,6 +153,16 @@ func (c *appContext) Run(
 // FundAccounts transfers the given amount of funds from the treasure to each of the
 // given accounts.
 func (c *appContext) FundAccounts(accounts []common.Address, value *big.Int) error {
+
+	// Install a helper contract on the network on first use.
+	if c.helper == nil {
+		helper, _, err := DeployContract(c, contract.DeployHelper)
+		if err != nil {
+			return fmt.Errorf("failed to deploy helper contract: %w", err)
+		}
+		c.helper = helper
+	}
+
 	// Group funding requests in batches to avoid making individual transactions
 	// too big for a single block.
 	const batchSize = 128

--- a/load/app/context_test.go
+++ b/load/app/context_test.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/0xsoniclabs/norma/driver/rpc"
+	"go.uber.org/mock/gomock"
+)
+
+func TestNewContext_DoesNotDeployHelperContract(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockRpc := rpc.NewMockClient(ctrl)
+	factory := NewMockRpcClientFactory(ctrl)
+	factory.EXPECT().DialRandomRpc().Return(mockRpc, nil)
+
+	mockRpc.EXPECT().Close()
+
+	// NewContext should succeed without any contract deployment calls.
+	// If it tried to deploy, it would call GetTransactOptions which needs
+	// ChainID, SuggestGasPrice, PendingNonceAt — none of which are mocked.
+	ctx, err := NewContext(factory, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer ctx.Close()
+
+	// Verify the internal helper is nil (lazy).
+	ac := ctx.(*appContext)
+	if ac.helper != nil {
+		t.Fatal("expected helper to be nil after NewContext (lazy deployment)")
+	}
+}
+
+func TestFundAccounts_AttemptsToDeployHelperOnFirstCall(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockRpc := rpc.NewMockClient(ctrl)
+	factory := NewMockRpcClientFactory(ctrl)
+	factory.EXPECT().DialRandomRpc().Return(mockRpc, nil)
+
+	ctx, err := NewContext(factory, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer ctx.Close()
+
+	mockRpc.EXPECT().Close()
+
+	ac := ctx.(*appContext)
+
+	// Mock the RPC calls that GetTransactOptions needs for deploying the helper.
+	mockRpc.EXPECT().ChainID(gomock.Any()).Return(nil, fmt.Errorf("simulated chain ID failure"))
+
+	// FundAccounts will try to deploy the helper, which calls GetTransactOptions,
+	// which calls ChainID — our mock returns an error so we can verify the lazy
+	// deployment path is taken without needing a full chain.
+	err = ac.FundAccounts(nil, nil)
+	if err == nil {
+		t.Fatal("expected error from FundAccounts")
+	}
+
+	// The error should come from the deploy path (transaction options).
+	if ac.helper != nil {
+		t.Fatal("helper should remain nil when deployment fails")
+	}
+}

--- a/load/controller/controller.go
+++ b/load/controller/controller.go
@@ -143,6 +143,13 @@ func (ac *AppController) GetSentTransactions() (uint64, error) {
 
 func (ac *AppController) GetReceivedTransactions() (uint64, error) {
 	for retry := 0; ; retry++ {
+		if ac.rpcClient == nil {
+			var err error
+			ac.rpcClient, err = ac.network.DialRandomRpc()
+			if err != nil {
+				return 0, fmt.Errorf("failed to dial random RPC: %w", err)
+			}
+		}
 		// fetch transaction data from the network
 		res, err := ac.application.GetReceivedTransactions(ac.rpcClient)
 		if err == nil {
@@ -156,7 +163,8 @@ func (ac *AppController) GetReceivedTransactions() (uint64, error) {
 		ac.rpcClient.Close()
 		ac.rpcClient, err = ac.network.DialRandomRpc()
 		if err != nil {
-			return 0, fmt.Errorf("failed to dial random RPC; %v", err)
+			ac.rpcClient = nil
+			return 0, fmt.Errorf("failed to dial random RPC: %w", err)
 		}
 	}
 }

--- a/load/controller/get_received_test.go
+++ b/load/controller/get_received_test.go
@@ -1,0 +1,98 @@
+package controller
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/0xsoniclabs/norma/driver"
+	"github.com/0xsoniclabs/norma/driver/rpc"
+	"github.com/0xsoniclabs/norma/load/app"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetReceivedTransactions_DialsRpcWhenClientIsNil(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockApp := app.NewMockApplication(ctrl)
+	mockNet := driver.NewMockNetwork(ctrl)
+	mockRpc := rpc.NewMockClient(ctrl)
+
+	ac := &AppController{
+		application: mockApp,
+		network:     mockNet,
+		rpcClient:   nil, // simulate nil client (e.g. after a failed reconnect)
+	}
+
+	// Expect a dial, then a successful query.
+	mockNet.EXPECT().DialRandomRpc().Return(mockRpc, nil)
+	mockApp.EXPECT().GetReceivedTransactions(mockRpc).Return(uint64(42), nil)
+
+	got, err := ac.GetReceivedTransactions()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 42 {
+		t.Fatalf("expected 42, got %d", got)
+	}
+}
+
+func TestGetReceivedTransactions_ReturnsErrorWhenDialFailsOnNilClient(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockApp := app.NewMockApplication(ctrl)
+	mockNet := driver.NewMockNetwork(ctrl)
+
+	ac := &AppController{
+		application: mockApp,
+		network:     mockNet,
+		rpcClient:   nil,
+	}
+
+	dialErr := errors.New("connection refused")
+	mockNet.EXPECT().DialRandomRpc().Return(nil, dialErr)
+
+	_, err := ac.GetReceivedTransactions()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, dialErr) {
+		t.Fatalf("expected wrapped dialErr, got: %v", err)
+	}
+}
+
+func TestGetReceivedTransactions_SetsClientToNilOnReconnectFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockApp := app.NewMockApplication(ctrl)
+	mockNet := driver.NewMockNetwork(ctrl)
+	mockRpc := rpc.NewMockClient(ctrl)
+
+	ac := &AppController{
+		application: mockApp,
+		network:     mockNet,
+		rpcClient:   mockRpc,
+	}
+
+	// First call fails, triggering a reconnect attempt.
+	appErr := errors.New("rpc call failed")
+	mockApp.EXPECT().GetReceivedTransactions(mockRpc).Return(uint64(0), appErr)
+	mockRpc.EXPECT().Close()
+
+	// Reconnect also fails.
+	reconnectErr := errors.New("all nodes down")
+	mockNet.EXPECT().DialRandomRpc().Return(nil, reconnectErr)
+
+	_, err := ac.GetReceivedTransactions()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, reconnectErr) {
+		t.Fatalf("expected wrapped reconnectErr, got: %v", err)
+	}
+
+	// The client must be nil so the next call re-dials instead of
+	// using a closed client.
+	if ac.rpcClient != nil {
+		t.Fatal("expected rpcClient to be nil after reconnect failure")
+	}
+}


### PR DESCRIPTION
1. Fix nil rpcClient in GetReceivedTransactions
When an RPC reconnect attempt failed, rpcClient was left pointing to a closed connection. Subsequent calls would use the dead client instead of re-dialing. Fix by setting rpcClient = nil on reconnect failure and adding a nil guard at the top of the retry loop.

2. Lazy-deploy helper contract in FundAccounts
The helper contract was deployed eagerly in NewContext, even when FundAccounts was never called (e.g. sequential scenarios without load apps). Move deployment to first use in FundAccounts to avoid unnecessary on-chain transactions during context creation.