### PR TITLE
Add sequential scenario format and parser

### DIFF
--- a/driver/parser/sequential.go
+++ b/driver/parser/sequential.go
@@ -1,0 +1,361 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package parser
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// StepFunction identifies the type of operation a step performs.
+type StepFunction string
+
+const (
+	FuncStartNode           StepFunction = "startNode"
+	FuncStopNode            StepFunction = "stopNode"
+	FuncUndelegate          StepFunction = "undelegate"
+	FuncUpdateRules         StepFunction = "updateRules"
+	FuncAdvanceEpoch        StepFunction = "advanceEpoch"
+	FuncWaitForEpoch        StepFunction = "waitForEpoch"
+	FuncRunApp              StepFunction = "runApp"
+	FuncStopApp             StepFunction = "stopApp"
+	FuncCheckBlocksProduced StepFunction = "checkBlocksProduced"
+	FuncCheckBlocksHalted   StepFunction = "checkBlocksHalted"
+	FuncCheckBlockHashes    StepFunction = "checkBlockHashes"
+	FuncCheckBlockHeights   StepFunction = "checkBlockHeights"
+	FuncCheckBlockGasRate   StepFunction = "checkBlockGasRate"
+	FuncWaitFor             StepFunction = "waitFor"
+)
+
+// allStepFunctions lists every known step function constant.
+var allStepFunctions = [...]StepFunction{
+	FuncStartNode,
+	FuncStopNode,
+	FuncUndelegate,
+	FuncUpdateRules,
+	FuncAdvanceEpoch,
+	FuncWaitForEpoch,
+	FuncRunApp,
+	FuncStopApp,
+	FuncCheckBlocksProduced,
+	FuncCheckBlocksHalted,
+	FuncCheckBlockHashes,
+	FuncCheckBlockHeights,
+	FuncCheckBlockGasRate,
+	FuncWaitFor,
+}
+
+// toStepFunction returns the StepFunction for a given string, or an error if not recognized.
+func toStepFunction(s string) (StepFunction, error) {
+	for _, fn := range allStepFunctions {
+		if string(fn) == s {
+			return fn, nil
+		}
+	}
+	return "", fmt.Errorf("unknown function: %q", s)
+}
+
+// SequentialScenario is the root element of a sequential scenario description.
+// Unlike the time-based Scenario, it defines an ordered list of blocking steps.
+type SequentialScenario struct {
+	Name         string            `yaml:"Name"`
+	InitialRules map[string]string `yaml:"InitialNetworkRules"`
+	Steps        []Step            `yaml:"Scenario"`
+}
+
+// Step is a single blocking operation in a sequential scenario.
+type Step struct {
+	// Function identifies which operation this step performs.
+	Function StepFunction
+
+	// Identifier is the main argument (node name, app name, check target).
+	Identifier string
+
+	// Node parameters
+	NodeType   string // "validator", "observer", "rpc"
+	ImageName  string
+	DataVolume string
+	Stake      *uint64
+	Instances  *int
+	Failing    bool
+
+	// App parameters
+	AppType string
+	Users   *int
+	Rate    *Rate
+
+	// Update rules parameters
+	Rules map[string]string
+
+	// Check parameters
+	Ceiling   *float64
+	Tolerance *int
+
+	// WaitFor parameters
+	Duration time.Duration
+}
+
+// UnmarshalYAML implements custom YAML unmarshalling for Step.
+// A step can be either:
+//   - A scalar string (e.g., "advanceEpoch")
+//   - A mapping where one key is the function name (e.g., "startNode: validator-A")
+func (s *Step) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		fn, err := toStepFunction(value.Value)
+		if err != nil {
+			return fmt.Errorf("line %d: %w", value.Line, err)
+		}
+		s.Function = fn
+		return nil
+	case yaml.MappingNode:
+		return s.unmarshalMapping(value)
+	default:
+		return fmt.Errorf("line %d: step must be a string or mapping, got kind %d", value.Line, value.Kind)
+	}
+}
+
+// unmarshalMapping parses a mapping node into a Step.
+// It identifies the function key and parses the remaining keys as parameters.
+func (s *Step) unmarshalMapping(node *yaml.Node) error {
+	// First pass: find the function key so that parameter parsing (e.g. "type")
+	// can depend on which function this step represents.
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valNode := node.Content[i+1]
+		key := keyNode.Value
+
+		if fn, err := toStepFunction(key); err == nil {
+			if s.Function != "" {
+				return fmt.Errorf("line %d: step contains multiple function keys: %q and %q", keyNode.Line, s.Function, fn)
+			}
+			s.Function = fn
+			if err := s.parseFunctionValue(fn, valNode); err != nil {
+				return fmt.Errorf("line %d: %w", valNode.Line, err)
+			}
+		}
+	}
+
+	if s.Function == "" {
+		return fmt.Errorf("line %d: no known function found in step mapping", node.Line)
+	}
+
+	// Second pass: parse parameters now that s.Function is known.
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valNode := node.Content[i+1]
+		key := keyNode.Value
+
+		// Skip function keys (already handled above).
+		if _, err := toStepFunction(key); err == nil {
+			continue
+		}
+
+		if err := s.parseParam(key, valNode); err != nil {
+			return fmt.Errorf("line %d: %w", keyNode.Line, err)
+		}
+	}
+
+	return nil
+}
+
+// parseFunctionValue parses the value associated with the function key.
+func (s *Step) parseFunctionValue(fn StepFunction, val *yaml.Node) error {
+	switch fn {
+	case FuncUpdateRules:
+		// Value is a map of rules.
+		if val.Kind == yaml.MappingNode {
+			s.Rules = make(map[string]string)
+			for i := 0; i < len(val.Content); i += 2 {
+				k := val.Content[i].Value
+				v := val.Content[i+1].Value
+				s.Rules[k] = v
+			}
+		} else if val.Tag != "!!null" && val.Value != "" {
+			return fmt.Errorf("Update rules value must be a mapping, got %q", val.Value)
+		}
+	case FuncAdvanceEpoch, FuncWaitForEpoch:
+		// These take no value (or null).
+		if val.Kind != yaml.ScalarNode || (val.Tag != "!!null" && val.Value != "" && val.Value != "null") {
+			return fmt.Errorf("%s does not take a value, got %q", fn, val.Value)
+		}
+	case FuncWaitFor:
+		// Value is a duration string (e.g., "1s", "5m", "1h").
+		if val.Kind != yaml.ScalarNode || val.Value == "" {
+			return fmt.Errorf("waitFor requires a duration value (e.g., \"1s\", \"5m\")")
+		}
+		d, err := time.ParseDuration(val.Value)
+		if err != nil {
+			return fmt.Errorf("invalid duration %q: %w", val.Value, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("waitFor duration must be positive, got %s", d)
+		}
+		s.Duration = d
+	default:
+		// Value is a string identifier (or null/empty for optional).
+		if val.Kind == yaml.ScalarNode && val.Tag != "!!null" && val.Value != "" {
+			s.Identifier = val.Value
+		}
+	}
+	return nil
+}
+
+// allowedParams defines which parameter keys are valid for each step function.
+var allowedParams = map[StepFunction][]string{
+	FuncStartNode:           {"type", "imageName", "dataVolume", "stake", "instances", "failing"},
+	FuncStopNode:            {},
+	FuncRunApp:              {"type", "users", "rate"},
+	FuncStopApp:             {},
+	FuncUpdateRules:         {},
+	FuncUndelegate:          {},
+	FuncAdvanceEpoch:        {},
+	FuncWaitForEpoch:        {},
+	FuncWaitFor:             {},
+	FuncCheckBlocksProduced: {"tolerance", "failing"},
+	FuncCheckBlocksHalted:   {"failing"},
+	FuncCheckBlockHashes:    {"failing"},
+	FuncCheckBlockHeights:   {"tolerance", "failing"},
+	FuncCheckBlockGasRate:   {"ceiling", "failing"},
+}
+
+// parseParam parses a single parameter key-value pair.
+func (s *Step) parseParam(key string, val *yaml.Node) error {
+	// Validate that this parameter is allowed for the current step function.
+	allowed, known := allowedParams[s.Function]
+	if !known || !slices.Contains(allowed, key) {
+		return fmt.Errorf("parameter %q is not valid for %s", key, s.Function)
+	}
+
+	switch key {
+	case "type":
+		var v string
+		if err := val.Decode(&v); err != nil {
+			return fmt.Errorf("invalid type value: %w", err)
+		}
+		switch s.Function {
+		case FuncRunApp:
+			s.AppType = v
+		default:
+			s.NodeType = v
+		}
+	case "imageName":
+		var v string
+		if err := val.Decode(&v); err != nil {
+			return fmt.Errorf("invalid imageName value: %w", err)
+		}
+		s.ImageName = v
+	case "dataVolume":
+		var v string
+		if err := val.Decode(&v); err != nil {
+			return fmt.Errorf("invalid dataVolume value: %w", err)
+		}
+		s.DataVolume = v
+	case "stake":
+		var v uint64
+		if err := val.Decode(&v); err != nil {
+			return fmt.Errorf("invalid stake value: %w", err)
+		}
+		s.Stake = &v
+	case "instances":
+		var v int
+		if err := val.Decode(&v); err != nil {
+			return fmt.Errorf("invalid instances value: %w", err)
+		}
+		s.Instances = &v
+	case "failing":
+		var v bool
+		if err := val.Decode(&v); err != nil {
+			return fmt.Errorf("invalid failing value: %w", err)
+		}
+		s.Failing = v
+	case "users":
+		var v int
+		if err := val.Decode(&v); err != nil {
+			return fmt.Errorf("invalid users value: %w", err)
+		}
+		s.Users = &v
+	case "rate":
+		var r Rate
+		if err := val.Decode(&r); err != nil {
+			return fmt.Errorf("invalid rate value: %w", err)
+		}
+		s.Rate = &r
+	case "ceiling":
+		var v float64
+		if err := val.Decode(&v); err != nil {
+			return fmt.Errorf("invalid ceiling value: %w", err)
+		}
+		s.Ceiling = &v
+	case "tolerance":
+		var v int
+		if err := val.Decode(&v); err != nil {
+			return fmt.Errorf("invalid tolerance value: %w", err)
+		}
+		s.Tolerance = &v
+	}
+	return nil
+}
+
+// ParseSequential parses a sequential scenario from the given reader.
+func ParseSequential(reader io.Reader) (SequentialScenario, error) {
+	var res SequentialScenario
+	decoder := yaml.NewDecoder(reader)
+	decoder.KnownFields(true)
+	err := decoder.Decode(&res)
+	if err != nil {
+		return SequentialScenario{}, err
+	}
+	res.setDefaults()
+	return res, nil
+}
+
+// ParseSequentialBytes parses a sequential scenario from a byte slice.
+func ParseSequentialBytes(data []byte) (SequentialScenario, error) {
+	return ParseSequential(bytes.NewReader(data))
+}
+
+// ParseSequentialFile parses a sequential scenario from a file.
+func ParseSequentialFile(path string) (scenario SequentialScenario, err error) {
+	reader, err := os.Open(path)
+	if err != nil {
+		return SequentialScenario{}, err
+	}
+	defer func() { err = errors.Join(err, reader.Close()) }()
+	return ParseSequential(reader)
+}
+
+// DefaultMaxEpochDuration is applied to sequential scenarios that do not
+// explicitly set MAX_EPOCH_DURATION in their InitialNetworkRules.
+const DefaultMaxEpochDuration = "15s"
+
+// setDefaults sets default values on the sequential scenario.
+func (s *SequentialScenario) setDefaults() {
+	if s.InitialRules == nil {
+		s.InitialRules = make(map[string]string)
+	}
+	if _, explicit := s.InitialRules["MAX_EPOCH_DURATION"]; !explicit {
+		s.InitialRules["MAX_EPOCH_DURATION"] = DefaultMaxEpochDuration
+	}
+}

--- a/driver/parser/sequential_check.go
+++ b/driver/parser/sequential_check.go
@@ -1,0 +1,181 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package parser
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/0xsoniclabs/norma/genesis"
+	"github.com/0xsoniclabs/norma/load/app"
+)
+
+// Check validates semantic constraints on a sequential scenario.
+func (s *SequentialScenario) Check() error {
+	errs := []error{}
+
+	if strings.TrimSpace(s.Name) == "" {
+		errs = append(errs, fmt.Errorf("scenario name must not be empty"))
+	}
+	// Validate initial network rules.
+	for key := range s.InitialRules {
+		if !genesis.IsSupportedNetworkRule(key) {
+			errs = append(errs, fmt.Errorf("unknown network rule in initial rules: %v", key))
+		}
+	}
+
+	// Validate each step.
+	for i, step := range s.Steps {
+		if err := step.Check(); err != nil {
+			errs = append(errs, fmt.Errorf("step %d (%s): %w", i+1, step.Function, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// Check validates semantic constraints on a single step.
+func (s *Step) Check() error {
+	switch s.Function {
+	case FuncStartNode:
+		return s.checkStartNode()
+	case FuncStopNode:
+		return s.checkStopNode()
+	case FuncRunApp:
+		return s.checkRunApp()
+	case FuncStopApp:
+		return s.checkStopApp()
+	case FuncUpdateRules:
+		return s.checkUpdateRules()
+	case FuncUndelegate:
+		if s.Identifier == "" {
+			return fmt.Errorf("undelegate requires a node name")
+		}
+		if !NamePattern.Match([]byte(s.Identifier)) {
+			return fmt.Errorf("node name must match %v, got %v", namePatternStr, s.Identifier)
+		}
+		return nil
+	case FuncWaitFor:
+		if s.Duration <= 0 {
+			return fmt.Errorf("waitFor requires a positive duration, got %v", s.Duration)
+		}
+		return nil
+	case FuncAdvanceEpoch, FuncWaitForEpoch:
+		return nil
+	case FuncCheckBlocksProduced:
+		return nil // optional identifier
+	case FuncCheckBlocksHalted, FuncCheckBlockHashes,
+		FuncCheckBlockHeights, FuncCheckBlockGasRate:
+		return nil
+	default:
+		return fmt.Errorf("unknown function: %q", s.Function)
+	}
+}
+
+func (s *Step) checkStartNode() error {
+	errs := []error{}
+
+	if s.Identifier == "" {
+		errs = append(errs, fmt.Errorf("Start node requires an identifier (name)"))
+	} else if !NamePattern.Match([]byte(s.Identifier)) {
+		errs = append(errs, fmt.Errorf("node name must match %v, got %v", namePatternStr, s.Identifier))
+	}
+
+	// Validate node type if specified.
+	nodeType := s.NodeType
+	if nodeType == "" {
+		nodeType = "observer"
+	}
+	if err := isTypeValid(nodeType); err != nil {
+		errs = append(errs, err)
+	}
+
+	if s.Instances != nil && *s.Instances < 1 {
+		errs = append(errs, fmt.Errorf("number of instances must be >= 1, got %d", *s.Instances))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *Step) checkStopNode() error {
+	errs := []error{}
+
+	if s.Identifier == "" {
+		errs = append(errs, fmt.Errorf("Stop node requires an identifier (name)"))
+	} else if !NamePattern.Match([]byte(s.Identifier)) {
+		errs = append(errs, fmt.Errorf("node name must match %v, got %v", namePatternStr, s.Identifier))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *Step) checkRunApp() error {
+	errs := []error{}
+
+	if s.Identifier == "" {
+		errs = append(errs, fmt.Errorf("Run app requires an identifier (name)"))
+	} else if !NamePattern.Match([]byte(s.Identifier)) {
+		errs = append(errs, fmt.Errorf("app name must match %v, got %v", namePatternStr, s.Identifier))
+	}
+
+	appType := s.AppType
+	if appType == "" {
+		errs = append(errs, fmt.Errorf("Run app requires a type"))
+	} else if !app.IsSupportedApplicationType(appType) {
+		errs = append(errs, fmt.Errorf("unknown application type: %v", appType))
+	}
+
+	if s.Rate == nil {
+		errs = append(errs, fmt.Errorf("Run app requires a rate"))
+	} else if err := s.Rate.Check(nil); err != nil {
+		errs = append(errs, err)
+	}
+
+	if s.Users != nil && *s.Users < 1 {
+		errs = append(errs, fmt.Errorf("number of users must be >= 1, got %d", *s.Users))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *Step) checkStopApp() error {
+	errs := []error{}
+
+	if s.Identifier == "" {
+		errs = append(errs, fmt.Errorf("Stop app requires an identifier (name)"))
+	} else if !NamePattern.Match([]byte(s.Identifier)) {
+		errs = append(errs, fmt.Errorf("app name must match %v, got %v", namePatternStr, s.Identifier))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *Step) checkUpdateRules() error {
+	errs := []error{}
+
+	if len(s.Rules) == 0 {
+		errs = append(errs, fmt.Errorf("Update rules requires at least one rule"))
+	}
+	for key := range s.Rules {
+		if !genesis.IsSupportedNetworkRule(key) {
+			errs = append(errs, fmt.Errorf("unknown network rule: %v", key))
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/driver/parser/sequential_test.go
+++ b/driver/parser/sequential_test.go
@@ -1,0 +1,652 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package parser
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestParseSequential_MinimalScenario(t *testing.T) {
+	input := `
+Name: Minimal Test
+Scenario:
+  - startNode: validator-A
+    type: validator
+  - runApp: load
+    type: counter
+    users: 10
+    rate:
+      constant: 5
+  - advanceEpoch
+  - stopApp: load
+  - stopNode: validator-A
+`
+	scenario, err := ParseSequentialBytes([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	if scenario.Name != "Minimal Test" {
+		t.Errorf("expected name 'Minimal Test', got %q", scenario.Name)
+	}
+	if len(scenario.Steps) != 5 {
+		t.Fatalf("expected 5 steps, got %d", len(scenario.Steps))
+	}
+
+	// Verify step 1: startNode
+	step := scenario.Steps[0]
+	if step.Function != FuncStartNode {
+		t.Errorf("step 0: expected FuncStartNode, got %q", step.Function)
+	}
+	if step.Identifier != "validator-A" {
+		t.Errorf("step 0: expected identifier 'validator-A', got %q", step.Identifier)
+	}
+	if step.NodeType != "validator" {
+		t.Errorf("step 0: expected node type 'validator', got %q", step.NodeType)
+	}
+
+	// Verify step 2: runApp
+	step = scenario.Steps[1]
+	if step.Function != FuncRunApp {
+		t.Errorf("step 1: expected FuncRunApp, got %q", step.Function)
+	}
+	if step.Identifier != "load" {
+		t.Errorf("step 1: expected identifier 'load', got %q", step.Identifier)
+	}
+	if step.AppType != "counter" {
+		t.Errorf("step 1: expected app type 'counter', got %q", step.AppType)
+	}
+	if step.Users == nil || *step.Users != 10 {
+		t.Errorf("step 1: expected users=10")
+	}
+	if step.Rate == nil || step.Rate.Constant == nil || *step.Rate.Constant != 5 {
+		t.Errorf("step 1: expected constant rate=5")
+	}
+
+	// Verify step 3: advanceEpoch
+	step = scenario.Steps[2]
+	if step.Function != FuncAdvanceEpoch {
+		t.Errorf("step 2: expected FuncAdvanceEpoch, got %q", step.Function)
+	}
+
+	// Verify step 4: stopApp
+	step = scenario.Steps[3]
+	if step.Function != FuncStopApp {
+		t.Errorf("step 3: expected FuncStopApp, got %q", step.Function)
+	}
+	if step.Identifier != "load" {
+		t.Errorf("step 3: expected identifier 'load', got %q", step.Identifier)
+	}
+
+	// Verify step 5: stopNode
+	step = scenario.Steps[4]
+	if step.Function != FuncStopNode {
+		t.Errorf("step 4: expected FuncStopNode, got %q", step.Function)
+	}
+	if step.Identifier != "validator-A" {
+		t.Errorf("step 4: expected identifier 'validator-A', got %q", step.Identifier)
+	}
+}
+
+func TestParseSequential_InitialRules(t *testing.T) {
+	input := `
+Name: Rules Test
+InitialNetworkRules:
+  UPGRADES_SONIC: "true"
+  UPGRADES_ALLEGRO: "true"
+  MAX_EPOCH_DURATION: 10s
+Scenario:
+  - startNode: validator
+    type: validator
+`
+	scenario, err := ParseSequentialBytes([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	if scenario.InitialRules["UPGRADES_SONIC"] != "true" {
+		t.Errorf("expected UPGRADES_SONIC=true, got %q", scenario.InitialRules["UPGRADES_SONIC"])
+	}
+	if scenario.InitialRules["UPGRADES_ALLEGRO"] != "true" {
+		t.Errorf("expected UPGRADES_ALLEGRO=true, got %q", scenario.InitialRules["UPGRADES_ALLEGRO"])
+	}
+	if scenario.InitialRules["MAX_EPOCH_DURATION"] != "10s" {
+		t.Errorf("expected MAX_EPOCH_DURATION=10s, got %q", scenario.InitialRules["MAX_EPOCH_DURATION"])
+	}
+}
+
+func TestParseSequential_UpdateRules(t *testing.T) {
+	input := `
+Name: Update Rules Test
+Scenario:
+  - startNode: validator
+    type: validator
+  - updateRules:
+      MIN_BASE_FEE: "3000000000"
+      MAX_BLOCK_GAS: "100000"
+`
+	scenario, err := ParseSequentialBytes([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	if len(scenario.Steps) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(scenario.Steps))
+	}
+
+	step := scenario.Steps[1]
+	if step.Function != FuncUpdateRules {
+		t.Errorf("expected FuncUpdateRules, got %q", step.Function)
+	}
+	if step.Rules["MIN_BASE_FEE"] != "3000000000" {
+		t.Errorf("expected MIN_BASE_FEE=3000000000, got %q", step.Rules["MIN_BASE_FEE"])
+	}
+	if step.Rules["MAX_BLOCK_GAS"] != "100000" {
+		t.Errorf("expected MAX_BLOCK_GAS=100000, got %q", step.Rules["MAX_BLOCK_GAS"])
+	}
+}
+
+func TestParseSequential_StartNodeWithOptions(t *testing.T) {
+	input := `
+Name: Node Options Test
+Scenario:
+  - startNode: my-node
+    type: validator
+    imageName: "sonic:v2.0.2"
+    instances: 3
+    dataVolume: "vol-A"
+    failing: true
+`
+	scenario, err := ParseSequentialBytes([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	step := scenario.Steps[0]
+	if step.Identifier != "my-node" {
+		t.Errorf("expected identifier 'my-node', got %q", step.Identifier)
+	}
+	if step.NodeType != "validator" {
+		t.Errorf("expected type 'validator', got %q", step.NodeType)
+	}
+	if step.ImageName != "sonic:v2.0.2" {
+		t.Errorf("expected imagename 'sonic:v2.0.2', got %q", step.ImageName)
+	}
+	if step.Instances == nil || *step.Instances != 3 {
+		t.Errorf("expected instances=3")
+	}
+	if step.DataVolume != "vol-A" {
+		t.Errorf("expected datavolume 'vol-A', got %q", step.DataVolume)
+	}
+	if !step.Failing {
+		t.Errorf("expected failing=true")
+	}
+}
+
+func TestParseSequential_Undelegate(t *testing.T) {
+	input := `
+Name: Stop Node Test
+Scenario:
+  - undelegate: validator-A
+`
+	scenario, err := ParseSequentialBytes([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	step := scenario.Steps[0]
+	if step.Function != FuncUndelegate {
+		t.Errorf("expected FuncUndelegate, got %q", step.Function)
+	}
+	if step.Identifier != "validator-A" {
+		t.Errorf("expected identifier 'validator-A', got %q", step.Identifier)
+	}
+}
+
+func TestParseSequential_Checks(t *testing.T) {
+	input := `
+Name: Checks Test
+Scenario:
+  - checkBlocksProduced: my-node
+  - checkBlocksHalted:
+    failing: true
+  - checkBlockHeights:
+    tolerance: 5
+  - checkBlockGasRate:
+    ceiling: 16500000
+    failing: true
+  - checkBlockHashes:
+`
+	scenario, err := ParseSequentialBytes([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	if len(scenario.Steps) != 5 {
+		t.Fatalf("expected 5 steps, got %d", len(scenario.Steps))
+	}
+
+	// checkBlocksProduced with identifier
+	step := scenario.Steps[0]
+	if step.Function != FuncCheckBlocksProduced {
+		t.Errorf("step 0: expected FuncCheckBlocksProduced, got %q", step.Function)
+	}
+	if step.Identifier != "my-node" {
+		t.Errorf("step 0: expected identifier 'my-node', got %q", step.Identifier)
+	}
+
+	// checkBlocksHalted with failing
+	step = scenario.Steps[1]
+	if step.Function != FuncCheckBlocksHalted {
+		t.Errorf("step 1: expected FuncCheckBlocksHalted, got %q", step.Function)
+	}
+	if !step.Failing {
+		t.Errorf("step 1: expected failing=true")
+	}
+
+	// checkBlockHeights with tolerance
+	step = scenario.Steps[2]
+	if step.Function != FuncCheckBlockHeights {
+		t.Errorf("step 2: expected FuncCheckBlockHeights, got %q", step.Function)
+	}
+	if step.Tolerance == nil || *step.Tolerance != 5 {
+		t.Errorf("step 2: expected tolerance=5")
+	}
+
+	// checkBlockGasRate with ceiling + failing
+	step = scenario.Steps[3]
+	if step.Function != FuncCheckBlockGasRate {
+		t.Errorf("step 3: expected FuncCheckBlockGasRate, got %q", step.Function)
+	}
+	if step.Ceiling == nil || *step.Ceiling != 16500000 {
+		t.Errorf("step 3: expected ceiling=16500000")
+	}
+	if !step.Failing {
+		t.Errorf("step 3: expected failing=true")
+	}
+
+	// checkBlockHashes
+	step = scenario.Steps[4]
+	if step.Function != FuncCheckBlockHashes {
+		t.Errorf("step 4: expected FuncCheckBlockHashes, got %q", step.Function)
+	}
+}
+
+func TestParseSequential_SlopeRate(t *testing.T) {
+	input := `
+Name: Slope Rate Test
+Scenario:
+  - runApp: subsidies
+    type: counter
+    users: 10
+    rate:
+      slope:
+        start: 20
+        increment: 5
+`
+	scenario, err := ParseSequentialBytes([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	step := scenario.Steps[0]
+	if step.Rate == nil {
+		t.Fatal("expected rate to be set")
+	}
+	if step.Rate.Slope == nil {
+		t.Fatal("expected slope rate")
+	}
+	if step.Rate.Slope.Start != 20 {
+		t.Errorf("expected slope start=20, got %f", step.Rate.Slope.Start)
+	}
+	if step.Rate.Slope.Increment != 5 {
+		t.Errorf("expected slope increment=5, got %f", step.Rate.Slope.Increment)
+	}
+}
+
+func TestParseSequential_DefaultsApplied(t *testing.T) {
+	input := `
+Name: Defaults Test
+Scenario:
+  - advanceEpoch
+`
+	scenario, err := ParseSequentialBytes([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	if scenario.InitialRules["MAX_EPOCH_DURATION"] != "15s" {
+		t.Errorf("expected default MAX_EPOCH_DURATION=15s, got %q", scenario.InitialRules["MAX_EPOCH_DURATION"])
+	}
+}
+
+func TestParseSequential_UnknownFunction(t *testing.T) {
+	input := `
+Name: Bad Function
+Scenario:
+  - Do something weird: foo
+`
+	_, err := ParseSequentialBytes([]byte(input))
+	if err == nil {
+		t.Fatal("expected parse error for unknown function")
+	}
+}
+
+func TestSequentialCheck_EmptyName(t *testing.T) {
+	scenario := SequentialScenario{
+		Name:  "",
+		Steps: []Step{{Function: FuncAdvanceEpoch}},
+	}
+	err := scenario.Check()
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+}
+
+func TestSequentialCheck_InvalidNodeName(t *testing.T) {
+	scenario := SequentialScenario{
+		Name: "Test",
+		Steps: []Step{{
+			Function:   FuncStartNode,
+			Identifier: "invalid name with spaces",
+			NodeType:   "validator",
+		}},
+	}
+	err := scenario.Check()
+	if err == nil {
+		t.Fatal("expected error for invalid node name")
+	}
+}
+
+func TestSequentialCheck_RunAppMissingRate(t *testing.T) {
+	scenario := SequentialScenario{
+		Name: "Test",
+		Steps: []Step{{
+			Function:   FuncRunApp,
+			Identifier: "load",
+			AppType:    "counter",
+		}},
+	}
+	err := scenario.Check()
+	if err == nil {
+		t.Fatal("expected error for missing rate")
+	}
+}
+
+func TestSequentialCheck_UpdateRulesEmpty(t *testing.T) {
+	scenario := SequentialScenario{
+		Name: "Test",
+		Steps: []Step{{
+			Function: FuncUpdateRules,
+			Rules:    map[string]string{},
+		}},
+	}
+	err := scenario.Check()
+	if err == nil {
+		t.Fatal("expected error for empty rules")
+	}
+}
+
+func TestParseSequential_FullBlackoutScenario(t *testing.T) {
+	input := `
+Name: Single Proposer Blackout
+InitialNetworkRules:
+  UPGRADES_SONIC: "true"
+  UPGRADES_ALLEGRO: "true"
+  UPGRADES_SINGLE_PROPOSER: "true"
+  MAX_EPOCH_DURATION: 1000s
+Scenario:
+  - startNode: validator
+    type: validator
+    instances: 2
+  - runApp: load
+    type: counter
+    users: 50
+    rate:
+      constant: 50
+  - startNode: validator-before-1
+    type: validator
+  - advanceEpoch
+  - startNode: validator-before-2
+    type: validator
+  - advanceEpoch
+  - checkBlocksProduced
+  - stopNode: validator-before-1
+  - stopNode: validator-before-2
+  - checkBlocksHalted
+  - startNode: validator-before-1
+    type: validator
+  - startNode: validator-before-2
+    type: validator
+  - advanceEpoch
+  - checkBlocksProduced
+  - checkBlockHeights
+  - checkBlockHashes
+  - stopApp: load
+`
+	scenario, err := ParseSequentialBytes([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	if scenario.Name != "Single Proposer Blackout" {
+		t.Errorf("wrong name: %q", scenario.Name)
+	}
+	if len(scenario.Steps) != 17 {
+		t.Errorf("expected 17 steps, got %d", len(scenario.Steps))
+	}
+
+	// Verify the rejoin pattern: validator-before-1 is started, stopped, then started again
+	starts := 0
+	for _, step := range scenario.Steps {
+		if step.Function == FuncStartNode && step.Identifier == "validator-before-1" {
+			starts++
+		}
+	}
+	if starts != 2 {
+		t.Errorf("expected validator-before-1 started 2 times (start + rejoin), got %d", starts)
+	}
+}
+
+func TestParseSequentialFile_NonExistentFile(t *testing.T) {
+	_, err := ParseSequentialFile("/non/existent/path.yml")
+	if err == nil {
+		t.Fatal("expected error for non-existent file")
+	}
+}
+
+func TestParseSequentialFile_InvalidContent(t *testing.T) {
+	// Write invalid YAML to a temp file.
+	path := t.TempDir() + "/bad.yml"
+	if err := os.WriteFile(path, []byte(":::not valid yaml"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ParseSequentialFile(path)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML file")
+	}
+}
+
+func TestParseSequential_InvalidParamForFunction(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "users on startNode",
+			input: `
+Name: Test
+Scenario:
+  - startNode: node-A
+    type: validator
+    users: 10
+`,
+		},
+		{
+			name: "rate on startNode",
+			input: `
+Name: Test
+Scenario:
+  - startNode: node-A
+    type: validator
+    rate:
+      constant: 5
+`,
+		},
+		{
+			name: "instances on runApp",
+			input: `
+Name: Test
+Scenario:
+  - runApp: load
+    type: counter
+    instances: 3
+    rate:
+      constant: 5
+`,
+		},
+		{
+			name: "tolerance on stopNode",
+			input: `
+Name: Test
+Scenario:
+  - stopNode: node-A
+    tolerance: 5
+`,
+		},
+		{
+			name: "ceiling on checkBlocksProduced",
+			input: `
+Name: Test
+Scenario:
+  - checkBlocksProduced:
+    ceiling: 100
+`,
+		},
+		{
+			name: "type on advanceEpoch",
+			input: `
+Name: Test
+Scenario:
+  - advanceEpoch:
+    type: validator
+`,
+		},
+		{
+			name: "imageName on runApp",
+			input: `
+Name: Test
+Scenario:
+  - runApp: load
+    type: counter
+    imageName: "sonic:v2.0.0"
+    rate:
+      constant: 5
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseSequentialBytes([]byte(tt.input))
+			if err == nil {
+				t.Fatalf("expected error for %s, but parsing succeeded", tt.name)
+			}
+			if !strings.Contains(err.Error(), "is not valid for") {
+				t.Fatalf("expected 'is not valid for' error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestParseSequential_NonScalarStringParam(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "type as list",
+			input: `
+Name: Test
+Scenario:
+  - startNode: node-A
+    type: [validator, observer]
+`,
+		},
+		{
+			name: "imageName as mapping",
+			input: `
+Name: Test
+Scenario:
+  - startNode: node-A
+    type: validator
+    imageName:
+      name: sonic
+      version: v2.0.0
+`,
+		},
+		{
+			name: "dataVolume as list",
+			input: `
+Name: Test
+Scenario:
+  - startNode: node-A
+    type: validator
+    dataVolume: [vol-1, vol-2]
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseSequentialBytes([]byte(tt.input))
+			if err == nil {
+				t.Fatalf("expected error for non-scalar %s, but parsing succeeded", tt.name)
+			}
+		})
+	}
+}
+
+func TestParseSequential_TypeOrderIndependent(t *testing.T) {
+	// type listed before the function key — should still be parsed correctly.
+	input := `
+Name: Order Test
+Scenario:
+  - type: counter
+    runApp: my-app
+    users: 5
+    rate:
+      constant: 10
+`
+	scenario, err := ParseSequentialBytes([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	step := scenario.Steps[0]
+	if step.Function != FuncRunApp {
+		t.Errorf("expected FuncRunApp, got %q", step.Function)
+	}
+	if step.AppType != "counter" {
+		t.Errorf("expected app type 'counter', got %q", step.AppType)
+	}
+	if step.NodeType != "" {
+		t.Errorf("expected empty NodeType, got %q", step.NodeType)
+	}
+}

--- a/scenarios/scenario_test.go
+++ b/scenarios/scenario_test.go
@@ -38,9 +38,18 @@ func TestCheckScenarios(t *testing.T) {
 	}
 	for _, file := range files {
 		t.Run(file, func(t *testing.T) {
+			// Try sequential format first, fall back to legacy format.
+			seqScenario, seqErr := parser.ParseSequentialFile(file)
+			if seqErr == nil {
+				if err := seqScenario.Check(); err != nil {
+					t.Fatalf("sequential scenario check failed for: %s: %v", file, err)
+				}
+				return
+			}
+
 			scenario, err := parser.ParseFile(file)
 			if err != nil {
-				t.Fatalf("failed to parse file: %v", err)
+				t.Fatalf("failed to parse file: %s\n  sequential: %v\n  legacy: %v", file, seqErr, err)
 			}
 			if err = scenario.Check(); err != nil {
 				t.Fatalf("scenario check failed for: %s: %v", file, err)
@@ -56,7 +65,10 @@ func listAll() ([]string, error) {
 			if err != nil {
 				return err
 			}
-			if strings.HasSuffix(path, ".yml") {
+			if info.IsDir() {
+				return nil
+			}
+			if strings.HasSuffix(path, ".yml") || strings.HasSuffix(path, ".yaml") {
 				files = append(files, path)
 			}
 			return nil

--- a/scenarios/sequential/checks.yml
+++ b/scenarios/sequential/checks.yml
@@ -1,0 +1,45 @@
+# This scenario demonstrates all available check functions.
+
+Name: All Checks Test
+
+InitialNetworkRules:
+  MAX_EPOCH_DURATION: 10s
+
+Scenario:
+  - startNode: validator
+    type: validator
+    instances: 3
+
+  - runApp: load
+    type: counter
+    users: 50
+    rate:
+      constant: 20
+
+  - waitFor: 15s
+
+  # Verify blocks are being produced (block height increases
+  # within a rolling window of samples).
+  - checkBlocksProduced:
+    tolerance: 10
+
+  # Verify all nodes agree on block hashes.
+  - checkBlockHashes
+
+  # Verify block heights across nodes are within tolerance.
+  - checkBlockHeights:
+    tolerance: 5
+
+  # Verify block gas rate does not exceed the ceiling.
+  - checkBlockGasRate:
+    ceiling: 1000000000000000
+
+  - stopApp: load
+
+  # Stop all validators so blocks genuinely halt.
+  - stopNode: validator
+
+  - waitFor: 15s
+
+  # Verify blocks have halted (monitoring data is stale after stopNode).
+  - checkBlocksHalted

--- a/scenarios/sequential/custom_stake.yml
+++ b/scenarios/sequential/custom_stake.yml
@@ -1,0 +1,29 @@
+# This scenario tests validators with custom stake values.
+# Validators with different stakes receive proportional voting weight
+# in the consensus, reflected in the stake distribution shown in progress logs.
+
+Name: Custom Stake Test
+
+Scenario:
+  - startNode: heavy
+    type: validator
+    stake: 10000000
+
+  - startNode: medium
+    type: validator
+    stake: 5000000
+
+  - startNode: light
+    type: validator
+    stake: 1000000
+
+  - waitFor: 10s
+
+  - advanceEpoch
+
+  - undelegate: medium
+
+  - stopNode: medium
+
+  - waitFor: 10s
+  

--- a/scenarios/sequential/enable_brio.yml
+++ b/scenarios/sequential/enable_brio.yml
@@ -1,0 +1,31 @@
+Name: Enable Brio Test
+
+InitialNetworkRules:
+  UPGRADES_SONIC: true
+  UPGRADES_ALLEGRO: true
+  UPGRADES_GAS_SUBSIDIES: true
+  UPGRADES_BRIO: false
+
+Scenario:
+  - startNode: validator-0
+    type: validator
+    instances: 5 # ensure the network continues after failures of other nodes
+
+  - waitFor: 5s
+
+  - startNode: validator-1
+    type: validator
+    imageName: "sonic:v2.1.6"
+    failing: true  # this node should stop working after the hardfork
+
+  - waitFor: 5s
+
+  - updateRules:
+      UPGRADES_BRIO: true  # hardfork enabled
+
+  - waitFor: 5s
+
+  - startNode: validator-2
+    type: validator
+    imageName: "sonic:v2.1.6"
+    failing: true  # this node should not be able to sync when Brio is enabled

--- a/scenarios/sequential/epoch_advance.yml
+++ b/scenarios/sequential/epoch_advance.yml
@@ -1,0 +1,29 @@
+# This scenario verifies epoch advancement behavior.
+#
+# Expected: one epoch change is observed (epoch 1 → 2). This is the genesis
+# epoch transition — the genesis seals epoch 1 to activate the initial
+# validators, so the first live blocks are produced in epoch 2. The monitoring
+# picks up genesis blocks (epoch 1) and then live blocks (epoch 2), reporting
+# one transition.
+#
+# No additional automatic epoch changes should occur because:
+# - MAX_EPOCH_DURATION (100s) is not exceeded (scenario runs ~20s)
+# - MAX_EPOCH_GAS is set high enough to not be exhausted by event overhead
+
+Name: Advance Epoch Test
+
+InitialNetworkRules:
+  MAX_EPOCH_DURATION: 100s
+  MAX_EPOCH_GAS: 1000000000
+
+Scenario:
+  - startNode: validator
+    type: validator
+    instances: 3
+
+  - waitFor: 10s
+
+  - advanceEpoch
+
+  - waitFor: 10s
+  

--- a/scenarios/sequential/full_exchange_distributed.yml
+++ b/scenarios/sequential/full_exchange_distributed.yml
@@ -1,0 +1,62 @@
+Name: Distributed Proposer Gradual Exchange Test
+
+InitialNetworkRules:
+  UPGRADES_SONIC: true
+  UPGRADES_ALLEGRO: false
+  UPGRADES_SINGLE_PROPOSER: false
+  MAX_EPOCH_DURATION: 1000s
+
+Scenario:
+  - startNode: val-g1-1
+    type: validator
+
+  - runApp: load
+    type: counter
+    users: 50
+    rate:
+      constant: 20
+
+  - startNode: val-g1-2
+    type: validator
+
+  - advanceEpoch  # val-g1-2 joined
+
+  - startNode: val-g1-3
+    type: validator
+
+  - advanceEpoch  # val-g1-3 joined
+
+  - startNode: val-g2-1
+    type: validator
+
+  - advanceEpoch  # val-g2-1 joined
+
+  - undelegate: val-g1-1
+
+  - stopNode: val-g1-1
+
+  - advanceEpoch  # val-g1-1 left
+
+  - startNode: val-g2-2
+    type: validator
+
+  - advanceEpoch  # val-g2-2 joined
+
+  - undelegate: val-g1-2
+
+  - stopNode: val-g1-2
+
+  - advanceEpoch  # val-g1-2 left
+
+  - startNode: val-g2-3
+    type: validator
+
+  - advanceEpoch  # val-g2-3 joined
+
+  - undelegate: val-g1-3
+
+  - stopNode: val-g1-3
+
+  - advanceEpoch  # val-g1-3 left
+
+  - stopApp: load

--- a/scenarios/sequential/full_exchange_single_proposer.yml
+++ b/scenarios/sequential/full_exchange_single_proposer.yml
@@ -1,0 +1,62 @@
+Name: Single Proposer Gradual Exchange Test
+
+InitialNetworkRules:
+  UPGRADES_SONIC: true
+  UPGRADES_ALLEGRO: false
+  UPGRADES_SINGLE_PROPOSER: true
+  MAX_EPOCH_DURATION: 1000s
+
+Scenario:
+  - startNode: val-g1-1
+    type: validator
+
+  - runApp: load
+    type: counter
+    users: 50
+    rate:
+      constant: 20
+
+  - startNode: val-g1-2
+    type: validator
+
+  - advanceEpoch  # val-g1-2 joined
+
+  - startNode: val-g1-3
+    type: validator
+
+  - advanceEpoch  # val-g1-3 joined
+
+  - startNode: val-g2-1
+    type: validator
+
+  - advanceEpoch  # val-g2-1 joined
+
+  - undelegate: val-g1-1
+
+  - stopNode: val-g1-1
+
+  - advanceEpoch  # val-g1-1 left
+
+  - startNode: val-g2-2
+    type: validator
+
+  - advanceEpoch  # val-g2-2 joined
+
+  - undelegate: val-g1-2
+
+  - stopNode: val-g1-2
+
+  - advanceEpoch  # val-g1-2 left
+
+  - startNode: val-g2-3
+    type: validator
+
+  - advanceEpoch  # val-g2-3 joined
+
+  - undelegate: val-g1-3
+
+  - stopNode: val-g1-3
+
+  - advanceEpoch  # val-g1-3 left
+
+  - stopApp: load

--- a/scenarios/sequential/one_node.yml
+++ b/scenarios/sequential/one_node.yml
@@ -1,0 +1,8 @@
+Name: Single Node Test
+
+Scenario:
+  - startNode: validator-latest
+    type: validator
+    instances: 1
+
+  - waitFor: 10s

--- a/scenarios/sequential/rejoin_with_volume.yml
+++ b/scenarios/sequential/rejoin_with_volume.yml
@@ -1,0 +1,24 @@
+Name: Rejoin With Volume Test
+
+Scenario:
+  - startNode: validator-0
+    type: validator
+    instances: 3
+
+  - waitForEpoch
+
+  - startNode: validator-1
+    type: validator
+    imageName: "sonic:v2.1.6"
+    dataVolume: validator-1-data
+
+  - waitForEpoch
+
+  - stopNode: validator-1
+
+  - startNode: validator-1
+    type: validator
+    imageName: "sonic:local"
+    dataVolume: validator-1-data
+
+  - waitForEpoch

--- a/scenarios/sequential/run_app.yml
+++ b/scenarios/sequential/run_app.yml
@@ -1,0 +1,23 @@
+Name: Run Application Test
+
+Scenario:
+  - startNode: validator-0
+    type: validator
+
+  - runApp: normal
+    type: counter
+    users: 10
+    rate:
+      constant: 1
+
+  - runApp: erc20
+    type: erc20
+    users: 10
+    rate:
+      constant: 1
+
+  - waitFor: 10s
+
+  - stopApp: normal
+
+  - waitFor: 10s

--- a/scenarios/sequential/single_proposer.yml
+++ b/scenarios/sequential/single_proposer.yml
@@ -1,0 +1,31 @@
+Name: Single Block Proposer Test
+
+InitialNetworkRules:
+  UPGRADES_SONIC: true
+  UPGRADES_ALLEGRO: true
+  UPGRADES_GAS_SUBSIDIES: true
+  UPGRADES_BRIO: false
+
+Scenario:
+  - startNode: validator-0
+    type: validator
+    instances: 5 # ensure the network continues after failures of other nodes
+
+  - waitFor: 5s
+
+  - startNode: validator-1
+    type: validator
+    imageName: "sonic:v2.1.6"
+    failing: true  # this node should stop working after the hardfork
+
+  - waitFor: 5s
+
+  - updateRules:
+      UPGRADES_BRIO: true  # hardfork enabled
+
+  - waitFor: 5s
+
+  - startNode: validator-2
+    type: validator
+    imageName: "sonic:v2.1.6"
+    failing: true  # this node should not be able to sync when Brio is enabled

--- a/scenarios/sequential/start_and_stop_nodes.yml
+++ b/scenarios/sequential/start_and_stop_nodes.yml
@@ -1,0 +1,40 @@
+Name: Start and Stop Nodes Test
+
+Scenario:
+  - startNode: validator-0
+    type: validator
+    instances: 2
+
+  - runApp: normal
+    type: counter
+    users: 10
+    rate:
+      constant: 10
+
+  - waitForEpoch
+
+  - startNode: validator-1
+    type: validator
+
+  - waitForEpoch
+
+  - startNode: validator-2
+    type: validator
+
+  - waitForEpoch
+
+  - stopNode: validator-1
+
+  - waitForEpoch
+
+  - startNode: validator-1 # same identifier => rejoin
+    type: validator
+
+  - advanceEpoch
+
+  - advanceEpoch
+
+  - undelegate: validator-2
+
+  - stopNode: validator-2
+  

--- a/scenarios/sequential/subsidies.yml
+++ b/scenarios/sequential/subsidies.yml
@@ -1,0 +1,19 @@
+Name: Subsidies Test
+
+InitialNetworkRules:
+  MAX_EPOCH_DURATION: 10s
+  UPGRADES_ALLEGRO: true
+  UPGRADES_GAS_SUBSIDIES: true
+
+Scenario:
+  - startNode: validator-0
+    type: validator
+
+  - runApp: subsidies
+    type: subsidies
+    users: 10
+    rate:
+      constant: 10
+
+  - waitFor: 10s
+  

--- a/scenarios/sequential/two_nodes.yml
+++ b/scenarios/sequential/two_nodes.yml
@@ -1,0 +1,13 @@
+Name: Two Nodes Test
+
+Scenario:
+  - startNode: validator-0
+    type: validator
+
+  - waitFor: 10s
+
+  - startNode: validator-1
+    type: validator
+    imageName: "sonic:v2.1.6"
+
+  - waitFor: 10s

--- a/scenarios/sequential/wait_for_epoch.yml
+++ b/scenarios/sequential/wait_for_epoch.yml
@@ -1,0 +1,18 @@
+# This scenario verifies the waitForEpoch function.
+# It starts validators with a short MAX_EPOCH_DURATION so that an epoch
+# change occurs naturally, then uses waitForEpoch to block until it happens.
+
+Name: Wait For Epoch Test
+
+InitialNetworkRules:
+  MAX_EPOCH_DURATION: 5s
+
+Scenario:
+  - startNode: validator
+    type: validator
+    instances: 3
+
+  - waitForEpoch
+
+  - checkBlocksProduced:
+    tolerance: 10


### PR DESCRIPTION
This PR adds a new YAML-based sequential scenario format that defines test scenarios as an ordered list of steps (`startNode`, `stopNode`, `runApp`, `stopApp`, `waitFor`, `updateRules`, `advanceEpoch`, `checks`).

This PR adds the parser and some example inputs, a follow-up PR will add the actual scenario execution.