### PR TITLE
Suppress error when node re-syncs

### DIFF
--- a/driver/monitoring/node/block_metrics.go
+++ b/driver/monitoring/node/block_metrics.go
@@ -19,7 +19,6 @@ package nodemon
 import (
 	"fmt"
 	"log/slog"
-	"sync"
 	"time"
 
 	"github.com/0xsoniclabs/norma/driver/monitoring"
@@ -53,8 +52,7 @@ type BlockNodeMetricSource[T any] struct {
 	*utils.SyncedSeriesSource[monitoring.Node, monitoring.BlockNumber, T]
 	getBlockProperty func(b monitoring.Block) T
 	monitor          *monitoring.Monitor
-	syncingNodes     map[monitoring.Node]bool
-	syncingMutex     sync.Mutex
+	syncingTracker
 }
 
 // NewBlockTimeSource creates a metric capturing time of the block finalisation for each Node.
@@ -93,7 +91,7 @@ func newBlockNodeMetricsSource[T any](
 		SyncedSeriesSource: utils.NewSyncedSeriesSource(metric),
 		getBlockProperty:   getBlockProperty,
 		monitor:            monitor,
-		syncingNodes:       make(map[monitoring.Node]bool, 50),
+		syncingTracker:     newSyncingTracker(),
 	}
 
 	monitor.NodeLogProvider().RegisterLogListener(m)
@@ -119,33 +117,4 @@ func (s *BlockNodeMetricSource[T]) OnBlock(node monitoring.Node, block monitorin
 	s.markNodeAsSynced(node)
 }
 
-func (s *BlockNodeMetricSource[T]) markNodeAsSyncing(node monitoring.Node) {
-	s.syncingMutex.Lock()
-	defer s.syncingMutex.Unlock()
-	if _, exists := s.syncingNodes[node]; !exists {
-		s.syncingNodes[node] = true
-	}
-}
 
-func (s *BlockNodeMetricSource[T]) markNodeAsSynced(node monitoring.Node) {
-	s.syncingMutex.Lock()
-	defer s.syncingMutex.Unlock()
-	s.syncingNodes[node] = false
-}
-
-func (s *BlockNodeMetricSource[T]) isNodeSyncing(node monitoring.Node) bool {
-	s.syncingMutex.Lock()
-	defer s.syncingMutex.Unlock()
-	syncing, exists := s.syncingNodes[node]
-	if !exists {
-		return true
-	}
-	return syncing
-}
-
-func (s *BlockNodeMetricSource[T]) shouldSuppressAppendConflict(node monitoring.Node, err error) bool {
-	if !monitoring.IsOutOfOrderAppendError(err) {
-		return false
-	}
-	return s.isNodeSyncing(node)
-}

--- a/driver/monitoring/node/block_metrics.go
+++ b/driver/monitoring/node/block_metrics.go
@@ -116,5 +116,3 @@ func (s *BlockNodeMetricSource[T]) OnBlock(node monitoring.Node, block monitorin
 	}
 	s.markNodeAsSynced(node)
 }
-
-

--- a/driver/monitoring/node/block_metrics.go
+++ b/driver/monitoring/node/block_metrics.go
@@ -19,6 +19,7 @@ package nodemon
 import (
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/0xsoniclabs/norma/driver/monitoring"
@@ -52,6 +53,8 @@ type BlockNodeMetricSource[T any] struct {
 	*utils.SyncedSeriesSource[monitoring.Node, monitoring.BlockNumber, T]
 	getBlockProperty func(b monitoring.Block) T
 	monitor          *monitoring.Monitor
+	syncingNodes     map[monitoring.Node]bool
+	syncingMutex     sync.Mutex
 }
 
 // NewBlockTimeSource creates a metric capturing time of the block finalisation for each Node.
@@ -90,6 +93,7 @@ func newBlockNodeMetricsSource[T any](
 		SyncedSeriesSource: utils.NewSyncedSeriesSource(metric),
 		getBlockProperty:   getBlockProperty,
 		monitor:            monitor,
+		syncingNodes:       make(map[monitoring.Node]bool, 50),
 	}
 
 	monitor.NodeLogProvider().RegisterLogListener(m)
@@ -103,8 +107,45 @@ func (s *BlockNodeMetricSource[T]) Shutdown() error {
 }
 
 func (s *BlockNodeMetricSource[T]) OnBlock(node monitoring.Node, block monitoring.Block) {
+	s.markNodeAsSyncing(node)
 	series := s.GetOrAddSubject(node)
 	if err := series.Append(monitoring.BlockNumber(block.Height), s.getBlockProperty(block)); err != nil {
+		if s.shouldSuppressAppendConflict(node, err) {
+			return
+		}
 		slog.Error("error to add to the series", "error", err)
+		return
 	}
+	s.markNodeAsSynced(node)
+}
+
+func (s *BlockNodeMetricSource[T]) markNodeAsSyncing(node monitoring.Node) {
+	s.syncingMutex.Lock()
+	defer s.syncingMutex.Unlock()
+	if _, exists := s.syncingNodes[node]; !exists {
+		s.syncingNodes[node] = true
+	}
+}
+
+func (s *BlockNodeMetricSource[T]) markNodeAsSynced(node monitoring.Node) {
+	s.syncingMutex.Lock()
+	defer s.syncingMutex.Unlock()
+	s.syncingNodes[node] = false
+}
+
+func (s *BlockNodeMetricSource[T]) isNodeSyncing(node monitoring.Node) bool {
+	s.syncingMutex.Lock()
+	defer s.syncingMutex.Unlock()
+	syncing, exists := s.syncingNodes[node]
+	if !exists {
+		return true
+	}
+	return syncing
+}
+
+func (s *BlockNodeMetricSource[T]) shouldSuppressAppendConflict(node monitoring.Node, err error) bool {
+	if !monitoring.IsOutOfOrderAppendError(err) {
+		return false
+	}
+	return s.isNodeSyncing(node)
 }

--- a/driver/monitoring/node/block_metrics_test.go
+++ b/driver/monitoring/node/block_metrics_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/monitoring"
@@ -104,6 +105,79 @@ func TestIntegrateRegistryWithShutdownNodeMetrics(t *testing.T) {
 	// series not created at all
 	if _, exists := source.GetData(monitoring.Node3TestId); exists {
 		t.Errorf("series shold not exist")
+	}
+}
+
+func TestBlockNodeMetricSource_SuppressesConflictWhileNodeIsSyncing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
+	net.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{})
+
+	monitor, err := monitoring.NewMonitor(net, monitoring.MonitorConfig{OutputDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("failed to initiate monitor: %v", err)
+	}
+	source := NewBlockTimeSource(monitor)
+
+	node := monitoring.Node("A")
+	series := source.GetOrAddSubject(node)
+	seedTime := time.Unix(100, 0)
+	if err := series.Append(monitoring.BlockNumber(10), seedTime); err != nil {
+		t.Fatalf("failed to seed series: %v", err)
+	}
+
+	source.OnBlock(node, monitoring.Block{Height: 10, Time: seedTime})
+
+	if !source.isNodeSyncing(node) {
+		t.Fatalf("node syncing state should remain enabled after suppressed conflict")
+	}
+
+	if got, want := len(series.GetRange(monitoring.BlockNumber(0), monitoring.BlockNumber(100))), 1; got != want {
+		t.Fatalf("unexpected number of points: %d != %d", got, want)
+	}
+}
+
+func TestBlockNodeMetricSource_DisablesSyncingAfterFirstSuccessfulAppend(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
+	net.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{})
+
+	monitor, err := monitoring.NewMonitor(net, monitoring.MonitorConfig{OutputDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("failed to initiate monitor: %v", err)
+	}
+	source := NewBlockTimeSource(monitor)
+
+	node := monitoring.Node("A")
+	source.OnBlock(node, monitoring.Block{Height: 10, Time: time.Unix(100, 0)})
+
+	if source.isNodeSyncing(node) {
+		t.Fatalf("node syncing state should be disabled after first successful append")
+	}
+}
+
+func TestBlockNodeMetricSource_DoesNotSuppressAfterSyncingDisabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
+	net.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{})
+
+	monitor, err := monitoring.NewMonitor(net, monitoring.MonitorConfig{OutputDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("failed to initiate monitor: %v", err)
+	}
+	source := NewBlockTimeSource(monitor)
+
+	node := monitoring.Node("A")
+	source.OnBlock(node, monitoring.Block{Height: 10, Time: time.Unix(100, 0)})
+
+	if source.shouldSuppressAppendConflict(node, monitoring.ErrOutOfOrderAppend) {
+		t.Fatalf("out-of-order conflict should not be suppressed after syncing is disabled")
 	}
 }
 

--- a/driver/monitoring/node/syncing_tracker.go
+++ b/driver/monitoring/node/syncing_tracker.go
@@ -1,0 +1,67 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package nodemon
+
+import (
+	"sync"
+
+	"github.com/0xsoniclabs/norma/driver/monitoring"
+)
+
+// syncingTracker tracks which nodes are currently catching up with the network
+// so that out-of-order block errors emitted during re-sync can be suppressed.
+type syncingTracker struct {
+	syncingNodes map[monitoring.Node]bool
+	syncingMutex sync.Mutex
+}
+
+func newSyncingTracker() syncingTracker {
+	return syncingTracker{
+		syncingNodes: make(map[monitoring.Node]bool, 50),
+	}
+}
+
+func (s *syncingTracker) markNodeAsSyncing(node monitoring.Node) {
+	s.syncingMutex.Lock()
+	defer s.syncingMutex.Unlock()
+	if _, exists := s.syncingNodes[node]; !exists {
+		s.syncingNodes[node] = true
+	}
+}
+
+func (s *syncingTracker) markNodeAsSynced(node monitoring.Node) {
+	s.syncingMutex.Lock()
+	defer s.syncingMutex.Unlock()
+	s.syncingNodes[node] = false
+}
+
+func (s *syncingTracker) isNodeSyncing(node monitoring.Node) bool {
+	s.syncingMutex.Lock()
+	defer s.syncingMutex.Unlock()
+	syncing, exists := s.syncingNodes[node]
+	if !exists {
+		return true
+	}
+	return syncing
+}
+
+func (s *syncingTracker) shouldSuppressAppendConflict(node monitoring.Node, err error) bool {
+	if !monitoring.IsOutOfOrderAppendError(err) {
+		return false
+	}
+	return s.isNodeSyncing(node)
+}

--- a/driver/monitoring/node/transactions_throughput.go
+++ b/driver/monitoring/node/transactions_throughput.go
@@ -19,7 +19,6 @@ package nodemon
 import (
 	"fmt"
 	"log/slog"
-	"sync"
 	"time"
 
 	"github.com/0xsoniclabs/norma/driver/monitoring"
@@ -43,9 +42,7 @@ func init() {
 // TransactionsThroughputSource is a metric source that captures transaction throughput.
 type TransactionsThroughputSource struct {
 	BlockNodeMetricSource[float32]
-	lastTimes    map[monitoring.Node]time.Time // timestamps of the latest received blocks
-	syncingNodes map[monitoring.Node]bool
-	syncingMutex sync.Mutex
+	lastTimes map[monitoring.Node]time.Time // timestamps of the latest received blocks
 }
 
 // NewTransactionsThroughputSource creates a metric capturing transaction throughput.
@@ -54,9 +51,9 @@ func NewTransactionsThroughputSource(monitor *monitoring.Monitor) *TransactionsT
 		BlockNodeMetricSource: BlockNodeMetricSource[float32]{
 			SyncedSeriesSource: utils.NewSyncedSeriesSource(TransactionsThroughput),
 			monitor:            monitor,
+			syncingTracker:     newSyncingTracker(),
 		},
-		lastTimes:    make(map[monitoring.Node]time.Time, 50),
-		syncingNodes: make(map[monitoring.Node]bool, 50),
+		lastTimes: make(map[monitoring.Node]time.Time, 50),
 	}
 	monitor.NodeLogProvider().RegisterLogListener(m)
 
@@ -93,35 +90,4 @@ func (s *TransactionsThroughputSource) OnBlock(node monitoring.Node, block monit
 		}
 		s.markNodeAsSynced(node)
 	}
-}
-
-func (s *TransactionsThroughputSource) markNodeAsSyncing(node monitoring.Node) {
-	s.syncingMutex.Lock()
-	defer s.syncingMutex.Unlock()
-	if _, exists := s.syncingNodes[node]; !exists {
-		s.syncingNodes[node] = true
-	}
-}
-
-func (s *TransactionsThroughputSource) markNodeAsSynced(node monitoring.Node) {
-	s.syncingMutex.Lock()
-	defer s.syncingMutex.Unlock()
-	s.syncingNodes[node] = false
-}
-
-func (s *TransactionsThroughputSource) isNodeSyncing(node monitoring.Node) bool {
-	s.syncingMutex.Lock()
-	defer s.syncingMutex.Unlock()
-	syncing, exists := s.syncingNodes[node]
-	if !exists {
-		return true
-	}
-	return syncing
-}
-
-func (s *TransactionsThroughputSource) shouldSuppressAppendConflict(node monitoring.Node, err error) bool {
-	if !monitoring.IsOutOfOrderAppendError(err) {
-		return false
-	}
-	return s.isNodeSyncing(node)
 }

--- a/driver/monitoring/node/transactions_throughput.go
+++ b/driver/monitoring/node/transactions_throughput.go
@@ -19,6 +19,7 @@ package nodemon
 import (
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/0xsoniclabs/norma/driver/monitoring"
@@ -42,19 +43,20 @@ func init() {
 // TransactionsThroughputSource is a metric source that captures transaction throughput.
 type TransactionsThroughputSource struct {
 	BlockNodeMetricSource[float32]
-	lastTimes map[monitoring.Node]time.Time // timestamps of the latest received blocks
+	lastTimes    map[monitoring.Node]time.Time // timestamps of the latest received blocks
+	syncingNodes map[monitoring.Node]bool
+	syncingMutex sync.Mutex
 }
 
 // NewTransactionsThroughputSource creates a metric capturing transaction throughput.
 func NewTransactionsThroughputSource(monitor *monitoring.Monitor) *TransactionsThroughputSource {
-	blockMetrics := BlockNodeMetricSource[float32]{
-		SyncedSeriesSource: utils.NewSyncedSeriesSource(TransactionsThroughput),
-		monitor:            monitor,
-	}
-
 	m := &TransactionsThroughputSource{
-		BlockNodeMetricSource: blockMetrics,
-		lastTimes:             make(map[monitoring.Node]time.Time, 50),
+		BlockNodeMetricSource: BlockNodeMetricSource[float32]{
+			SyncedSeriesSource: utils.NewSyncedSeriesSource(TransactionsThroughput),
+			monitor:            monitor,
+		},
+		lastTimes:    make(map[monitoring.Node]time.Time, 50),
+		syncingNodes: make(map[monitoring.Node]bool, 50),
 	}
 	monitor.NodeLogProvider().RegisterLogListener(m)
 
@@ -67,6 +69,7 @@ func newTransactionsThroughputSource(monitor *monitoring.Monitor) monitoring.Sou
 }
 
 func (s *TransactionsThroughputSource) OnBlock(node monitoring.Node, block monitoring.Block) {
+	s.markNodeAsSyncing(node)
 
 	prevTime, exists := s.lastTimes[node]
 	s.lastTimes[node] = block.Time
@@ -82,7 +85,43 @@ func (s *TransactionsThroughputSource) OnBlock(node monitoring.Node, block monit
 		txs := float64(block.Txs) * 1e9 / float64(timeDiff)
 		series := s.GetOrAddSubject(node)
 		if err := series.Append(monitoring.BlockNumber(block.Height), float32(txs)); err != nil {
+			if s.shouldSuppressAppendConflict(node, err) {
+				return
+			}
 			slog.Error("error to add to the series", "error", err)
+			return
 		}
+		s.markNodeAsSynced(node)
 	}
+}
+
+func (s *TransactionsThroughputSource) markNodeAsSyncing(node monitoring.Node) {
+	s.syncingMutex.Lock()
+	defer s.syncingMutex.Unlock()
+	if _, exists := s.syncingNodes[node]; !exists {
+		s.syncingNodes[node] = true
+	}
+}
+
+func (s *TransactionsThroughputSource) markNodeAsSynced(node monitoring.Node) {
+	s.syncingMutex.Lock()
+	defer s.syncingMutex.Unlock()
+	s.syncingNodes[node] = false
+}
+
+func (s *TransactionsThroughputSource) isNodeSyncing(node monitoring.Node) bool {
+	s.syncingMutex.Lock()
+	defer s.syncingMutex.Unlock()
+	syncing, exists := s.syncingNodes[node]
+	if !exists {
+		return true
+	}
+	return syncing
+}
+
+func (s *TransactionsThroughputSource) shouldSuppressAppendConflict(node monitoring.Node, err error) bool {
+	if !monitoring.IsOutOfOrderAppendError(err) {
+		return false
+	}
+	return s.isNodeSyncing(node)
 }

--- a/driver/monitoring/node/transactions_throughput_test.go
+++ b/driver/monitoring/node/transactions_throughput_test.go
@@ -199,3 +199,81 @@ func TestTransactionsZeroTransactionsBellowMeasurableDiff(t *testing.T) {
 		t.Errorf("there should be no value")
 	}
 }
+
+func TestTransactionsThroughputSource_SuppressesConflictWhileNodeIsSyncing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
+	net.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{})
+
+	monitor, err := monitoring.NewMonitor(net, monitoring.MonitorConfig{OutputDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("failed to initiate monitor: %v", err)
+	}
+	source := NewTransactionsThroughputSource(monitor)
+
+	node := monitoring.Node("A")
+	series := source.GetOrAddSubject(node)
+	if err := series.Append(monitoring.BlockNumber(11), 1); err != nil {
+		t.Fatalf("failed to seed series: %v", err)
+	}
+
+	baseTime := time.Unix(100, 0)
+	source.lastTimes[node] = baseTime
+	source.OnBlock(node, monitoring.Block{Height: 11, Time: baseTime.Add(time.Second), Txs: 1})
+
+	if !source.isNodeSyncing(node) {
+		t.Fatalf("node syncing state should remain enabled after suppressed conflict")
+	}
+
+	if got, want := len(series.GetRange(monitoring.BlockNumber(0), monitoring.BlockNumber(100))), 1; got != want {
+		t.Fatalf("unexpected number of points: %d != %d", got, want)
+	}
+}
+
+func TestTransactionsThroughputSource_DisablesSyncingAfterFirstSuccessfulAppend(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
+	net.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{})
+
+	monitor, err := monitoring.NewMonitor(net, monitoring.MonitorConfig{OutputDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("failed to initiate monitor: %v", err)
+	}
+	source := NewTransactionsThroughputSource(monitor)
+
+	node := monitoring.Node("A")
+	baseTime := time.Unix(100, 0)
+	source.OnBlock(node, monitoring.Block{Height: 10, Time: baseTime, Txs: 1})
+	source.OnBlock(node, monitoring.Block{Height: 11, Time: baseTime.Add(time.Second), Txs: 1})
+
+	if source.isNodeSyncing(node) {
+		t.Fatalf("node syncing state should be disabled after first successful append")
+	}
+}
+
+func TestTransactionsThroughputSource_DoesNotSuppressAfterSyncingDisabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
+	net.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{})
+
+	monitor, err := monitoring.NewMonitor(net, monitoring.MonitorConfig{OutputDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("failed to initiate monitor: %v", err)
+	}
+	source := NewTransactionsThroughputSource(monitor)
+
+	node := monitoring.Node("A")
+	baseTime := time.Unix(100, 0)
+	source.OnBlock(node, monitoring.Block{Height: 10, Time: baseTime, Txs: 1})
+	source.OnBlock(node, monitoring.Block{Height: 11, Time: baseTime.Add(time.Second), Txs: 1})
+
+	if source.shouldSuppressAppendConflict(node, monitoring.ErrOutOfOrderAppend) {
+		t.Fatalf("out-of-order conflict should not be suppressed after syncing is disabled")
+	}
+}

--- a/driver/monitoring/synced_series.go
+++ b/driver/monitoring/synced_series.go
@@ -17,12 +17,18 @@
 package monitoring
 
 import (
-	"fmt"
+	"errors"
 	"sort"
 	"sync"
 
 	"golang.org/x/exp/constraints"
 )
+
+var ErrOutOfOrderAppend = errors.New("cannot append data out-of-order")
+
+func IsOutOfOrderAppendError(err error) bool {
+	return errors.Is(err, ErrOutOfOrderAppend)
+}
 
 // SyncedSeries implements a generic series retaining all data in memory and
 // offering synchronized access to its content.
@@ -69,7 +75,7 @@ func (s *SyncedSeries[K, T]) Append(point K, value T) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	if len(s.data) > 0 && s.data[len(s.data)-1].Position >= point {
-		return fmt.Errorf("cannot append data out-of-order")
+		return ErrOutOfOrderAppend
 	}
 	s.data = append(s.data, DataPoint[K, T]{point, value})
 	return nil


### PR DESCRIPTION
An error would print when a node is stopped and started again with the same name, blocks will be produced during synccing, because the metrics would already had accounted them before.
this PR introduces a synccing flag so that this error does not produce an error. 