### PR TITLE
Default end-of-test checks

### DIFF
--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"math/rand"
 	"os"
 	"strings"
@@ -279,6 +280,10 @@ func (c *Container) Cleanup(ctx context.Context) error {
 	if c.cleaned {
 		return nil
 	}
+	start := time.Now()
+	defer func() {
+		slog.Debug("container cleanup completed", "container", c.id, "duration", time.Since(start))
+	}()
 	if err := c.Stop(ctx); err != nil {
 		return err
 	}

--- a/driver/network/retry.go
+++ b/driver/network/retry.go
@@ -3,6 +3,7 @@ package network
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"time"
 )
 
@@ -39,6 +40,8 @@ func RetryReturn[Out any](
 		if errors.Is(err, ErrPermanent) {
 			return out, err // don't retry when the error is permanent
 		}
+
+		slog.Debug("query failed, retrying", "error", err, "attempt", i+1, "max_attempts", numAttempts)
 		select {
 		case <-ctx.Done():
 			return out, ctx.Err()

--- a/driver/parser/sequential.go
+++ b/driver/parser/sequential.go
@@ -175,9 +175,10 @@ func (c *CheckSpec) unmarshalCheckMapping(node *yaml.Node) error {
 // SequentialScenario is the root element of a sequential scenario description.
 // Unlike the time-based Scenario, it defines an ordered list of blocking steps.
 type SequentialScenario struct {
-	Name         string                    `yaml:"Name"`
-	InitialRules genesis.NetworkRulesPatch `yaml:"InitialNetworkRules"`
-	Steps        []Step                    `yaml:"Scenario"`
+	Name             string                    `yaml:"Name"`
+	InitialRules     genesis.NetworkRulesPatch `yaml:"InitialNetworkRules"`
+	DisableEndChecks bool                      `yaml:"DisableEndChecks,omitempty"`
+	Steps            []Step                    `yaml:"Scenario"`
 }
 
 // Step is a single blocking operation in a sequential scenario.
@@ -464,6 +465,17 @@ func ParseSequentialFile(path string) (scenario SequentialScenario, err error) {
 // setDefaults sets default values on the sequential scenario.
 func (s *SequentialScenario) setDefaults() {
 	ensureDefaultEpochDuration(&s.InitialRules)
+
+	// if the scenario does not disable end checks, append the default end
+	// checks to the steps list
+	if !s.DisableEndChecks {
+		s.Steps = append(s.Steps,
+			Step{Function: FuncAdvanceEpoch},
+			Step{Function: FuncAdvanceEpoch},
+			Step{Function: FuncCheckBlockHashes},
+			Step{Function: FuncCheckBlockHeights},
+		)
+	}
 }
 
 // checkFunctionDescriptions provides a human-readable description for each sub-check function.

--- a/driver/parser/sequential_test.go
+++ b/driver/parser/sequential_test.go
@@ -74,8 +74,8 @@ Scenario:
 	if scenario.Name != "Minimal Test" {
 		t.Errorf("expected name 'Minimal Test', got %q", scenario.Name)
 	}
-	if len(scenario.Steps) != 5 {
-		t.Fatalf("expected 5 steps, got %d", len(scenario.Steps))
+	if len(scenario.Steps) != 9 {
+		t.Fatalf("expected 9 steps, got %d", len(scenario.Steps))
 	}
 
 	// Verify step 1: startNode
@@ -180,8 +180,8 @@ Scenario:
 		t.Fatalf("unexpected parse error: %v", err)
 	}
 
-	if len(scenario.Steps) != 2 {
-		t.Fatalf("expected 2 steps, got %d", len(scenario.Steps))
+	if len(scenario.Steps) != 6 {
+		t.Fatalf("expected 6 steps, got %d", len(scenario.Steps))
 	}
 
 	step := scenario.Steps[1]
@@ -275,8 +275,8 @@ Scenario:
 		t.Fatalf("unexpected parse error: %v", err)
 	}
 
-	if len(scenario.Steps) != 1 {
-		t.Fatalf("expected 1 step, got %d", len(scenario.Steps))
+	if len(scenario.Steps) != 5 {
+		t.Fatalf("expected 5 steps, got %d", len(scenario.Steps))
 	}
 
 	step := scenario.Steps[0]
@@ -370,6 +370,40 @@ Scenario:
 	if scenario.InitialRules.Epochs == nil || scenario.InitialRules.Epochs.MaxEpochDuration == nil ||
 		int64(*scenario.InitialRules.Epochs.MaxEpochDuration) != int64(15*time.Second) {
 		t.Errorf("expected default Epochs.MaxEpochDuration=15s")
+	}
+
+	if len(scenario.Steps) != 5 {
+		t.Fatalf("expected 5 steps with default implicit end-checks, got %d", len(scenario.Steps))
+	}
+
+	if scenario.Steps[1].Function != FuncAdvanceEpoch {
+		t.Errorf("expected implicit step 2 to be advanceEpoch, got %q", scenario.Steps[1].Function)
+	}
+	if scenario.Steps[2].Function != FuncAdvanceEpoch {
+		t.Errorf("expected implicit step 3 to be advanceEpoch, got %q", scenario.Steps[2].Function)
+	}
+	if scenario.Steps[3].Function != FuncCheckBlockHashes {
+		t.Errorf("expected implicit step 4 to be checkBlockHashes, got %q", scenario.Steps[3].Function)
+	}
+	if scenario.Steps[4].Function != FuncCheckBlockHeights {
+		t.Errorf("expected implicit step 5 to be checkBlockHeights, got %q", scenario.Steps[4].Function)
+	}
+}
+
+func TestParseSequential_DisableEndChecks(t *testing.T) {
+	input := `
+Name: Disable End Checks Test
+DisableEndChecks: true
+Scenario:
+  - advanceEpoch
+`
+	scenario, err := ParseSequentialBytes([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	if len(scenario.Steps) != 1 {
+		t.Fatalf("expected 1 step when DisableEndChecks=true, got %d", len(scenario.Steps))
 	}
 }
 
@@ -490,8 +524,8 @@ Scenario:
 	if scenario.Name != "Single Proposer Blackout" {
 		t.Errorf("wrong name: %q", scenario.Name)
 	}
-	if len(scenario.Steps) != 15 {
-		t.Errorf("expected 15 steps, got %d", len(scenario.Steps))
+	if len(scenario.Steps) != 19 {
+		t.Errorf("expected 19 steps, got %d", len(scenario.Steps))
 	}
 
 	// Verify the rejoin pattern: validator-before-1 is started, stopped, then started again

--- a/scenarios/sequential/checks.yml
+++ b/scenarios/sequential/checks.yml
@@ -1,10 +1,14 @@
 # This scenario demonstrates all available check functions.
 
-Name: All Checks Test
+Name: Checks Test
 
 InitialNetworkRules:
   Epochs:
     MaxEpochDuration: 10s
+
+# this scenario is intended to halt the network, therefore usual 
+# end-of-scenario checks are disabled to avoid false failures.
+DisableEndChecks: true
 
 Scenario:
   - startNode: validator


### PR DESCRIPTION
This PR adds default end of test checks to all scenarios if not specified otherwise.
Further, it improves logging.