### PR TITLE
Add default end of test checks to sequential scenarios

### DIFF
--- a/driver/parser/sequential.go
+++ b/driver/parser/sequential.go
@@ -175,9 +175,10 @@ func (c *CheckSpec) unmarshalCheckMapping(node *yaml.Node) error {
 // SequentialScenario is the root element of a sequential scenario description.
 // Unlike the time-based Scenario, it defines an ordered list of blocking steps.
 type SequentialScenario struct {
-	Name         string                    `yaml:"Name"`
-	InitialRules genesis.NetworkRulesPatch `yaml:"InitialNetworkRules"`
-	Steps        []Step                    `yaml:"Scenario"`
+	Name             string                    `yaml:"Name"`
+	InitialRules     genesis.NetworkRulesPatch `yaml:"InitialNetworkRules"`
+	DisableEndChecks bool                      `yaml:"DisableEndChecks,omitempty"`
+	Steps            []Step                    `yaml:"Scenario"`
 }
 
 // Step is a single blocking operation in a sequential scenario.
@@ -464,6 +465,22 @@ func ParseSequentialFile(path string) (scenario SequentialScenario, err error) {
 // setDefaults sets default values on the sequential scenario.
 func (s *SequentialScenario) setDefaults() {
 	ensureDefaultEpochDuration(&s.InitialRules)
+
+	// if the scenario does not disable end checks, append the default end
+	// checks to the steps list
+	if !s.DisableEndChecks {
+		s.Steps = append(s.Steps,
+			Step{Function: FuncAdvanceEpoch},
+			Step{Function: FuncAdvanceEpoch},
+			Step{
+				Function: FuncChecks,
+				SubChecks: []CheckSpec{
+					{Function: FuncCheckBlockHashes},
+					{Function: FuncCheckBlockHeights},
+				},
+			},
+		)
+	}
 }
 
 // checkFunctionDescriptions provides a human-readable description for each sub-check function.

--- a/driver/parser/sequential_test.go
+++ b/driver/parser/sequential_test.go
@@ -74,8 +74,8 @@ Scenario:
 	if scenario.Name != "Minimal Test" {
 		t.Errorf("expected name 'Minimal Test', got %q", scenario.Name)
 	}
-	if len(scenario.Steps) != 9 {
-		t.Fatalf("expected 9 steps, got %d", len(scenario.Steps))
+	if len(scenario.Steps) != 8 {
+		t.Fatalf("expected 8 steps, got %d", len(scenario.Steps))
 	}
 
 	// Verify step 1: startNode
@@ -180,8 +180,8 @@ Scenario:
 		t.Fatalf("unexpected parse error: %v", err)
 	}
 
-	if len(scenario.Steps) != 6 {
-		t.Fatalf("expected 6 steps, got %d", len(scenario.Steps))
+	if len(scenario.Steps) != 5 {
+		t.Fatalf("expected 5 steps, got %d", len(scenario.Steps))
 	}
 
 	step := scenario.Steps[1]
@@ -275,8 +275,8 @@ Scenario:
 		t.Fatalf("unexpected parse error: %v", err)
 	}
 
-	if len(scenario.Steps) != 5 {
-		t.Fatalf("expected 5 steps, got %d", len(scenario.Steps))
+	if len(scenario.Steps) != 4 {
+		t.Fatalf("expected 4 steps, got %d", len(scenario.Steps))
 	}
 
 	step := scenario.Steps[0]
@@ -372,8 +372,8 @@ Scenario:
 		t.Errorf("expected default Epochs.MaxEpochDuration=15s")
 	}
 
-	if len(scenario.Steps) != 5 {
-		t.Fatalf("expected 5 steps with default implicit end-checks, got %d", len(scenario.Steps))
+	if len(scenario.Steps) != 4 {
+		t.Fatalf("expected 4 steps with default implicit end-checks, got %d", len(scenario.Steps))
 	}
 
 	if scenario.Steps[1].Function != FuncAdvanceEpoch {
@@ -382,11 +382,8 @@ Scenario:
 	if scenario.Steps[2].Function != FuncAdvanceEpoch {
 		t.Errorf("expected implicit step 3 to be advanceEpoch, got %q", scenario.Steps[2].Function)
 	}
-	if scenario.Steps[3].Function != FuncCheckBlockHashes {
+	if scenario.Steps[3].Function != FuncChecks {
 		t.Errorf("expected implicit step 4 to be checkBlockHashes, got %q", scenario.Steps[3].Function)
-	}
-	if scenario.Steps[4].Function != FuncCheckBlockHeights {
-		t.Errorf("expected implicit step 5 to be checkBlockHeights, got %q", scenario.Steps[4].Function)
 	}
 }
 
@@ -524,8 +521,8 @@ Scenario:
 	if scenario.Name != "Single Proposer Blackout" {
 		t.Errorf("wrong name: %q", scenario.Name)
 	}
-	if len(scenario.Steps) != 19 {
-		t.Errorf("expected 19 steps, got %d", len(scenario.Steps))
+	if len(scenario.Steps) != 18 {
+		t.Errorf("expected 18 steps, got %d", len(scenario.Steps))
 	}
 
 	// Verify the rejoin pattern: validator-before-1 is started, stopped, then started again

--- a/driver/parser/sequential_test.go
+++ b/driver/parser/sequential_test.go
@@ -74,8 +74,8 @@ Scenario:
 	if scenario.Name != "Minimal Test" {
 		t.Errorf("expected name 'Minimal Test', got %q", scenario.Name)
 	}
-	if len(scenario.Steps) != 5 {
-		t.Fatalf("expected 5 steps, got %d", len(scenario.Steps))
+	if len(scenario.Steps) != 9 {
+		t.Fatalf("expected 9 steps, got %d", len(scenario.Steps))
 	}
 
 	// Verify step 1: startNode
@@ -180,8 +180,8 @@ Scenario:
 		t.Fatalf("unexpected parse error: %v", err)
 	}
 
-	if len(scenario.Steps) != 2 {
-		t.Fatalf("expected 2 steps, got %d", len(scenario.Steps))
+	if len(scenario.Steps) != 6 {
+		t.Fatalf("expected 6 steps, got %d", len(scenario.Steps))
 	}
 
 	step := scenario.Steps[1]
@@ -275,8 +275,8 @@ Scenario:
 		t.Fatalf("unexpected parse error: %v", err)
 	}
 
-	if len(scenario.Steps) != 1 {
-		t.Fatalf("expected 1 step, got %d", len(scenario.Steps))
+	if len(scenario.Steps) != 5 {
+		t.Fatalf("expected 5 steps, got %d", len(scenario.Steps))
 	}
 
 	step := scenario.Steps[0]
@@ -370,6 +370,40 @@ Scenario:
 	if scenario.InitialRules.Epochs == nil || scenario.InitialRules.Epochs.MaxEpochDuration == nil ||
 		int64(*scenario.InitialRules.Epochs.MaxEpochDuration) != int64(15*time.Second) {
 		t.Errorf("expected default Epochs.MaxEpochDuration=15s")
+	}
+
+	if len(scenario.Steps) != 5 {
+		t.Fatalf("expected 5 steps with default implicit end-checks, got %d", len(scenario.Steps))
+	}
+
+	if scenario.Steps[1].Function != FuncAdvanceEpoch {
+		t.Errorf("expected implicit step 2 to be advanceEpoch, got %q", scenario.Steps[1].Function)
+	}
+	if scenario.Steps[2].Function != FuncAdvanceEpoch {
+		t.Errorf("expected implicit step 3 to be advanceEpoch, got %q", scenario.Steps[2].Function)
+	}
+	if scenario.Steps[3].Function != FuncCheckBlockHashes {
+		t.Errorf("expected implicit step 4 to be checkBlockHashes, got %q", scenario.Steps[3].Function)
+	}
+	if scenario.Steps[4].Function != FuncCheckBlockHeights {
+		t.Errorf("expected implicit step 5 to be checkBlockHeights, got %q", scenario.Steps[4].Function)
+	}
+}
+
+func TestParseSequential_DisableEndChecks(t *testing.T) {
+	input := `
+Name: Disable End Checks Test
+DisableEndChecks: true
+Scenario:
+  - advanceEpoch
+`
+	scenario, err := ParseSequentialBytes([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	if len(scenario.Steps) != 1 {
+		t.Fatalf("expected 1 step when DisableEndChecks=true, got %d", len(scenario.Steps))
 	}
 }
 
@@ -490,8 +524,8 @@ Scenario:
 	if scenario.Name != "Single Proposer Blackout" {
 		t.Errorf("wrong name: %q", scenario.Name)
 	}
-	if len(scenario.Steps) != 15 {
-		t.Errorf("expected 15 steps, got %d", len(scenario.Steps))
+	if len(scenario.Steps) != 19 {
+		t.Errorf("expected 19 steps, got %d", len(scenario.Steps))
 	}
 
 	// Verify the rejoin pattern: validator-before-1 is started, stopped, then started again

--- a/driver/parser/sequential_test.go
+++ b/driver/parser/sequential_test.go
@@ -24,16 +24,17 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/norma/genesis"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAllStepFunctionsAreDocumented(t *testing.T) {
 	for _, fn := range allStepFunctions {
-		if desc, ok := stepFunctionDescriptions[fn]; !ok || strings.TrimSpace(desc) == "" {
-			t.Errorf("step function %q has no entry in stepFunctionDescriptions", fn)
-		}
-		if _, ok := allowedParams[fn]; !ok {
-			t.Errorf("step function %q has no entry in allowedParams", fn)
-		}
+		desc, ok := stepFunctionDescriptions[fn]
+		require.Truef(t, ok, "step function %q has no entry in stepFunctionDescriptions", fn)
+		require.NotEmptyf(t, strings.TrimSpace(desc), "step function %q has empty description", fn)
+
+		_, ok = allowedParams[fn]
+		require.Truef(t, ok, "step function %q has no entry in allowedParams", fn)
 	}
 }
 
@@ -45,9 +46,9 @@ func TestAllParamKeysAreDocumented(t *testing.T) {
 		}
 	}
 	for p := range seen {
-		if desc, ok := paramDescriptions[p]; !ok || strings.TrimSpace(desc) == "" {
-			t.Errorf("parameter %q has no entry in paramDescriptions", p)
-		}
+		desc, ok := paramDescriptions[p]
+		require.Truef(t, ok, "parameter %q has no entry in paramDescriptions", p)
+		require.NotEmptyf(t, strings.TrimSpace(desc), "parameter %q has empty description", p)
 	}
 }
 
@@ -67,70 +68,40 @@ Scenario:
   - stopNode: validator-A
 `
 	scenario, err := ParseSequentialBytes([]byte(input))
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-
-	if scenario.Name != "Minimal Test" {
-		t.Errorf("expected name 'Minimal Test', got %q", scenario.Name)
-	}
-	if len(scenario.Steps) != 8 {
-		t.Fatalf("expected 8 steps, got %d", len(scenario.Steps))
-	}
+	require.NoError(t, err)
+	require.Equal(t, "Minimal Test", scenario.Name)
+	require.Len(t, scenario.Steps, 8)
 
 	// Verify step 1: startNode
 	step := scenario.Steps[0]
-	if step.Function != FuncStartNode {
-		t.Errorf("step 0: expected FuncStartNode, got %q", step.Function)
-	}
-	if step.Identifier != "validator-A" {
-		t.Errorf("step 0: expected identifier 'validator-A', got %q", step.Identifier)
-	}
-	if step.NodeType != "validator" {
-		t.Errorf("step 0: expected node type 'validator', got %q", step.NodeType)
-	}
+	require.Equal(t, FuncStartNode, step.Function)
+	require.Equal(t, "validator-A", step.Identifier)
+	require.Equal(t, "validator", step.NodeType)
 
 	// Verify step 2: runApp
 	step = scenario.Steps[1]
-	if step.Function != FuncRunApp {
-		t.Errorf("step 1: expected FuncRunApp, got %q", step.Function)
-	}
-	if step.Identifier != "load" {
-		t.Errorf("step 1: expected identifier 'load', got %q", step.Identifier)
-	}
-	if step.AppType != "counter" {
-		t.Errorf("step 1: expected app type 'counter', got %q", step.AppType)
-	}
-	if step.Users == nil || *step.Users != 10 {
-		t.Errorf("step 1: expected users=10")
-	}
-	if step.Rate == nil || step.Rate.Constant == nil || *step.Rate.Constant != 5 {
-		t.Errorf("step 1: expected constant rate=5")
-	}
+	require.Equal(t, FuncRunApp, step.Function)
+	require.Equal(t, "load", step.Identifier)
+	require.Equal(t, "counter", step.AppType)
+	require.NotNil(t, step.Users)
+	require.Equal(t, 10, *step.Users)
+	require.NotNil(t, step.Rate)
+	require.NotNil(t, step.Rate.Constant)
+	require.EqualValues(t, 5, *step.Rate.Constant)
 
 	// Verify step 3: advanceEpoch
 	step = scenario.Steps[2]
-	if step.Function != FuncAdvanceEpoch {
-		t.Errorf("step 2: expected FuncAdvanceEpoch, got %q", step.Function)
-	}
+	require.Equal(t, FuncAdvanceEpoch, step.Function)
 
 	// Verify step 4: stopApp
 	step = scenario.Steps[3]
-	if step.Function != FuncStopApp {
-		t.Errorf("step 3: expected FuncStopApp, got %q", step.Function)
-	}
-	if step.Identifier != "load" {
-		t.Errorf("step 3: expected identifier 'load', got %q", step.Identifier)
-	}
+	require.Equal(t, FuncStopApp, step.Function)
+	require.Equal(t, "load", step.Identifier)
 
 	// Verify step 5: stopNode
 	step = scenario.Steps[4]
-	if step.Function != FuncStopNode {
-		t.Errorf("step 4: expected FuncStopNode, got %q", step.Function)
-	}
-	if step.Identifier != "validator-A" {
-		t.Errorf("step 4: expected identifier 'validator-A', got %q", step.Identifier)
-	}
+	require.Equal(t, FuncStopNode, step.Function)
+	require.Equal(t, "validator-A", step.Identifier)
 }
 
 func TestParseSequential_InitialRules(t *testing.T) {
@@ -147,20 +118,19 @@ Scenario:
     type: validator
 `
 	scenario, err := ParseSequentialBytes([]byte(input))
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-
-	if scenario.InitialRules.Upgrades == nil || scenario.InitialRules.Upgrades.Sonic == nil || !*scenario.InitialRules.Upgrades.Sonic {
-		t.Errorf("expected Upgrades.Sonic=true")
-	}
-	if scenario.InitialRules.Upgrades == nil || scenario.InitialRules.Upgrades.Allegro == nil || !*scenario.InitialRules.Upgrades.Allegro {
-		t.Errorf("expected Upgrades.Allegro=true")
-	}
-	if scenario.InitialRules.Epochs == nil || scenario.InitialRules.Epochs.MaxEpochDuration == nil ||
-		int64(*scenario.InitialRules.Epochs.MaxEpochDuration) != int64(10*time.Second) {
-		t.Errorf("expected Epochs.MaxEpochDuration=10s")
-	}
+	require.NoError(t, err)
+	require.NotNil(t, scenario.InitialRules.Upgrades)
+	require.NotNil(t, scenario.InitialRules.Upgrades.Sonic)
+	require.True(t, *scenario.InitialRules.Upgrades.Sonic)
+	require.NotNil(t, scenario.InitialRules.Upgrades.Allegro)
+	require.True(t, *scenario.InitialRules.Upgrades.Allegro)
+	require.NotNil(t, scenario.InitialRules.Epochs)
+	require.NotNil(t, scenario.InitialRules.Epochs.MaxEpochDuration)
+	require.Equal(
+		t,
+		int64(10*time.Second),
+		int64(*scenario.InitialRules.Epochs.MaxEpochDuration),
+	)
 }
 
 func TestParseSequential_UpdateRules(t *testing.T) {
@@ -176,27 +146,19 @@ Scenario:
         MaxBlockGas: 100000
 `
 	scenario, err := ParseSequentialBytes([]byte(input))
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-
-	if len(scenario.Steps) != 5 {
-		t.Fatalf("expected 5 steps, got %d", len(scenario.Steps))
-	}
+	require.NoError(t, err)
+	require.Len(t, scenario.Steps, 5)
 
 	step := scenario.Steps[1]
-	if step.Function != FuncUpdateRules {
-		t.Errorf("expected FuncUpdateRules, got %q", step.Function)
-	}
-	if step.Rules.Economy == nil || step.Rules.Economy.MinBaseFee == nil {
-		t.Fatal("expected Economy.MinBaseFee to be set")
-	}
+	require.Equal(t, FuncUpdateRules, step.Function)
+	require.NotNil(t, step.Rules.Economy)
+	require.NotNil(t, step.Rules.Economy.MinBaseFee)
 	if got := big.Int(*step.Rules.Economy.MinBaseFee); got.Cmp(big.NewInt(3000000000)) != 0 {
-		t.Errorf("expected Economy.MinBaseFee=3000000000, got %s", got.String())
+		require.Failf(t, "unexpected min base fee", "expected Economy.MinBaseFee=3000000000, got %s", got.String())
 	}
-	if step.Rules.Blocks == nil || step.Rules.Blocks.MaxBlockGas == nil || *step.Rules.Blocks.MaxBlockGas != 100000 {
-		t.Errorf("expected Blocks.MaxBlockGas=100000")
-	}
+	require.NotNil(t, step.Rules.Blocks)
+	require.NotNil(t, step.Rules.Blocks.MaxBlockGas)
+	require.EqualValues(t, 100000, *step.Rules.Blocks.MaxBlockGas)
 }
 
 func TestParseSequential_StartNodeWithOptions(t *testing.T) {
@@ -211,29 +173,16 @@ Scenario:
     failing: true
 `
 	scenario, err := ParseSequentialBytes([]byte(input))
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
+	require.NoError(t, err)
 
 	step := scenario.Steps[0]
-	if step.Identifier != "my-node" {
-		t.Errorf("expected identifier 'my-node', got %q", step.Identifier)
-	}
-	if step.NodeType != "validator" {
-		t.Errorf("expected type 'validator', got %q", step.NodeType)
-	}
-	if step.ImageName != "sonic:v2.0.2" {
-		t.Errorf("expected imagename 'sonic:v2.0.2', got %q", step.ImageName)
-	}
-	if step.Instances == nil || *step.Instances != 3 {
-		t.Errorf("expected instances=3")
-	}
-	if step.DataVolume != "vol-A" {
-		t.Errorf("expected datavolume 'vol-A', got %q", step.DataVolume)
-	}
-	if !step.Failing {
-		t.Errorf("expected failing=true")
-	}
+	require.Equal(t, "my-node", step.Identifier)
+	require.Equal(t, "validator", step.NodeType)
+	require.Equal(t, "sonic:v2.0.2", step.ImageName)
+	require.NotNil(t, step.Instances)
+	require.Equal(t, 3, *step.Instances)
+	require.Equal(t, "vol-A", step.DataVolume)
+	require.True(t, step.Failing)
 }
 
 func TestParseSequential_Undelegate(t *testing.T) {
@@ -243,17 +192,11 @@ Scenario:
   - undelegate: validator-A
 `
 	scenario, err := ParseSequentialBytes([]byte(input))
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
+	require.NoError(t, err)
 
 	step := scenario.Steps[0]
-	if step.Function != FuncUndelegate {
-		t.Errorf("expected FuncUndelegate, got %q", step.Function)
-	}
-	if step.Identifier != "validator-A" {
-		t.Errorf("expected identifier 'validator-A', got %q", step.Identifier)
-	}
+	require.Equal(t, FuncUndelegate, step.Function)
+	require.Equal(t, "validator-A", step.Identifier)
 }
 
 func TestParseSequential_Checks(t *testing.T) {
@@ -271,57 +214,34 @@ Scenario:
       - blockHashes
 `
 	scenario, err := ParseSequentialBytes([]byte(input))
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-
-	if len(scenario.Steps) != 4 {
-		t.Fatalf("expected 4 steps, got %d", len(scenario.Steps))
-	}
+	require.NoError(t, err)
+	require.Len(t, scenario.Steps, 4)
 
 	step := scenario.Steps[0]
-	if step.Function != FuncChecks {
-		t.Errorf("expected FuncChecks, got %q", step.Function)
-	}
-	if len(step.SubChecks) != 4 {
-		t.Fatalf("expected 4 sub-checks, got %d", len(step.SubChecks))
-	}
+	require.Equal(t, FuncChecks, step.Function)
+	require.Len(t, step.SubChecks, 4)
 
 	// blocksHalted with failing
 	check := step.SubChecks[0]
-	if check.Function != FuncCheckBlocksHalted {
-		t.Errorf("check 0: expected FuncCheckBlocksHalted, got %q", check.Function)
-	}
-	if !check.Failing {
-		t.Errorf("check 0: expected failing=true")
-	}
+	require.Equal(t, FuncCheckBlocksHalted, check.Function)
+	require.True(t, check.Failing)
 
 	// blockHeights with tolerance
 	check = step.SubChecks[1]
-	if check.Function != FuncCheckBlockHeights {
-		t.Errorf("check 1: expected FuncCheckBlockHeights, got %q", check.Function)
-	}
-	if check.Tolerance == nil || *check.Tolerance != 5 {
-		t.Errorf("check 1: expected tolerance=5")
-	}
+	require.Equal(t, FuncCheckBlockHeights, check.Function)
+	require.NotNil(t, check.Tolerance)
+	require.Equal(t, 5, *check.Tolerance)
 
 	// blockGasRate with ceiling + failing
 	check = step.SubChecks[2]
-	if check.Function != FuncCheckBlockGasRate {
-		t.Errorf("check 2: expected FuncCheckBlockGasRate, got %q", check.Function)
-	}
-	if check.Ceiling == nil || *check.Ceiling != 16500000 {
-		t.Errorf("check 2: expected ceiling=16500000")
-	}
-	if !check.Failing {
-		t.Errorf("check 2: expected failing=true")
-	}
+	require.Equal(t, FuncCheckBlockGasRate, check.Function)
+	require.NotNil(t, check.Ceiling)
+	require.EqualValues(t, 16500000, *check.Ceiling)
+	require.True(t, check.Failing)
 
 	// blockHashes
 	check = step.SubChecks[3]
-	if check.Function != FuncCheckBlockHashes {
-		t.Errorf("check 3: expected FuncCheckBlockHashes, got %q", check.Function)
-	}
+	require.Equal(t, FuncCheckBlockHashes, check.Function)
 }
 
 func TestParseSequential_SlopeRate(t *testing.T) {
@@ -337,23 +257,13 @@ Scenario:
         increment: 5
 `
 	scenario, err := ParseSequentialBytes([]byte(input))
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
+	require.NoError(t, err)
 
 	step := scenario.Steps[0]
-	if step.Rate == nil {
-		t.Fatal("expected rate to be set")
-	}
-	if step.Rate.Slope == nil {
-		t.Fatal("expected slope rate")
-	}
-	if step.Rate.Slope.Start != 20 {
-		t.Errorf("expected slope start=20, got %f", step.Rate.Slope.Start)
-	}
-	if step.Rate.Slope.Increment != 5 {
-		t.Errorf("expected slope increment=5, got %f", step.Rate.Slope.Increment)
-	}
+	require.NotNil(t, step.Rate)
+	require.NotNil(t, step.Rate.Slope)
+	require.EqualValues(t, 20, step.Rate.Slope.Start)
+	require.EqualValues(t, 5, step.Rate.Slope.Increment)
 }
 
 func TestParseSequential_DefaultsApplied(t *testing.T) {
@@ -363,28 +273,19 @@ Scenario:
   - advanceEpoch
 `
 	scenario, err := ParseSequentialBytes([]byte(input))
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
+	require.NoError(t, err)
+	require.NotNil(t, scenario.InitialRules.Epochs)
+	require.NotNil(t, scenario.InitialRules.Epochs.MaxEpochDuration)
+	require.Equal(
+		t,
+		int64(15*time.Second),
+		int64(*scenario.InitialRules.Epochs.MaxEpochDuration),
+	)
 
-	if scenario.InitialRules.Epochs == nil || scenario.InitialRules.Epochs.MaxEpochDuration == nil ||
-		int64(*scenario.InitialRules.Epochs.MaxEpochDuration) != int64(15*time.Second) {
-		t.Errorf("expected default Epochs.MaxEpochDuration=15s")
-	}
-
-	if len(scenario.Steps) != 4 {
-		t.Fatalf("expected 4 steps with default implicit end-checks, got %d", len(scenario.Steps))
-	}
-
-	if scenario.Steps[1].Function != FuncAdvanceEpoch {
-		t.Errorf("expected implicit step 2 to be advanceEpoch, got %q", scenario.Steps[1].Function)
-	}
-	if scenario.Steps[2].Function != FuncAdvanceEpoch {
-		t.Errorf("expected implicit step 3 to be advanceEpoch, got %q", scenario.Steps[2].Function)
-	}
-	if scenario.Steps[3].Function != FuncChecks {
-		t.Errorf("expected implicit step 4 to be checkBlockHashes, got %q", scenario.Steps[3].Function)
-	}
+	require.Len(t, scenario.Steps, 4)
+	require.Equal(t, FuncAdvanceEpoch, scenario.Steps[1].Function)
+	require.Equal(t, FuncAdvanceEpoch, scenario.Steps[2].Function)
+	require.Equal(t, FuncChecks, scenario.Steps[3].Function)
 }
 
 func TestParseSequential_DisableEndChecks(t *testing.T) {
@@ -395,13 +296,8 @@ Scenario:
   - advanceEpoch
 `
 	scenario, err := ParseSequentialBytes([]byte(input))
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-
-	if len(scenario.Steps) != 1 {
-		t.Fatalf("expected 1 step when DisableEndChecks=true, got %d", len(scenario.Steps))
-	}
+	require.NoError(t, err)
+	require.Len(t, scenario.Steps, 1)
 }
 
 func TestParseSequential_UnknownFunction(t *testing.T) {
@@ -411,9 +307,7 @@ Scenario:
   - Do something weird: foo
 `
 	_, err := ParseSequentialBytes([]byte(input))
-	if err == nil {
-		t.Fatal("expected parse error for unknown function")
-	}
+	require.Error(t, err)
 }
 
 func TestSequentialCheck_EmptyName(t *testing.T) {
@@ -422,9 +316,7 @@ func TestSequentialCheck_EmptyName(t *testing.T) {
 		Steps: []Step{{Function: FuncAdvanceEpoch}},
 	}
 	err := scenario.Check()
-	if err == nil {
-		t.Fatal("expected error for empty name")
-	}
+	require.Error(t, err)
 }
 
 func TestSequentialCheck_InvalidNodeName(t *testing.T) {
@@ -437,9 +329,7 @@ func TestSequentialCheck_InvalidNodeName(t *testing.T) {
 		}},
 	}
 	err := scenario.Check()
-	if err == nil {
-		t.Fatal("expected error for invalid node name")
-	}
+	require.Error(t, err)
 }
 
 func TestSequentialCheck_RunAppMissingRate(t *testing.T) {
@@ -452,9 +342,7 @@ func TestSequentialCheck_RunAppMissingRate(t *testing.T) {
 		}},
 	}
 	err := scenario.Check()
-	if err == nil {
-		t.Fatal("expected error for missing rate")
-	}
+	require.Error(t, err)
 }
 
 func TestSequentialCheck_UpdateRulesEmpty(t *testing.T) {
@@ -466,9 +354,7 @@ func TestSequentialCheck_UpdateRulesEmpty(t *testing.T) {
 		}},
 	}
 	err := scenario.Check()
-	if err == nil {
-		t.Fatal("expected error for empty rules")
-	}
+	require.Error(t, err)
 }
 
 func TestParseSequential_FullBlackoutScenario(t *testing.T) {
@@ -514,16 +400,9 @@ Scenario:
   - stopApp: load
 `
 	scenario, err := ParseSequentialBytes([]byte(input))
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-
-	if scenario.Name != "Single Proposer Blackout" {
-		t.Errorf("wrong name: %q", scenario.Name)
-	}
-	if len(scenario.Steps) != 18 {
-		t.Errorf("expected 18 steps, got %d", len(scenario.Steps))
-	}
+	require.NoError(t, err)
+	require.Equal(t, "Single Proposer Blackout", scenario.Name)
+	require.Len(t, scenario.Steps, 18)
 
 	// Verify the rejoin pattern: validator-before-1 is started, stopped, then started again
 	starts := 0
@@ -532,28 +411,20 @@ Scenario:
 			starts++
 		}
 	}
-	if starts != 2 {
-		t.Errorf("expected validator-before-1 started 2 times (start + rejoin), got %d", starts)
-	}
+	require.Equal(t, 2, starts)
 }
 
 func TestParseSequentialFile_NonExistentFile(t *testing.T) {
 	_, err := ParseSequentialFile("/non/existent/path.yml")
-	if err == nil {
-		t.Fatal("expected error for non-existent file")
-	}
+	require.Error(t, err)
 }
 
 func TestParseSequentialFile_InvalidContent(t *testing.T) {
 	// Write invalid YAML to a temp file.
 	path := t.TempDir() + "/bad.yml"
-	if err := os.WriteFile(path, []byte(":::not valid yaml"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(":::not valid yaml"), 0644))
 	_, err := ParseSequentialFile(path)
-	if err == nil {
-		t.Fatal("expected error for invalid YAML file")
-	}
+	require.Error(t, err)
 }
 
 func TestParseSequential_InvalidParamForFunction(t *testing.T) {
@@ -639,12 +510,8 @@ Scenario:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := ParseSequentialBytes([]byte(tt.input))
-			if err == nil {
-				t.Fatalf("expected error for %s, but parsing succeeded", tt.name)
-			}
-			if !strings.Contains(err.Error(), "is not valid for") {
-				t.Fatalf("expected 'is not valid for' error, got: %v", err)
-			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "is not valid for")
 		})
 	}
 }
@@ -690,9 +557,7 @@ Scenario:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := ParseSequentialBytes([]byte(tt.input))
-			if err == nil {
-				t.Fatalf("expected error for non-scalar %s, but parsing succeeded", tt.name)
-			}
+			require.Error(t, err)
 		})
 	}
 }
@@ -709,20 +574,12 @@ Scenario:
       constant: 10
 `
 	scenario, err := ParseSequentialBytes([]byte(input))
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
+	require.NoError(t, err)
 
 	step := scenario.Steps[0]
-	if step.Function != FuncRunApp {
-		t.Errorf("expected FuncRunApp, got %q", step.Function)
-	}
-	if step.AppType != "counter" {
-		t.Errorf("expected app type 'counter', got %q", step.AppType)
-	}
-	if step.NodeType != "" {
-		t.Errorf("expected empty NodeType, got %q", step.NodeType)
-	}
+	require.Equal(t, FuncRunApp, step.Function)
+	require.Equal(t, "counter", step.AppType)
+	require.Empty(t, step.NodeType)
 }
 
 func TestParseSequential_RulesPatchAllCategories(t *testing.T) {
@@ -754,82 +611,59 @@ Scenario:
         Brio: true
 `
 	scenario, err := ParseSequentialBytes([]byte(input))
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
+	require.NoError(t, err)
 
 	r := scenario.InitialRules
 
 	// Epochs
-	if r.Epochs == nil {
-		t.Fatal("expected Epochs to be set")
-	}
+	require.NotNil(t, r.Epochs)
 	if got, want := *r.Epochs.MaxEpochGas, uint64(5000000000); got != want {
-		t.Errorf("MaxEpochGas: got %d, want %d", got, want)
+		require.Failf(t, "unexpected MaxEpochGas", "MaxEpochGas: got %d, want %d", got, want)
 	}
 	if got, want := int64(*r.Epochs.MaxEpochDuration), int64(30*time.Second); got != want {
-		t.Errorf("MaxEpochDuration: got %d, want %d", got, want)
+		require.Failf(t, "unexpected MaxEpochDuration", "MaxEpochDuration: got %d, want %d", got, want)
 	}
 
 	// Blocks
-	if r.Blocks == nil {
-		t.Fatal("expected Blocks to be set")
-	}
+	require.NotNil(t, r.Blocks)
 	if got, want := *r.Blocks.MaxBlockGas, uint64(20500000000); got != want {
-		t.Errorf("MaxBlockGas: got %d, want %d", got, want)
+		require.Failf(t, "unexpected MaxBlockGas", "MaxBlockGas: got %d, want %d", got, want)
 	}
 	if got, want := int64(*r.Blocks.MaxEmptyBlockSkipPeriod), int64(3*time.Second); got != want {
-		t.Errorf("MaxEmptyBlockSkipPeriod: got %d, want %d", got, want)
+		require.Failf(t, "unexpected MaxEmptyBlockSkipPeriod", "MaxEmptyBlockSkipPeriod: got %d, want %d", got, want)
 	}
 
 	// Economy (BigIntValue fields)
-	if r.Economy == nil || r.Economy.MinBaseFee == nil {
-		t.Fatal("expected Economy.MinBaseFee to be set")
-	}
-	if r.Economy.MinGasPrice == nil {
-		t.Fatal("expected Economy.MinGasPrice to be set")
-	}
+	require.NotNil(t, r.Economy)
+	require.NotNil(t, r.Economy.MinBaseFee)
+	require.NotNil(t, r.Economy.MinGasPrice)
 
 	// Upgrades
-	if r.Upgrades == nil {
-		t.Fatal("expected Upgrades to be set")
-	}
-	if r.Upgrades.Sonic == nil || !*r.Upgrades.Sonic {
-		t.Error("expected Upgrades.Sonic=true")
-	}
-	if r.Upgrades.Allegro == nil || !*r.Upgrades.Allegro {
-		t.Error("expected Upgrades.Allegro=true")
-	}
-	if r.Upgrades.Brio == nil || *r.Upgrades.Brio {
-		t.Error("expected Upgrades.Brio=false")
-	}
+	require.NotNil(t, r.Upgrades)
+	require.NotNil(t, r.Upgrades.Sonic)
+	require.True(t, *r.Upgrades.Sonic)
+	require.NotNil(t, r.Upgrades.Allegro)
+	require.True(t, *r.Upgrades.Allegro)
+	require.NotNil(t, r.Upgrades.Brio)
+	require.False(t, *r.Upgrades.Brio)
 
 	// Unset categories should be nil
-	if r.Dag != nil {
-		t.Error("expected Dag to be nil")
-	}
-	if r.Emitter != nil {
-		t.Error("expected Emitter to be nil")
-	}
+	require.Nil(t, r.Dag)
+	require.Nil(t, r.Emitter)
 
 	// Verify updateRules step
 	step := scenario.Steps[1]
-	if step.Function != FuncUpdateRules {
-		t.Fatalf("expected FuncUpdateRules, got %q", step.Function)
-	}
-	if step.Rules.Blocks == nil || *step.Rules.Blocks.MaxBlockGas != 30000000000 {
-		t.Error("expected updateRules Blocks.MaxBlockGas=30000000000")
-	}
-	if step.Rules.Economy == nil || step.Rules.Economy.MinBaseFee == nil {
-		t.Error("expected updateRules Economy.MinBaseFee to be set")
-	}
-	if step.Rules.Upgrades == nil || step.Rules.Upgrades.Brio == nil || !*step.Rules.Upgrades.Brio {
-		t.Error("expected updateRules Upgrades.Brio=true")
-	}
+	require.Equal(t, FuncUpdateRules, step.Function)
+	require.NotNil(t, step.Rules.Blocks)
+	require.NotNil(t, step.Rules.Blocks.MaxBlockGas)
+	require.EqualValues(t, 30000000000, *step.Rules.Blocks.MaxBlockGas)
+	require.NotNil(t, step.Rules.Economy)
+	require.NotNil(t, step.Rules.Economy.MinBaseFee)
+	require.NotNil(t, step.Rules.Upgrades)
+	require.NotNil(t, step.Rules.Upgrades.Brio)
+	require.True(t, *step.Rules.Upgrades.Brio)
 	// Fields not in the update should remain nil
-	if step.Rules.Epochs != nil {
-		t.Error("expected updateRules Epochs to be nil")
-	}
+	require.Nil(t, step.Rules.Epochs)
 }
 
 func TestSequentialCheck_EmptySubChecks(t *testing.T) {
@@ -841,12 +675,8 @@ func TestSequentialCheck_EmptySubChecks(t *testing.T) {
 		}},
 	}
 	err := scenario.Check()
-	if err == nil {
-		t.Fatal("expected error for empty sub-checks")
-	}
-	if !strings.Contains(err.Error(), "at least one sub-check") {
-		t.Fatalf("expected 'at least one sub-check' error, got: %v", err)
-	}
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at least one sub-check")
 }
 
 func TestParseSequential_UnknownCheckFunction(t *testing.T) {
@@ -857,10 +687,6 @@ Scenario:
       - unknownCheck
 `
 	_, err := ParseSequentialBytes([]byte(input))
-	if err == nil {
-		t.Fatal("expected error for unknown check function")
-	}
-	if !strings.Contains(err.Error(), "unknown check function") {
-		t.Fatalf("expected 'unknown check function' error, got: %v", err)
-	}
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown check function")
 }

--- a/scenarios/scenario_test.go
+++ b/scenarios/scenario_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/norma/driver/parser"
+	"github.com/stretchr/testify/require"
 )
 
 // TestCheckScenarios iterates through all scenarios in this directory
@@ -30,30 +31,28 @@ import (
 // define valid scenarios.
 func TestCheckScenarios(t *testing.T) {
 	files, err := listAll()
-	if err != nil {
-		t.Fatalf("failed to get list of all scenario files: %v", err)
-	}
-	if len(files) == 0 {
-		t.Fatalf("failed to locate any scenario files!")
-	}
+	require.NoError(t, err, "failed to get list of all scenario files")
+	require.NotEmpty(t, files, "failed to locate any scenario files")
 	for _, file := range files {
 		t.Run(file, func(t *testing.T) {
 			// Try sequential format first, fall back to legacy format.
 			seqScenario, seqErr := parser.ParseSequentialFile(file)
 			if seqErr == nil {
-				if err := seqScenario.Check(); err != nil {
-					t.Fatalf("sequential scenario check failed for: %s: %v", file, err)
-				}
+				require.NoError(
+					t,
+					seqScenario.Check(),
+					"sequential scenario check failed for: %s", file,
+				)
 				return
 			}
 
 			scenario, err := parser.ParseFile(file)
-			if err != nil {
-				t.Fatalf("failed to parse file: %s\n  sequential: %v\n  legacy: %v", file, seqErr, err)
-			}
-			if err = scenario.Check(); err != nil {
-				t.Fatalf("scenario check failed for: %s: %v", file, err)
-			}
+			require.NoError(
+				t,
+				err,
+				"failed to parse file: %s\n  sequential: %v", file, seqErr,
+			)
+			require.NoError(t, scenario.Check(), "scenario check failed for: %s", file)
 		})
 	}
 }

--- a/scenarios/scenario_test.go
+++ b/scenarios/scenario_test.go
@@ -41,7 +41,7 @@ func TestCheckScenarios(t *testing.T) {
 				require.NoError(
 					t,
 					seqScenario.Check(),
-					"sequential scenario check failed for: %s", file,
+					"sequential scenario check failed for file", file,
 				)
 				return
 			}
@@ -50,9 +50,9 @@ func TestCheckScenarios(t *testing.T) {
 			require.NoError(
 				t,
 				err,
-				"failed to parse file: %s\n  sequential: %v", file, seqErr,
+				"failed to parse file", file, "sequential error:", seqErr,
 			)
-			require.NoError(t, scenario.Check(), "scenario check failed for: %s", file)
+			require.NoError(t, scenario.Check(), "scenario check failed for file", file)
 		})
 	}
 }

--- a/scenarios/sequential/checks.yml
+++ b/scenarios/sequential/checks.yml
@@ -1,10 +1,14 @@
 # This scenario demonstrates all available check functions.
 
-Name: All Checks Test
+Name: Checks Test
 
 InitialNetworkRules:
   Epochs:
     MaxEpochDuration: 10s
+
+# this scenario is intended to halt the network, therefore usual 
+# end-of-scenario checks are disabled to avoid false failures.
+DisableEndChecks: true
 
 Scenario:
   - startNode: validator


### PR DESCRIPTION
This PR adds the end of scenario checks to sequential scenarios syntax
introduced to scenarios in Norma for release testing 2.2

These checks advance epochs at the end and check that the nodes are all up to date. 
the option to disable these checks is given for tests which have special end conditions. 