### PR TITLE
Add sequential executor

### DIFF
--- a/driver/checking/blocks_halted.go
+++ b/driver/checking/blocks_halted.go
@@ -1,0 +1,94 @@
+package checking
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/0xsoniclabs/norma/driver"
+	"github.com/0xsoniclabs/norma/driver/monitoring"
+)
+
+func init() {
+	RegisterNetworkCheck("blocks_halted", func(net driver.Network, monitor *monitoring.Monitor) Checker {
+		return &blocksHaltedChecker{
+			monitor:          &monitoringDataAdapter{monitor},
+			toleranceSamples: defaultToleranceSamples,
+			now:              time.Now,
+		}
+	})
+}
+
+// blocksHaltedChecker verifies that no node in the network is producing blocks.
+// It checks only the most recent window of data points (tail), so historical
+// data from removed nodes does not interfere.
+type blocksHaltedChecker struct {
+	monitor          MonitoringData
+	toleranceSamples int
+	now              func() time.Time
+}
+
+func (c *blocksHaltedChecker) Configure(config CheckerConfig) Checker {
+	if config == nil {
+		return c
+	}
+
+	tolerance := c.toleranceSamples
+	if t, exist := config["tolerance"]; exist {
+		tolerance = t.(int)
+	}
+
+	return &blocksHaltedChecker{
+		monitor:          c.monitor,
+		toleranceSamples: tolerance,
+		now:              c.now,
+	}
+}
+
+func (c *blocksHaltedChecker) Check(_ context.Context) error {
+	nodes := c.monitor.GetNodes()
+	for _, node := range nodes {
+		series := c.monitor.GetBlockStatus(node)
+
+		last := series.GetLatest()
+		if last == nil {
+			continue
+		}
+
+		// If monitoring has not received new data for longer than the
+		// tolerance window, the node is no longer reachable and is
+		// considered halted (e.g. after stopNode).
+		staleness := c.now().Sub(last.Position.Time())
+		if staleness > time.Duration(c.toleranceSamples)*time.Second {
+			continue
+		}
+
+		// Fetch all data points and examine the tail.
+		allPoints := series.GetRange(0, last.Position+1)
+		if len(allPoints) < 2 {
+			continue
+		}
+
+		// Only look at the last toleranceSamples data points.
+		start := len(allPoints) - c.toleranceSamples
+		if start < 0 {
+			start = 0
+		}
+		points := allPoints[start:]
+
+		// The network is halted only if block height has not increased
+		// between any two consecutive samples in the window. A single
+		// increase anywhere means blocks are still being produced.
+		halted := true
+		for i := 1; i < len(points); i++ {
+			if points[i].Value.BlockHeight > points[i-1].Value.BlockHeight {
+				halted = false
+				break
+			}
+		}
+		if !halted {
+			return fmt.Errorf("network is still producing blocks: node %s block height increased from %d to %d in the last %d samples", node, points[0].Value.BlockHeight, points[len(points)-1].Value.BlockHeight, len(points))
+		}
+	}
+	return nil
+}

--- a/driver/checking/blocks_halted_test.go
+++ b/driver/checking/blocks_halted_test.go
@@ -1,0 +1,125 @@
+package checking
+
+import (
+	"testing"
+	"time"
+
+	"github.com/0xsoniclabs/norma/driver/monitoring"
+	"go.uber.org/mock/gomock"
+)
+
+// recentNow returns a time close to the test data timestamps (which use
+// monitoring.Time(i) i.e. nanoseconds 0,1,2,...). This ensures the staleness
+// check does not skip the data.
+func recentNow() time.Time {
+	return time.Unix(0, 0)
+}
+
+func TestBlocksHalted_Passes_WhenConstant(t *testing.T) {
+	tests := map[string]struct {
+		series []uint64
+	}{
+		"constant": {
+			series: []uint64{5, 5, 5, 5, 5, 5, 5, 5, 5, 5},
+		},
+		"increased-then-stopped": {
+			series: []uint64{1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5},
+		},
+		"single-point": {
+			series: []uint64{10},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			series := createBlockSeries(t, test.series)
+			ctrl := gomock.NewController(t)
+			monitor := NewMockMonitoringData(ctrl)
+			monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
+			monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
+
+			c := blocksHaltedChecker{monitor: monitor, toleranceSamples: 5, now: recentNow}
+			if err := c.Check(t.Context()); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestBlocksHalted_Fails_WhenIncreasing(t *testing.T) {
+	tests := map[string]struct {
+		series []uint64
+	}{
+		"increasing": {
+			series: []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		},
+		"increasing-at-tail": {
+			series: []uint64{5, 5, 5, 5, 5, 5, 5, 5, 9, 10},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			series := createBlockSeries(t, test.series)
+			ctrl := gomock.NewController(t)
+			monitor := NewMockMonitoringData(ctrl)
+			monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
+			monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
+
+			c := blocksHaltedChecker{monitor: monitor, toleranceSamples: 5, now: recentNow}
+			if err := c.Check(t.Context()); err == nil {
+				t.Errorf("expected error but got nil")
+			}
+		})
+	}
+}
+
+func TestBlocksHalted_Passes_WhenNoData(t *testing.T) {
+	series := createBlockSeries(t, []uint64{})
+	ctrl := gomock.NewController(t)
+	monitor := NewMockMonitoringData(ctrl)
+	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
+	monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
+
+	c := blocksHaltedChecker{monitor: monitor, toleranceSamples: 5, now: recentNow}
+	if err := c.Check(t.Context()); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestBlocksHalted_Configure(t *testing.T) {
+	// With tolerance=5, this series looks halted (last 5 points: 5,5,5,5,5)
+	series := createBlockSeries(t, []uint64{1, 2, 3, 4, 5, 5, 5, 5, 5})
+	ctrl := gomock.NewController(t)
+	monitor := NewMockMonitoringData(ctrl)
+	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"}).Times(2)
+	monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series).Times(2)
+
+	c := blocksHaltedChecker{monitor: monitor, toleranceSamples: 5, now: recentNow}
+	if err := c.Check(t.Context()); err != nil {
+		t.Errorf("unexpected error with tolerance 5: %v", err)
+	}
+
+	// With tolerance=9, this series is NOT halted (first point=1, last=5)
+	configured := c.Configure(CheckerConfig{"tolerance": 9})
+	if err := configured.Check(t.Context()); err == nil {
+		t.Errorf("expected error with tolerance 9 but got nil")
+	}
+}
+
+func TestBlocksHalted_Passes_WhenStaleData(t *testing.T) {
+	// Data shows increasing blocks, but the monitoring is stale (node removed).
+	series := createBlockSeries(t, []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+	ctrl := gomock.NewController(t)
+	monitor := NewMockMonitoringData(ctrl)
+	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
+	monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
+
+	// "now" is far in the future relative to the data timestamps,
+	// so the data is considered stale and the node is treated as halted.
+	farFuture := func() time.Time { return time.Unix(60, 0) }
+	c := blocksHaltedChecker{monitor: monitor, toleranceSamples: 5, now: farFuture}
+	if err := c.Check(t.Context()); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/driver/executor/executor_test.go
+++ b/driver/executor/executor_test.go
@@ -426,6 +426,10 @@ func TestExecutor_RunScenarioWithDefaultChecks(t *testing.T) {
 	checking.RegisterNetworkCheck("block_gas_rate", func(driver.Network, *monitoring.Monitor) checking.Checker {
 		return checkBlockGasRate
 	})
+	checkBlocksHalted := checking.NewMockChecker(ctrl)
+	checking.RegisterNetworkCheck("blocks_halted", func(driver.Network, *monitoring.Monitor) checking.Checker {
+		return checkBlocksHalted
+	})
 
 	net.EXPECT().AdvanceEpoch(2)
 
@@ -433,6 +437,7 @@ func TestExecutor_RunScenarioWithDefaultChecks(t *testing.T) {
 	checkBlocksHashes.EXPECT().Check(gomock.Any())
 	checkBlocksRolling.EXPECT().Check(gomock.Any())
 	checkBlockGasRate.EXPECT().Check(gomock.Any())
+	checkBlocksHalted.EXPECT().Check(gomock.Any()).Return(nil)
 
 	checks := checking.InitNetworkChecks(net, nil)
 	if err := Run(t.Context(), clock, net, &scenario, checks); err != nil {

--- a/driver/executor/sequential.go
+++ b/driver/executor/sequential.go
@@ -1,0 +1,537 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package executor
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/0xsoniclabs/norma/driver"
+	"github.com/0xsoniclabs/norma/driver/checking"
+	"github.com/0xsoniclabs/norma/driver/parser"
+)
+
+// RunSequential executes a sequential scenario on the given network.
+// Steps are executed one by one in order. The context can be used to abort
+// execution, and a default timeout is enforced as a deadline.
+func RunSequential(
+	ctx context.Context,
+	network driver.Network,
+	scenario *parser.SequentialScenario,
+	checks checking.Checks,
+) error {
+	return runSequential(ctx, network, scenario, checks, &netBasedValidatorRegistry{
+		net: network,
+	})
+}
+
+// defaultScenarioTimeout is the maximum time a sequential scenario is
+// allowed to run before being aborted.
+const defaultScenarioTimeout = 10 * time.Minute
+
+// runSequential is the internal implementation, allowing injection of
+// a validatorRegistry for testing.
+func runSequential(
+	ctx context.Context,
+	network driver.Network,
+	scenario *parser.SequentialScenario,
+	checks checking.Checks,
+	registry validatorRegistry,
+) error {
+	if err := scenario.Check(); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, defaultScenarioTimeout)
+	defer cancel()
+
+	state := &sequentialState{
+		nodes:        make(map[string]driver.Node),
+		apps:         make(map[string]driver.Application),
+		nodeHistory:  make(map[string]bool),
+		validatorIds: make(map[string]int),
+	}
+
+	// Populate state with nodes already present in the network (bootstrap validators).
+	for _, node := range network.GetActiveNodes() {
+		label := node.GetLabel()
+		state.nodes[label] = node
+		state.nodeHistory[label] = true
+	}
+
+	for i, step := range scenario.Steps {
+		select {
+		case <-ctx.Done():
+			slog.Warn("scenario aborted", "step", i+1, "reason", ctx.Err())
+			return fmt.Errorf("scenario aborted at step %d (%s): %w", i+1, step.Function, ctx.Err())
+		default:
+		}
+
+		slog.Info("executing step",
+			"step", i+1,
+			"function", step.Function,
+			"identifier", step.Identifier,
+		)
+
+		start := time.Now()
+		if err := executeStep(ctx, &step, network, checks, registry, state); err != nil {
+			slog.Error("step failed",
+				"step", i+1,
+				"function", step.Function,
+				"identifier", step.Identifier,
+				"error", err,
+				"duration", time.Since(start),
+			)
+			return fmt.Errorf("step %d (%s %s) failed: %w", i+1, step.Function, step.Identifier, err)
+		}
+
+		slog.Info("step completed",
+			"step", i+1,
+			"function", step.Function,
+			"duration", time.Since(start),
+		)
+
+		// Wait for block production after steps that actively modify the
+		// network and expect it to remain healthy. Skip for steps that can
+		// legitimately leave the network stalled (stopNode, failing startNode)
+		// or that don't affect network state (waitFor, checks).
+		if requiresBlockProductionCheck(step) {
+			if err := waitForBlockProduction(ctx, network); err != nil {
+				return fmt.Errorf("network unstable after step %d (%s %s): %w", i+1, step.Function, step.Identifier, err)
+			}
+		}
+	}
+
+	slog.Info("sequential scenario completed successfully")
+	return nil
+}
+
+// sequentialState tracks runtime state during sequential execution.
+type sequentialState struct {
+	// nodes maps node identifiers to active node instances.
+	nodes map[string]driver.Node
+	// apps maps app identifiers to active application instances.
+	apps map[string]driver.Application
+	// nodeHistory tracks names that have been started before (for rejoin detection).
+	nodeHistory map[string]bool
+	// validatorIds preserves validator IDs for nodes that were stopped,
+	// so they can be reused on rejoin.
+	validatorIds map[string]int
+}
+
+// executeStep dispatches a single step to the appropriate handler.
+func executeStep(
+	ctx context.Context,
+	step *parser.Step,
+	net driver.Network,
+	checks checking.Checks,
+	registry validatorRegistry,
+	state *sequentialState,
+) error {
+	switch step.Function {
+	case parser.FuncStartNode:
+		return execStartNode(ctx, step, net, registry, state)
+	case parser.FuncStopNode:
+		return execStopNode(ctx, step, net, state)
+	case parser.FuncUndelegate:
+		return execUndelegate(step, registry, state)
+	case parser.FuncRunApp:
+		return execRunApp(ctx, step, net, state)
+	case parser.FuncStopApp:
+		return execStopApp(step, state)
+	case parser.FuncUpdateRules:
+		return execUpdateRules(step, net)
+	case parser.FuncAdvanceEpoch:
+		if err := waitForBlockProduction(ctx, net); err != nil {
+			return err
+		}
+		if err := net.AdvanceEpoch(1); err != nil {
+			return err
+		}
+		return waitForBlockProduction(ctx, net)
+	case parser.FuncWaitForEpoch:
+		return net.WaitForEpochChange()
+	case parser.FuncCheckBlocksProduced:
+		return execCheck(ctx, "blocks_rolling", step, checks)
+	case parser.FuncCheckBlocksHalted:
+		return execCheck(ctx, "blocks_halted", step, checks)
+	case parser.FuncCheckBlockHashes:
+		return execCheck(ctx, "blocks_hashes", step, checks)
+	case parser.FuncCheckBlockHeights:
+		return execCheck(ctx, "block_height", step, checks)
+	case parser.FuncCheckBlockGasRate:
+		return execCheck(ctx, "block_gas_rate", step, checks)
+	case parser.FuncWaitFor:
+		slog.Info("waiting", "duration", step.Duration)
+		select {
+		case <-time.After(step.Duration):
+			return nil
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled during waitFor: %w", ctx.Err())
+		}
+	default:
+		return fmt.Errorf("unknown step function: %q", step.Function)
+	}
+}
+
+// execStartNode creates a node. If the same name was previously started and
+// stopped, this is treated as a rejoin (no new validator registration).
+func execStartNode(
+	ctx context.Context,
+	step *parser.Step,
+	net driver.Network,
+	registry validatorRegistry,
+	state *sequentialState,
+) error {
+	name := step.Identifier
+	isRejoin := state.nodeHistory[name]
+	isValidator := step.NodeType == "validator"
+
+	image := driver.DefaultClientDockerImageName
+	if step.ImageName != "" {
+		image = step.ImageName
+	}
+
+	instances := 1
+	if step.Instances != nil {
+		instances = *step.Instances
+	}
+
+	// Get the current block height from an existing node before starting new ones.
+	// We'll wait for new nodes to reach this height before proceeding.
+	targetBlock, err := getNetworkBlockHeight(ctx, net)
+	if err != nil {
+		slog.Warn("failed to get network block height; node sync target defaults to 0", "error", err)
+	}
+
+	var newNodes []driver.Node
+	for instance := range instances {
+		instanceName := name
+		if instances > 1 {
+			instanceName = fmt.Sprintf("%s-%d", name, instance)
+		}
+
+		var validatorId *int
+		if isValidator && !isRejoin {
+			id, err := registry.registerNewValidator()
+			if err != nil {
+				return fmt.Errorf("failed to register validator %s: %w", instanceName, err)
+			}
+			validatorId = &id
+		} else if isValidator && isRejoin {
+			if id, ok := state.validatorIds[instanceName]; ok {
+				validatorId = &id
+			}
+		}
+
+		node, err := net.CreateNode(&driver.NodeConfig{
+			Name:        instanceName,
+			Failing:     step.Failing,
+			Image:       image,
+			Validator:   isValidator,
+			ValidatorId: validatorId,
+			DataVolume:  dataVolumePtr(step.DataVolume),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create node %s: %w", instanceName, err)
+		}
+
+		state.nodes[instanceName] = node
+		state.nodeHistory[instanceName] = true
+		if validatorId != nil {
+			state.validatorIds[instanceName] = *validatorId
+		}
+		newNodes = append(newNodes, node)
+	}
+
+	// Also mark the base name in history for single-instance nodes.
+	state.nodeHistory[name] = true
+
+	// Wait for newly created nodes to sync to the network's block height.
+	// Skip sync wait for nodes expected to fail (they may never reach the target).
+	if !step.Failing {
+		for _, node := range newNodes {
+			slog.Info("waiting for node to sync", "node", node.GetLabel(), "target_block", targetBlock)
+			if err := waitForNodeSync(ctx, node, targetBlock+1); err != nil {
+				slog.Warn("node sync wait failed", "node", node.GetLabel(), "error", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// getNetworkBlockHeight returns the current block height from an existing network node.
+func getNetworkBlockHeight(ctx context.Context, net driver.Network) (uint64, error) {
+	client, err := net.DialRandomRpc()
+	if err != nil {
+		return 0, err
+	}
+	defer client.Close()
+	return client.BlockNumber(ctx)
+}
+
+// waitForNodeSync waits until the given node has synced to at least the target block height.
+func waitForNodeSync(ctx context.Context, node driver.Node, targetBlock uint64) error {
+	client, err := node.DialRpc(ctx)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	const syncTimeout = 60 * time.Second
+	deadline := time.Now().Add(syncTimeout)
+
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		block, err := client.BlockNumber(ctx)
+		if err != nil {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		if block >= targetBlock {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return fmt.Errorf("node did not sync to block %d within %s", targetBlock, syncTimeout)
+}
+
+// execStopNode stops a node.
+func execStopNode(
+	ctx context.Context,
+	step *parser.Step,
+	net driver.Network,
+	state *sequentialState,
+) error {
+	name := step.Identifier
+
+	// Find the node (try exact name first, then single-instance pattern).
+	node, ok := state.nodes[name]
+	if !ok {
+		// Try with -0 suffix for single-instance nodes created with instances > 1.
+		node, ok = state.nodes[name+"-0"]
+		if !ok {
+			return fmt.Errorf("node %q not found in active nodes", name)
+		}
+		name = name + "-0"
+	}
+
+	if err := net.RemoveNode(node); err != nil {
+		return fmt.Errorf("failed to remove node %s: %w", name, err)
+	}
+	if err := node.Stop(ctx); err != nil {
+		return fmt.Errorf("failed to stop node %s: %w", name, err)
+	}
+	if err := node.Cleanup(ctx); err != nil {
+		return fmt.Errorf("failed to cleanup node %s: %w", name, err)
+	}
+
+	delete(state.nodes, name)
+
+	// Also stop all instances if this was a multi-instance node.
+	for key, n := range state.nodes {
+		if len(key) > len(step.Identifier)+1 && key[:len(step.Identifier)+1] == step.Identifier+"-" {
+			_ = net.RemoveNode(n)
+			_ = n.Stop(ctx)
+			_ = n.Cleanup(ctx)
+			delete(state.nodes, key)
+		}
+	}
+
+	return nil
+}
+
+// execUndelegate undelegates a validator's stake from the SFC.
+func execUndelegate(
+	step *parser.Step,
+	registry validatorRegistry,
+	state *sequentialState,
+) error {
+	name := step.Identifier
+
+	node, ok := state.nodes[name]
+	if !ok {
+		node, ok = state.nodes[name+"-0"]
+		if !ok {
+			return fmt.Errorf("node %q not found in active nodes", name)
+		}
+	}
+
+	if id := node.GetValidatorId(); id != nil {
+		if err := registry.unregisterValidator(*id); err != nil {
+			return fmt.Errorf("failed to unregister validator %s: %w", name, err)
+		}
+	} else {
+		return fmt.Errorf("node %q is not a validator", name)
+	}
+
+	return nil
+}
+
+// execRunApp creates and starts an application.
+func execRunApp(
+	ctx context.Context,
+	step *parser.Step,
+	net driver.Network,
+	state *sequentialState,
+) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	users := 1
+	if step.Users != nil {
+		users = *step.Users
+	}
+
+	app, err := net.CreateApplication(ctx, &driver.ApplicationConfig{
+		Name:  step.Identifier,
+		Type:  step.AppType,
+		Rate:  step.Rate,
+		Users: users,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create application %s: %w", step.Identifier, err)
+	}
+
+	if err := app.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start application %s: %w", step.Identifier, err)
+	}
+
+	state.apps[step.Identifier] = app
+	return nil
+}
+
+// execStopApp stops a running application.
+func execStopApp(step *parser.Step, state *sequentialState) error {
+	app, ok := state.apps[step.Identifier]
+	if !ok {
+		return fmt.Errorf("application %q not found in active apps", step.Identifier)
+	}
+
+	if err := app.Stop(); err != nil {
+		return fmt.Errorf("failed to stop application %s: %w", step.Identifier, err)
+	}
+
+	delete(state.apps, step.Identifier)
+	return nil
+}
+
+// execUpdateRules applies network rule updates.
+func execUpdateRules(step *parser.Step, net driver.Network) error {
+	rules := driver.NetworkRules(step.Rules)
+	if err := net.ApplyNetworkRules(rules); err != nil {
+		return fmt.Errorf("failed to apply network rules: %w", err)
+	}
+
+	return nil
+}
+
+// execCheck runs a named checker with optional configuration from the step.
+func execCheck(ctx context.Context, checkerName string, step *parser.Step, checks checking.Checks) error {
+	if checks == nil {
+		slog.Warn("checks skipped (no checker configured)", "check", checkerName)
+		return nil
+	}
+
+	checker := checks.GetCheckerByName(checkerName)
+	if checker == nil {
+		return fmt.Errorf("checker %q not found", checkerName)
+	}
+
+	// Build configuration from step parameters.
+	config := checking.CheckerConfig{}
+	if step.Failing {
+		config["failing"] = true
+	}
+	if step.Tolerance != nil {
+		config["tolerance"] = *step.Tolerance
+	}
+	if step.Ceiling != nil {
+		config["ceiling"] = int(*step.Ceiling)
+	}
+
+	if len(config) > 0 {
+		checker = checking.NewFailingChecker(checker).Configure(config)
+	}
+
+	return checker.Check(ctx)
+}
+
+// dataVolumePtr returns a *string for a non-empty DataVolume, nil otherwise.
+func dataVolumePtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// requiresBlockProductionCheck returns true for steps after which we should
+// verify the network is still producing blocks.
+func requiresBlockProductionCheck(step parser.Step) bool {
+	switch step.Function {
+	case parser.FuncStartNode:
+		return !step.Failing
+	case parser.FuncRunApp, parser.FuncUpdateRules, parser.FuncAdvanceEpoch:
+		return true
+	default:
+		// stopNode, undelegate, waitFor, waitForEpoch, stopApp, checks — skip
+		return false
+	}
+}
+
+// waitForBlockProduction waits until the network produces a new block,
+// confirming it is actively processing transactions after an epoch transition.
+func waitForBlockProduction(ctx context.Context, net driver.Network) error {
+	client, err := net.DialRandomRpc()
+	if err != nil {
+		// If we can't connect, log and proceed — the next step will fail
+		// with a more descriptive error if the network is truly down.
+		slog.Warn("skipping block production wait", "error", err)
+		return nil
+	}
+	defer client.Close()
+
+	baseline, err := client.BlockNumber(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get block number: %w", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled while waiting for block production: %w", ctx.Err())
+		default:
+		}
+		block, err := client.BlockNumber(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get block number: %w", err)
+		}
+		if block > baseline {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/driver/executor/sequential_test.go
+++ b/driver/executor/sequential_test.go
@@ -1,0 +1,358 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package executor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/0xsoniclabs/norma/driver"
+	"github.com/0xsoniclabs/norma/driver/checking"
+	"github.com/0xsoniclabs/norma/driver/parser"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSequential_EmptyScenario(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().GetActiveNodes().Return(nil)
+
+	scenario := parser.SequentialScenario{
+		Name:  "Empty",
+		Steps: []parser.Step{},
+	}
+
+	if err := runSequential(t.Context(), net, &scenario, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSequential_StartAndStopNode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	registry := NewMockvalidatorRegistry(ctrl)
+	node := driver.NewMockNode(ctrl)
+
+	net.EXPECT().GetActiveNodes().Return(nil)
+	// DialRandomRpc returns error so sync wait is skipped.
+	net.EXPECT().DialRandomRpc().Return(nil, fmt.Errorf("no nodes")).AnyTimes()
+	node.EXPECT().GetLabel().Return("validator-A").AnyTimes()
+	node.EXPECT().DialRpc(gomock.Any()).Return(nil, fmt.Errorf("not ready")).AnyTimes()
+
+	validatorId := 2
+	gomock.InOrder(
+		registry.EXPECT().registerNewValidator().Return(validatorId, nil),
+		net.EXPECT().CreateNode(gomock.Any()).Return(node, nil),
+		node.EXPECT().GetValidatorId().Return(&validatorId),
+		registry.EXPECT().unregisterValidator(validatorId).Return(nil),
+		net.EXPECT().RemoveNode(node).Return(nil),
+		node.EXPECT().Stop(gomock.Any()).Return(nil),
+		node.EXPECT().Cleanup(gomock.Any()).Return(nil),
+	)
+
+	scenario := parser.SequentialScenario{
+		Name: "Start Stop",
+		Steps: []parser.Step{
+			{
+				Function:   parser.FuncStartNode,
+				Identifier: "validator-A",
+				NodeType:   "validator",
+			},
+			{
+				Function:   parser.FuncUndelegate,
+				Identifier: "validator-A",
+			},
+			{
+				Function:   parser.FuncStopNode,
+				Identifier: "validator-A",
+			},
+		},
+	}
+
+	if err := runSequential(t.Context(), net, &scenario, nil, registry); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSequential_StopNodeWithoutUndelegate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	registry := NewMockvalidatorRegistry(ctrl)
+	node := driver.NewMockNode(ctrl)
+
+	net.EXPECT().GetActiveNodes().Return(nil)
+	net.EXPECT().DialRandomRpc().Return(nil, fmt.Errorf("no nodes")).AnyTimes()
+	node.EXPECT().GetLabel().Return("validator-A").AnyTimes()
+	node.EXPECT().DialRpc(gomock.Any()).Return(nil, fmt.Errorf("not ready")).AnyTimes()
+
+	validatorId := 2
+	gomock.InOrder(
+		registry.EXPECT().registerNewValidator().Return(validatorId, nil),
+		net.EXPECT().CreateNode(gomock.Any()).Return(node, nil),
+		// No unregister call expected
+		net.EXPECT().RemoveNode(node).Return(nil),
+		node.EXPECT().Stop(gomock.Any()).Return(nil),
+		node.EXPECT().Cleanup(gomock.Any()).Return(nil),
+	)
+
+	scenario := parser.SequentialScenario{
+		Name: "Leave",
+		Steps: []parser.Step{
+			{
+				Function:   parser.FuncStartNode,
+				Identifier: "validator-A",
+				NodeType:   "validator",
+			},
+			{
+				// Stop without undelegate
+				Function:   parser.FuncStopNode,
+				Identifier: "validator-A",
+			},
+		},
+	}
+
+	if err := runSequential(t.Context(), net, &scenario, nil, registry); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSequential_RejoinNode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	registry := NewMockvalidatorRegistry(ctrl)
+	node1 := driver.NewMockNode(ctrl)
+	node2 := driver.NewMockNode(ctrl)
+
+	net.EXPECT().GetActiveNodes().Return(nil)
+	net.EXPECT().DialRandomRpc().Return(nil, fmt.Errorf("no nodes")).AnyTimes()
+	node1.EXPECT().GetLabel().Return("validator-A").AnyTimes()
+	node1.EXPECT().DialRpc(gomock.Any()).Return(nil, fmt.Errorf("not ready")).AnyTimes()
+	node2.EXPECT().GetLabel().Return("validator-A").AnyTimes()
+	node2.EXPECT().DialRpc(gomock.Any()).Return(nil, fmt.Errorf("not ready")).AnyTimes()
+
+	validatorId := 2
+	gomock.InOrder(
+		// First start: registers as new validator
+		registry.EXPECT().registerNewValidator().Return(validatorId, nil),
+		net.EXPECT().CreateNode(gomock.Any()).Do(func(config *driver.NodeConfig) {
+			if config.ValidatorId == nil || *config.ValidatorId != validatorId {
+				t.Errorf("first start: expected ValidatorId=%d, got %v", validatorId, config.ValidatorId)
+			}
+		}).Return(node1, nil),
+		// Stop without undelegate
+		net.EXPECT().RemoveNode(node1).Return(nil),
+		node1.EXPECT().Stop(gomock.Any()).Return(nil),
+		node1.EXPECT().Cleanup(gomock.Any()).Return(nil),
+		// Rejoin: no registration, but validator ID is preserved
+		net.EXPECT().CreateNode(gomock.Any()).Do(func(config *driver.NodeConfig) {
+			if config.ValidatorId == nil || *config.ValidatorId != validatorId {
+				t.Errorf("rejoin: expected ValidatorId=%d, got %v", validatorId, config.ValidatorId)
+			}
+		}).Return(node2, nil),
+	)
+
+	scenario := parser.SequentialScenario{
+		Name: "Rejoin",
+		Steps: []parser.Step{
+			{
+				Function:   parser.FuncStartNode,
+				Identifier: "validator-A",
+				NodeType:   "validator",
+			},
+			{
+				Function:   parser.FuncStopNode,
+				Identifier: "validator-A",
+			},
+			{
+				Function:   parser.FuncStartNode,
+				Identifier: "validator-A",
+				NodeType:   "validator",
+			},
+		},
+	}
+
+	if err := runSequential(t.Context(), net, &scenario, nil, registry); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSequential_RunAndStopApp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().GetActiveNodes().Return(nil)
+	net.EXPECT().DialRandomRpc().Return(nil, fmt.Errorf("no nodes")).AnyTimes()
+	app := driver.NewMockApplication(ctrl)
+
+	rate := float32(10)
+
+	gomock.InOrder(
+		net.EXPECT().CreateApplication(gomock.Any(), gomock.Any()).Return(app, nil),
+		app.EXPECT().Start(gomock.Any()).Return(nil),
+		app.EXPECT().Stop().Return(nil),
+	)
+
+	scenario := parser.SequentialScenario{
+		Name: "App",
+		Steps: []parser.Step{
+			{
+				Function:   parser.FuncRunApp,
+				Identifier: "load",
+				AppType:    "counter",
+				Users:      New(50),
+				Rate:       &parser.Rate{Constant: &rate},
+			},
+			{
+				Function:   parser.FuncStopApp,
+				Identifier: "load",
+			},
+		},
+	}
+
+	if err := runSequential(t.Context(), net, &scenario, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSequential_UpdateRules(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().GetActiveNodes().Return(nil)
+	net.EXPECT().DialRandomRpc().Return(nil, fmt.Errorf("no nodes")).AnyTimes()
+
+	net.EXPECT().ApplyNetworkRules(driver.NetworkRules(map[string]string{
+		"MIN_BASE_FEE": "3000000000",
+	})).Return(nil)
+
+	scenario := parser.SequentialScenario{
+		Name: "Rules",
+		Steps: []parser.Step{
+			{
+				Function: parser.FuncUpdateRules,
+				Rules:    map[string]string{"MIN_BASE_FEE": "3000000000"},
+			},
+		},
+	}
+
+	if err := runSequential(t.Context(), net, &scenario, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSequential_AdvanceEpoch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+
+	net.EXPECT().GetActiveNodes().Return(nil)
+	net.EXPECT().AdvanceEpoch(1).Return(nil)
+	// DialRandomRpc returns error so waitForBlockProduction is skipped.
+	net.EXPECT().DialRandomRpc().Return(nil, fmt.Errorf("no nodes")).AnyTimes()
+
+	scenario := parser.SequentialScenario{
+		Name: "Epoch",
+		Steps: []parser.Step{
+			{Function: parser.FuncAdvanceEpoch},
+		},
+	}
+
+	if err := runSequential(t.Context(), net, &scenario, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSequential_Check(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().GetActiveNodes().Return(nil)
+	net.EXPECT().DialRandomRpc().Return(nil, fmt.Errorf("no nodes")).AnyTimes()
+	checker := checking.NewMockChecker(ctrl)
+
+	checker.EXPECT().Check(gomock.Any()).Return(nil)
+
+	checks := checking.Checks{"blocks_rolling": checker}
+
+	scenario := parser.SequentialScenario{
+		Name: "Check",
+		Steps: []parser.Step{
+			{Function: parser.FuncCheckBlocksProduced},
+		},
+	}
+
+	if err := runSequential(t.Context(), net, &scenario, checks, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSequential_ContextCancellation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().GetActiveNodes().Return(nil)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // Cancel immediately.
+
+	scenario := parser.SequentialScenario{
+		Name: "Cancelled",
+		Steps: []parser.Step{
+			{Function: parser.FuncAdvanceEpoch},
+		},
+	}
+
+	err := runSequential(ctx, net, &scenario, nil, nil)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}
+
+func TestSequential_MultiInstanceNode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	registry := NewMockvalidatorRegistry(ctrl)
+	node1 := driver.NewMockNode(ctrl)
+	node2 := driver.NewMockNode(ctrl)
+
+	net.EXPECT().GetActiveNodes().Return(nil)
+	net.EXPECT().DialRandomRpc().Return(nil, fmt.Errorf("no nodes")).AnyTimes()
+	node1.EXPECT().GetLabel().Return("validators-0").AnyTimes()
+	node1.EXPECT().DialRpc(gomock.Any()).Return(nil, fmt.Errorf("not ready")).AnyTimes()
+	node2.EXPECT().GetLabel().Return("validators-1").AnyTimes()
+	node2.EXPECT().DialRpc(gomock.Any()).Return(nil, fmt.Errorf("not ready")).AnyTimes()
+
+	gomock.InOrder(
+		registry.EXPECT().registerNewValidator().Return(2, nil),
+		net.EXPECT().CreateNode(gomock.Any()).Return(node1, nil),
+		registry.EXPECT().registerNewValidator().Return(3, nil),
+		net.EXPECT().CreateNode(gomock.Any()).Return(node2, nil),
+	)
+
+	instances := 2
+	scenario := parser.SequentialScenario{
+		Name: "Multi",
+		Steps: []parser.Step{
+			{
+				Function:   parser.FuncStartNode,
+				Identifier: "validators",
+				NodeType:   "validator",
+				Instances:  &instances,
+			},
+		},
+	}
+
+	if err := runSequential(t.Context(), net, &scenario, nil, registry); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/driver/network.go
+++ b/driver/network.go
@@ -99,6 +99,9 @@ type Network interface {
 
 	// AdvanceEpoch advances an epoch by the given number.
 	AdvanceEpoch(epochIncrement int) error
+
+	// WaitForEpochChange waits until the epoch changes.
+	WaitForEpochChange() error
 }
 
 // NetworkConfig is a collection of network parameters to be used by factories

--- a/driver/network/epoch.go
+++ b/driver/network/epoch.go
@@ -74,6 +74,31 @@ func AdvanceEpoch(client rpc.Client, epochIncrement int) error {
 	return fmt.Errorf("failed to advance epoch: waited too long for the epoch to be advanced")
 }
 
+// WaitForEpochChange waits until the current epoch changes. It polls the
+// network until a new epoch is observed or a timeout of 60 seconds is reached.
+func WaitForEpochChange(client rpc.Client) error {
+	currentEpoch, err := GetCurrentEpoch(client)
+	if err != nil {
+		return fmt.Errorf("failed to get current epoch: %w", err)
+	}
+
+	start := time.Now()
+	for time.Since(start) < 60*time.Second {
+		newEpoch, err := GetCurrentEpoch(client)
+		if err != nil {
+			return fmt.Errorf("failed to get epoch while waiting: %w", err)
+		}
+		if newEpoch > currentEpoch {
+			slog.Info("epoch changed", "from", uint64(currentEpoch), "to", uint64(newEpoch))
+			logEpochSummary(client)
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return fmt.Errorf("timed out waiting for epoch to change from %d", uint64(currentEpoch))
+}
+
 func GetCurrentEpoch(client rpc.Client) (hexutil.Uint64, error) {
 	var currentEpoch hexutil.Uint64
 	if err := client.Call(&currentEpoch, "eth_currentEpoch"); err != nil {

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/docker"
@@ -188,6 +189,8 @@ func NewLocalNetwork(ctx context.Context, config *driver.NetworkConfig) (*LocalN
 }
 
 // addNodeIntoNetwork connects the node with other nodes in the network, adds it into the list of nodes.
+// It is best-effort: if some existing nodes are unreachable, the new node will
+// still join the network as long as at least one peer connection succeeds.
 func (n *LocalNetwork) addNodeIntoNetwork(ctx context.Context, node *node.OperaNode) error {
 	n.nodesMutex.Lock()
 	defer n.nodesMutex.Unlock()
@@ -196,10 +199,21 @@ func (n *LocalNetwork) addNodeIntoNetwork(ctx context.Context, node *node.OperaN
 	if err != nil {
 		return fmt.Errorf("failed to get node id; %v", err)
 	}
+	var succeeded int
 	for _, other := range n.nodes {
 		if err = other.AddPeer(ctx, id); err != nil {
-			return fmt.Errorf("failed to add peer; %v", err)
+			label := other.GetLabel()
+			if checkErr := other.CheckRunning(ctx); checkErr != nil {
+				slog.Error("node has crashed", "node", label, "status", checkErr)
+			} else {
+				slog.Warn("failed to add peer to node", "node", label, "error", err)
+			}
+		} else {
+			succeeded++
 		}
+	}
+	if len(n.nodes) > 0 && succeeded == 0 {
+		return fmt.Errorf("failed to add peer; no existing node was reachable")
 	}
 	n.nodes[id] = node
 	return nil
@@ -324,7 +338,29 @@ func (n *LocalNetwork) DialRandomRpc() (rpcdriver.Client, error) {
 	if len(reliable) == 0 {
 		reliable = nodes // use failing nodes if there are no reliable nodes
 	}
-	return reliable[rand.Intn(len(reliable))].DialRpc(n.ctx)
+	// Shuffle and try nodes in order, skipping unresponsive ones.
+	perm := rand.Perm(len(reliable))
+	for _, i := range perm {
+		chosen := reliable[i]
+		client, err := chosen.DialRpc(n.ctx)
+		if err != nil {
+			slog.Warn("node unreachable in DialRandomRpc, skipping",
+				"node", chosen.GetLabel(), "error", err)
+			continue
+		}
+		// Verify the connection is actually alive with a quick call.
+		probeCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_, probeErr := client.BlockNumber(probeCtx)
+		cancel()
+		if probeErr != nil {
+			slog.Warn("node not responding in DialRandomRpc, skipping",
+				"node", chosen.GetLabel(), "error", probeErr)
+			client.Close()
+			continue
+		}
+		return client, nil
+	}
+	return nil, fmt.Errorf("no reachable node found among %d active nodes", len(reliable))
 }
 
 func (n *LocalNetwork) ApplyNetworkRules(rules driver.NetworkRules) error {
@@ -345,6 +381,16 @@ func (n *LocalNetwork) AdvanceEpoch(epochIncrement int) error {
 	defer client.Close()
 
 	return network.AdvanceEpoch(client, epochIncrement)
+}
+
+func (n *LocalNetwork) WaitForEpochChange() error {
+	client, err := n.DialRandomRpc()
+	if err != nil {
+		return fmt.Errorf("failed to connect to network: %w", err)
+	}
+	defer client.Close()
+
+	return network.WaitForEpochChange(client)
 }
 
 // treasureAccountPrivateKey is an account with tokens that can be used to

--- a/driver/network_mock.go
+++ b/driver/network_mock.go
@@ -207,6 +207,20 @@ func (mr *MockNetworkMockRecorder) UnregisterListener(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnregisterListener", reflect.TypeOf((*MockNetwork)(nil).UnregisterListener), arg0)
 }
 
+// WaitForEpochChange mocks base method.
+func (m *MockNetwork) WaitForEpochChange() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForEpochChange")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitForEpochChange indicates an expected call of WaitForEpochChange.
+func (mr *MockNetworkMockRecorder) WaitForEpochChange() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForEpochChange", reflect.TypeOf((*MockNetwork)(nil).WaitForEpochChange))
+}
+
 // MockNetworkListener is a mock of NetworkListener interface.
 type MockNetworkListener struct {
 	ctrl     *gomock.Controller

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -374,6 +374,12 @@ func (n *OperaNode) IsRunning() bool {
 	return n.host.IsRunning()
 }
 
+// CheckRunning returns an error if the node's container process is no longer
+// running (e.g. it crashed or exited unexpectedly).
+func (n *OperaNode) CheckRunning(ctx context.Context) error {
+	return n.host.CheckRunning(ctx)
+}
+
 func (n *OperaNode) GetServiceUrl(service *network.ServiceDescription) *driver.URL {
 	addr := n.host.GetAddressForService(service)
 	if addr == nil {

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -137,10 +137,19 @@ func runScenario(ctx context.Context, path, outputDir, label string, keepPrometh
 		return fmt.Errorf("couldn't create temp dir for output; %w", err)
 	}
 
+	// Try sequential format first.
+	seqScenario, seqErr := parser.ParseSequentialFile(path)
+	if seqErr == nil {
+		if err := seqScenario.Check(); err != nil {
+			return err
+		}
+		return runSequentialScenario(ctx, &seqScenario, path, outputDir, label, keepPrometheusRunning, skipChecks, skipReportRendering, openReport)
+	}
+
 	slog.Info("reading scenario file", "path", path)
 	scenario, err := parser.ParseFile(path)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to parse scenario file:\n  sequential: %w\n  legacy: %w", seqErr, err)
 	}
 
 	if err := scenario.Check(); err != nil {
@@ -268,6 +277,178 @@ func runScenario(ctx context.Context, path, outputDir, label string, keepPrometh
 	slog.Info("execution completed successfully")
 
 	return nil
+}
+
+// runSequentialScenario handles execution of the new sequential scenario format.
+func runSequentialScenario(ctx context.Context, scenario *parser.SequentialScenario, path, outputDir, label string, keepPrometheusRunning, skipChecks, skipReportRendering, openReport bool) error {
+	slog.Info("running sequential scenario", "path", path, "name", scenario.Name)
+
+	// create symlink as qol (_latest => _####) where #### is the randomly generated name
+	symlink := filepath.Join(filepath.Dir(outputDir), fmt.Sprintf("norma_data_%s_latest", label))
+	if _, lstatErr := os.Lstat(symlink); lstatErr == nil {
+		if err := os.Remove(symlink); err != nil {
+			return fmt.Errorf("failed to remove existing _latest symlink: %w", err)
+		}
+	}
+	if err := os.Symlink(outputDir, symlink); err != nil {
+		return fmt.Errorf("failed to create _latest symlink: %w", err)
+	}
+
+	slog.Info("monitoring data is written", "output", outputDir)
+
+	// Copy scenario yml to outputDir as well to provide context
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, filepath.Base(path)), data, 0644); err != nil {
+		return err
+	}
+
+	// Log initial rules.
+	for k, v := range scenario.InitialRules {
+		slog.Info("network Rule", "key", k, "value", v)
+	}
+
+	// Startup network. The first "startNode" step with type=validator is used
+	// as the initial validators configuration (for genesis and bootstrap).
+	// That step is then removed from the scenario since those nodes are already running.
+	validators, scenario := extractBootstrapValidators(scenario)
+	net, err := local.NewLocalNetwork(ctx, &driver.NetworkConfig{
+		Validators:   validators,
+		NetworkRules: driver.NetworkRules(maps.Clone(scenario.InitialRules)),
+		OutputDir:    outputDir,
+	})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		slog.Info("shutting down network ...")
+		if err := net.Shutdown(); err != nil {
+			slog.Error("error during network shutdown", "error", err)
+		}
+	}()
+
+	// Initialize monitoring environment.
+	monitor, err := monitoring.NewMonitor(net, monitoring.MonitorConfig{
+		EvaluationLabel: label,
+		OutputDir:       outputDir,
+	})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		slog.Info("shutting down data monitor ...")
+		if err := monitor.Shutdown(); err != nil {
+			slog.Error("error during monitor shutdown", "error", err)
+		}
+		slog.Info("monitoring data was written", "output", outputDir)
+		slog.Info("raw data was exported", "file", monitor.GetMeasurementFileName())
+
+		if !skipReportRendering && ctx.Err() == nil {
+			slog.Info("rendering summary report ...")
+			if file, err := report.SingleEvalReport.Render(monitor.GetMeasurementFileName(), outputDir, scenario.Name); err != nil {
+				slog.Error("report generation failed", "error", err)
+			} else {
+				slog.Info("summary report was exported", "file", fmt.Sprintf("file://%s/%s", outputDir, file))
+				if openReport {
+					if err := openBrowser(filepath.Join(outputDir, file)); err != nil {
+						slog.Warn("failed to open report in browser", "error", err)
+					}
+				}
+			}
+		} else {
+			slog.Info("report rendering skipped")
+			slog.Info(fmt.Sprintf("To render report run `norma render %s`", monitor.GetMeasurementFileName()))
+		}
+	}()
+
+	// Install monitoring sensory.
+	if err := monitoring.InstallAllRegisteredSources(monitor); err != nil {
+		return err
+	}
+
+	// Run prometheus.
+	slog.Info("starting Prometheus ...")
+	prom, err := prometheusmon.Start(ctx, net, net.GetDockerNetwork())
+	if err != nil {
+		slog.Error("error starting Prometheus", "error", err)
+	}
+	defer func() {
+		if !keepPrometheusRunning && prom != nil {
+			slog.Info("shutting down Prometheus ...")
+			if err := prom.Shutdown(); err != nil {
+				slog.Error("error during Prometheus shutdown", "error", err)
+			}
+		}
+	}()
+
+	var checks map[string]checking.Checker
+	if !skipChecks {
+		checks = checking.InitNetworkChecks(net, monitor)
+	}
+
+	// Run the sequential scenario.
+	slog.Info("running scenario", "path", path)
+	logger := startProgressLogger(monitor, net)
+	defer logger.shutdown()
+	if err := executor.RunSequential(ctx, net, scenario, checks); err != nil {
+		return err
+	}
+	slog.Info("execution completed successfully")
+
+	return nil
+}
+
+// extractBootstrapValidators determines the initial validators for the network.
+// All leading "startNode" steps with type=validator at the beginning
+// of the scenario are extracted and used as bootstrap validators.
+// If no validators are found, a single default validator is used.
+func extractBootstrapValidators(scenario *parser.SequentialScenario) (driver.Validators, *parser.SequentialScenario) {
+	// Extract leading validator startNode steps.
+	var validators driver.Validators
+	var count int
+
+	for _, step := range scenario.Steps {
+		if step.Function != parser.FuncStartNode {
+			break // stop at first non-startNode step
+		}
+		if step.NodeType != "validator" {
+			break // stop at first non-validator startNode
+		}
+
+		instances := 1
+		if step.Instances != nil {
+			instances = *step.Instances
+		}
+		image := driver.ResolveClientImageName(step.ImageName)
+
+		var stake uint64
+		if step.Stake != nil {
+			stake = *step.Stake
+		}
+
+		validators = append(validators, driver.Validator{
+			Name:      step.Identifier,
+			Instances: instances,
+			ImageName: image,
+			Stake:     stake,
+		})
+		count++
+	}
+
+	if len(validators) == 0 {
+		// No validator step found; use a single default validator.
+		return driver.NewDefaultValidators(1), scenario
+	}
+
+	// Return a copy of the scenario with the bootstrap steps removed.
+	remaining := make([]parser.Step, 0, len(scenario.Steps)-count)
+	remaining = append(remaining, scenario.Steps[count:]...)
+
+	modified := *scenario
+	modified.Steps = remaining
+	return validators, &modified
 }
 
 func openBrowser(s string) error {


### PR DESCRIPTION
Adds the runtime executor for sequential scenarios, enabling end-to-end execution of the YAML-based sequential test format introduced in #237.