### PR TITLE
Add documentation for sequential norma steps. 

### DIFF
--- a/driver/norma/scenario_help.go
+++ b/driver/norma/scenario_help.go
@@ -17,36 +17,20 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
-	"github.com/0xsoniclabs/norma/driver/globalflags"
+	"github.com/0xsoniclabs/norma/driver/parser"
 	"github.com/urfave/cli/v2"
 )
 
-// Run with `go run ./driver/norma`
+// Run with `go run ./driver/norma scenario-help`
 
-func main() {
-	app := &cli.App{
-		Name:      "Norma Network Runner",
-		HelpName:  "norma",
-		Usage:     "A set of tools for running network scenarios",
-		Copyright: "(c) 2023 Fantom Foundation",
-		Flags:     globalflags.AllGlobalFlags,
-		Commands: []*cli.Command{
-			&checkCommand,
-			&runCommand,
-			&buildCommand,
-			&purgeCommand,
-			&renderCommand,
-			&diffCommand,
-			&scenarioHelpCommand,
-		},
-		Before: globalflags.ProcessGlobalFlags,
-	}
+var scenarioHelpCommand = cli.Command{
+	Action: scenarioHelp,
+	Name:   "scenario-help",
+	Usage:  "prints available step functions and parameters for sequential scenarios",
+}
 
-	if err := app.Run(os.Args); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
+func scenarioHelp(_ *cli.Context) error {
+	return parser.PrintSequentialHelp(os.Stdout)
 }

--- a/driver/parser/sequential.go
+++ b/driver/parser/sequential.go
@@ -222,6 +222,38 @@ func (s *Step) parseFunctionValue(fn StepFunction, val *yaml.Node) error {
 	return nil
 }
 
+// stepFunctionDescriptions provides a human-readable description for each step function.
+var stepFunctionDescriptions = map[StepFunction]string{
+	FuncStartNode:           "Start a new network node (validator, observer, or rpc).",
+	FuncStopNode:            "Stop a running network node by name.",
+	FuncUndelegate:          "Undelegate stake from a validator node.",
+	FuncUpdateRules:         "Update one or more network rules (key/value pairs).",
+	FuncAdvanceEpoch:        "Advance the network to the next epoch by sending transactions.",
+	FuncWaitForEpoch:        "Wait until the network reaches the next epoch boundary.",
+	FuncRunApp:              "Start a load-generating application.",
+	FuncStopApp:             "Stop a running load-generating application by name.",
+	FuncCheckBlocksProduced: "Assert that all nodes have produced blocks within tolerance.",
+	FuncCheckBlocksHalted:   "Assert that block production has halted on the specified node.",
+	FuncCheckBlockHashes:    "Assert that all nodes agree on the same block hashes.",
+	FuncCheckBlockHeights:   "Assert that all nodes are within tolerance of the same block height.",
+	FuncCheckBlockGasRate:   "Assert that the block gas rate is at or below a ceiling.",
+	FuncWaitFor:             "Pause scenario execution for a fixed duration.",
+}
+
+// paramDescriptions provides a human-readable description for each parameter key.
+var paramDescriptions = map[string]string{
+	"type":       "Node type (\"validator\", \"observer\", \"rpc\") for startNode; application type for runApp.",
+	"imageName":  "Docker image name to use for the node.",
+	"dataVolume": "Docker volume name to mount as the node data directory.",
+	"stake":      "Initial stake amount (uint64) for a validator node.",
+	"instances":  "Number of node instances to start.",
+	"failing":    "When true, the step is expected to fail; a passing result is treated as an error.",
+	"users":      "Number of concurrent user accounts the application should simulate.",
+	"rate":       "Transaction rate configuration for the application.",
+	"ceiling":    "Maximum allowed value (float64) for a check (e.g. gas rate ceiling).",
+	"tolerance":  "Allowed deviation (int, in blocks) between nodes for a height/production check.",
+}
+
 // allowedParams defines which parameter keys are valid for each step function.
 var allowedParams = map[StepFunction][]string{
 	FuncStartNode:           {"type", "imageName", "dataVolume", "stake", "instances", "failing"},
@@ -358,4 +390,38 @@ func (s *SequentialScenario) setDefaults() {
 	if _, explicit := s.InitialRules["MAX_EPOCH_DURATION"]; !explicit {
 		s.InitialRules["MAX_EPOCH_DURATION"] = DefaultMaxEpochDuration
 	}
+}
+
+// PrintSequentialHelp writes a formatted summary of all available sequential
+// scenario step functions, their descriptions, and accepted parameters to w.
+// It returns the first write error encountered, if any.
+func PrintSequentialHelp(w io.Writer) error {
+	ew := &errWriter{w: w}
+	ew.printf("Sequential scenario step functions:\n\n")
+	for _, fn := range allStepFunctions {
+		desc := stepFunctionDescriptions[fn]
+		params := allowedParams[fn]
+		ew.printf("  %-26s %s\n", fn, desc)
+		for _, p := range params {
+			ew.printf("      %-22s %s\n", p+":", paramDescriptions[p])
+		}
+		if len(params) > 0 {
+			ew.printf("\n")
+		}
+	}
+	return ew.err
+}
+
+// errWriter wraps an io.Writer and records the first write error so that
+// callers can chain multiple writes without checking each one individually.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (ew *errWriter) printf(format string, args ...any) {
+	if ew.err != nil {
+		return
+	}
+	_, ew.err = fmt.Fprintf(ew.w, format, args...)
 }

--- a/driver/parser/sequential_test.go
+++ b/driver/parser/sequential_test.go
@@ -22,6 +22,31 @@ import (
 	"testing"
 )
 
+func TestAllStepFunctionsAreDocumented(t *testing.T) {
+	for _, fn := range allStepFunctions {
+		if desc, ok := stepFunctionDescriptions[fn]; !ok || strings.TrimSpace(desc) == "" {
+			t.Errorf("step function %q has no entry in stepFunctionDescriptions", fn)
+		}
+		if _, ok := allowedParams[fn]; !ok {
+			t.Errorf("step function %q has no entry in allowedParams", fn)
+		}
+	}
+}
+
+func TestAllParamKeysAreDocumented(t *testing.T) {
+	seen := map[string]bool{}
+	for _, params := range allowedParams {
+		for _, p := range params {
+			seen[p] = true
+		}
+	}
+	for p := range seen {
+		if desc, ok := paramDescriptions[p]; !ok || strings.TrimSpace(desc) == "" {
+			t.Errorf("parameter %q has no entry in paramDescriptions", p)
+		}
+	}
+}
+
 func TestParseSequential_MinimalScenario(t *testing.T) {
 	input := `
 Name: Minimal Test


### PR DESCRIPTION
Use specification to print help for developers:

```
>  go run ./driver/norma scenario-help    
Sequential scenario step functions:

  startNode                  Start a new network node (validator, observer, or rpc).
      type:                  Node type ("validator", "observer", "rpc") for startNode; application type for runApp.
      imageName:             Docker image name to use for the node.
      dataVolume:            Docker volume name to mount as the node data directory.
      stake:                 Initial stake amount (uint64) for a validator node.
      instances:             Number of node instances to start.
      failing:               When true, the step is expected to fail; a passing result is treated as an error.

  stopNode                   Stop a running network node by name.
  undelegate                 Undelegate stake from a validator node.
  updateRules                Update one or more network rules (key/value pairs).
  advanceEpoch               Advance the network to the next epoch by sending transactions.
  waitForEpoch               Wait until the network reaches the next epoch boundary.
  runApp                     Start a load-generating application.
      type:                  Node type ("validator", "observer", "rpc") for startNode; application type for runApp.
      users:                 Number of concurrent user accounts the application should simulate.
      rate:                  Transaction rate configuration for the application.

  stopApp                    Stop a running load-generating application by name.
  checkBlocksProduced        Assert that all nodes have produced blocks within tolerance.
      tolerance:             Allowed deviation (int, in blocks) between nodes for a height/production check.
      failing:               When true, the step is expected to fail; a passing result is treated as an error.

  checkBlocksHalted          Assert that block production has halted on the specified node.
      failing:               When true, the step is expected to fail; a passing result is treated as an error.

  checkBlockHashes           Assert that all nodes agree on the same block hashes.
      failing:               When true, the step is expected to fail; a passing result is treated as an error.

  checkBlockHeights          Assert that all nodes are within tolerance of the same block height.
      tolerance:             Allowed deviation (int, in blocks) between nodes for a height/production check.
      failing:               When true, the step is expected to fail; a passing result is treated as an error.

  checkBlockGasRate          Assert that the block gas rate is at or below a ceiling.
      ceiling:               Maximum allowed value (float64) for a check (e.g. gas rate ceiling).
      failing:               When true, the step is expected to fail; a passing result is treated as an error.

  waitFor                    Pause scenario execution for a fixed duration.
