### PR TITLE
Re-add single proposer blackout scenario

### DIFF
--- a/driver/checking/blocks_rolling.go
+++ b/driver/checking/blocks_rolling.go
@@ -3,6 +3,7 @@ package checking
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/monitoring"
@@ -20,7 +21,10 @@ func init() {
 type blocksRollingChecker struct {
 	monitor          MonitoringData
 	toleranceSamples int
-	start            monitoring.Time
+	// duration, when > 0, switches the checker into live-observation mode:
+	// Check blocks for that long and then verifies that at least one node
+	// advanced its block height during the observation window.
+	duration time.Duration
 }
 
 // Configure returns a deep copy of the original checker.
@@ -37,15 +41,15 @@ func (c *blocksRollingChecker) Configure(config CheckerConfig) Checker {
 		tolerance = t.(int)
 	}
 
-	start := c.start
-	if s, exist := config["start"]; exist {
-		start = monitoring.Time(s.(int64))
+	duration := c.duration
+	if d, exist := config["duration"]; exist {
+		duration = time.Duration(d.(int64))
 	}
 
 	return &blocksRollingChecker{
 		monitor:          c.monitor,
 		toleranceSamples: tolerance,
-		start:            start,
+		duration:         duration,
 	}
 }
 
@@ -53,27 +57,37 @@ func (c *blocksRollingChecker) Check(ctx context.Context) error {
 	if c.toleranceSamples <= 0 {
 		return fmt.Errorf("tolerance must be > 0, got %d", c.toleranceSamples)
 	}
-	nodes := c.monitor.GetNodes()
+
+	// Two evaluation modes are supported:
+	//   * duration == 0 (default): a sliding window of size 'toleranceSamples'
+	//     is walked across the entire recorded series; the node is considered
+	//     functional if every window shows a strict block-height increase from
+	//     its oldest to its newest sample.
+	//   * duration > 0 (live-observation mode): mark the current time,
+	//     sleep for the configured duration, then require that at least one
+	//     node produced new blocks during the observation window. This models
+	//     the intuitive question "is the network making progress right now?"
+	//     without depending on samples recorded prior to this check.
+	var observationStart monitoring.Time
+	if c.duration > 0 {
+		observationStart = monitoring.Time(time.Now().UnixNano())
+		timer := time.NewTimer(c.duration)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+
 	// This function iterates through all nodes in the network and verifies whether their block height increases.
 	// A node with a stagnant block height indicates it is not actively participating in block production.
 	// If no nodes are found to be producing blocks, the network is deemed non-functional.
 	//
 	// The test ensures that at least one node is generating blocks, confirming that the network is operational
 	// to some extent. It does not verify the functionality of every node, as that is handled by other checks.
-	//
-	// Two evaluation modes are supported:
-	//   * start == 0 (default): a sliding window of size 'toleranceSamples' is
-	//     walked across the entire series; the node is functional if every
-	//     window shows a strict block-height increase from its oldest to its
-	//     newest sample.
-	//   * start > 0: the user has already narrowed the window of interest to
-	//     samples with Position >= start. The node is considered functional if
-	//     the block height at the first in-range sample is strictly less than
-	//     the block height of the latest sample. This models the intuitive
-	//     question "did the network make progress during the last N seconds?"
-	//     and is robust against transient stalls inside that window.
 	var networkFunctional bool
-	for _, node := range nodes {
+	for _, node := range c.monitor.GetNodes() {
 		nodeFunctional := true
 		series := c.monitor.GetBlockStatus(node)
 
@@ -83,31 +97,22 @@ func (c *blocksRollingChecker) Check(ctx context.Context) error {
 			continue
 		}
 
-		var first monitoring.Time = 0
-		found := false
-		dataPoints := series.GetRange(0, last.Position+1)
-		for _, dp := range dataPoints {
-			// >= to account for various tick configuration
-			// example: if ticked at 0, 5, 10, ... and c.start = 8,
-			// the first tick that is bigger, 10, is selected instead.
-			if dp.Position >= c.start {
-				first = dp.Position
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("start %d not found", c.start)
-		}
-
-		items := append(series.GetRange(first, last.Position), *last)
-		if c.start > 0 {
-			// Windowed mode: compare the first in-range sample to the latest.
-			if items[0].Value.BlockHeight >= last.Value.BlockHeight {
-				nodeFunctional = false
+		if c.duration > 0 {
+			// Live-observation mode: find the first sample recorded after the
+			// observation window started and compare its block height to the
+			// latest sample. Missing new samples counts as no progress.
+			nodeFunctional = false
+			for _, dp := range series.GetRange(0, last.Position+1) {
+				if dp.Position >= observationStart {
+					if dp.Value.BlockHeight < last.Value.BlockHeight {
+						nodeFunctional = true
+					}
+					break
+				}
 			}
 		} else {
 			// Sliding-window mode over the entire history.
+			items := series.GetRange(0, last.Position+1)
 			window := make([]monitoring.BlockStatus, c.toleranceSamples)
 			for i, point := range items {
 				window[i%c.toleranceSamples] = point.Value
@@ -125,10 +130,8 @@ func (c *blocksRollingChecker) Check(ctx context.Context) error {
 		networkFunctional = networkFunctional || nodeFunctional
 	}
 
-	var err error
 	if !networkFunctional {
-		err = fmt.Errorf("network is down, nodes stopped producing blocks")
+		return fmt.Errorf("network is down, nodes stopped producing blocks")
 	}
-
-	return err
+	return nil
 }

--- a/driver/checking/blocks_rolling.go
+++ b/driver/checking/blocks_rolling.go
@@ -39,7 +39,7 @@ func (c *blocksRollingChecker) Configure(config CheckerConfig) Checker {
 
 	start := c.start
 	if s, exist := config["start"]; exist {
-		start = monitoring.Time(s.(int))
+		start = monitoring.Time(s.(int64))
 	}
 
 	return &blocksRollingChecker{
@@ -50,6 +50,9 @@ func (c *blocksRollingChecker) Configure(config CheckerConfig) Checker {
 }
 
 func (c *blocksRollingChecker) Check(ctx context.Context) error {
+	if c.toleranceSamples <= 0 {
+		return fmt.Errorf("tolerance must be > 0, got %d", c.toleranceSamples)
+	}
 	nodes := c.monitor.GetNodes()
 	// This function iterates through all nodes in the network and verifies whether their block height increases.
 	// A node with a stagnant block height indicates it is not actively participating in block production.
@@ -58,9 +61,17 @@ func (c *blocksRollingChecker) Check(ctx context.Context) error {
 	// The test ensures that at least one node is generating blocks, confirming that the network is operational
 	// to some extent. It does not verify the functionality of every node, as that is handled by other checks.
 	//
-	// To account for flexibility in block processing, the verification is performed within a sliding window
-	// defined by 'toleranceSamples'. Only the block height at the beginning and end of this window are assessed,
-	// allowing for scenarios where blocks may not be produced every second.
+	// Two evaluation modes are supported:
+	//   * start == 0 (default): a sliding window of size 'toleranceSamples' is
+	//     walked across the entire series; the node is functional if every
+	//     window shows a strict block-height increase from its oldest to its
+	//     newest sample.
+	//   * start > 0: the user has already narrowed the window of interest to
+	//     samples with Position >= start. The node is considered functional if
+	//     the block height at the first in-range sample is strictly less than
+	//     the block height of the latest sample. This models the intuitive
+	//     question "did the network make progress during the last N seconds?"
+	//     and is robust against transient stalls inside that window.
 	var networkFunctional bool
 	for _, node := range nodes {
 		nodeFunctional := true
@@ -79,7 +90,7 @@ func (c *blocksRollingChecker) Check(ctx context.Context) error {
 			// >= to account for various tick configuration
 			// example: if ticked at 0, 5, 10, ... and c.start = 8,
 			// the first tick that is bigger, 10, is selected instead.
-			if dp.Position >= monitoring.Time(c.start) {
+			if dp.Position >= c.start {
 				first = dp.Position
 				found = true
 				break
@@ -89,19 +100,28 @@ func (c *blocksRollingChecker) Check(ctx context.Context) error {
 			return fmt.Errorf("start %d not found", c.start)
 		}
 
-		items := series.GetRange(first, last.Position) // skip last item
-		window := make([]monitoring.BlockStatus, c.toleranceSamples)
-		for i, point := range append(items, *last) {
-			window[i%c.toleranceSamples] = point.Value
-			if i < c.toleranceSamples-1 {
-				continue
-			}
-			prev := (i - c.toleranceSamples + 1) % c.toleranceSamples
-			if window[prev].BlockHeight >= point.Value.BlockHeight {
+		items := append(series.GetRange(first, last.Position), *last)
+		if c.start > 0 {
+			// Windowed mode: compare the first in-range sample to the latest.
+			if items[0].Value.BlockHeight >= last.Value.BlockHeight {
 				nodeFunctional = false
-				break
+			}
+		} else {
+			// Sliding-window mode over the entire history.
+			window := make([]monitoring.BlockStatus, c.toleranceSamples)
+			for i, point := range items {
+				window[i%c.toleranceSamples] = point.Value
+				if i < c.toleranceSamples-1 {
+					continue
+				}
+				prev := (i - c.toleranceSamples + 1) % c.toleranceSamples
+				if window[prev].BlockHeight >= point.Value.BlockHeight {
+					nodeFunctional = false
+					break
+				}
 			}
 		}
+
 		networkFunctional = networkFunctional || nodeFunctional
 	}
 

--- a/driver/checking/blocks_rolling_test.go
+++ b/driver/checking/blocks_rolling_test.go
@@ -101,7 +101,7 @@ func TestBlocksRolling_Blocks_WithStarts(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	configured := checker.Configure(CheckerConfig{"start": 5})
+	configured := checker.Configure(CheckerConfig{"start": int64(5)})
 	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
 	monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
 	if err := configured.Check(t.Context()); err != nil {
@@ -138,6 +138,72 @@ func TestBlocksRolling_Configure(t *testing.T) {
 	emptySuccess := success.Configure(CheckerConfig{})
 	if err := emptySuccess.Check(t.Context()); err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestBlocksRolling_Start_UsesFirstVsLastComparison verifies that when a
+// non-zero start is set, the checker only compares the first in-range sample
+// to the latest sample instead of applying a sliding sub-window. This makes
+// the check robust against transient stalls inside the window.
+func TestBlocksRolling_Start_UsesFirstVsLastComparison(t *testing.T) {
+	// Long-lived stall in the middle, but overall progress at the ends.
+	// Sliding window (tolerance=5) would fail on the 6-sample flat span,
+	// but the windowed-mode (start > 0) check should pass because the
+	// first in-range sample (2) has a lower block height than the last (6).
+	blocks := []uint64{1, 2, 2, 2, 2, 2, 2, 3, 4, 5, 6}
+	series := createBlockSeries(t, blocks)
+
+	ctrl := gomock.NewController(t)
+	monitor := NewMockMonitoringData(ctrl)
+
+	// Sliding-window mode (start = 0) fails as expected.
+	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
+	monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
+	strict := blocksRollingChecker{monitor: monitor, toleranceSamples: 5}
+	if err := strict.Check(t.Context()); err == nil {
+		t.Fatalf("expected sliding-window failure")
+	}
+
+	// Windowed mode (start = 1) passes because 2 < 6 at the endpoints.
+	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
+	monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
+	windowed := strict.Configure(CheckerConfig{"start": int64(1)})
+	if err := windowed.Check(t.Context()); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestBlocksRolling_Start_FailsWhenWindowStalls verifies that the windowed
+// mode still fails if the block height did not advance across the window.
+func TestBlocksRolling_Start_FailsWhenWindowStalls(t *testing.T) {
+	// Progress in the first half, then a total stall for the last 5 samples.
+	blocks := []uint64{1, 2, 3, 4, 5, 5, 5, 5, 5, 5}
+	series := createBlockSeries(t, blocks)
+
+	ctrl := gomock.NewController(t)
+	monitor := NewMockMonitoringData(ctrl)
+	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
+	monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
+
+	checker := (&blocksRollingChecker{monitor: monitor, toleranceSamples: 5}).
+		Configure(CheckerConfig{"start": int64(5)})
+	if err := checker.Check(t.Context()); err == nil || err.Error() != "network is down, nodes stopped producing blocks" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestBlocksRolling_ZeroTolerance_ReturnsErrorInsteadOfPanic verifies that
+// configuring tolerance=0 does not cause a divide-by-zero panic in the
+// sliding-window path; the checker must fail cleanly with a descriptive
+// error instead.
+func TestBlocksRolling_ZeroTolerance_ReturnsErrorInsteadOfPanic(t *testing.T) {
+	checker := &blocksRollingChecker{toleranceSamples: 0}
+	err := checker.Check(t.Context())
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if got := err.Error(); got != "tolerance must be > 0, got 0" {
+		t.Fatalf("unexpected error: %s", got)
 	}
 }
 

--- a/driver/checking/blocks_rolling_test.go
+++ b/driver/checking/blocks_rolling_test.go
@@ -2,6 +2,7 @@ package checking
 
 import (
 	"testing"
+	"time"
 
 	"github.com/0xsoniclabs/norma/driver/monitoring"
 	"go.uber.org/mock/gomock"
@@ -87,24 +88,68 @@ func TestBlocksRolling_Blocks_Failure(t *testing.T) {
 	}
 }
 
-func TestBlocksRolling_Blocks_WithStarts(t *testing.T) {
-	series := createBlockSeries(t, []uint64{1, 1, 1, 1, 1, 2, 3, 4, 5, 6})
+func TestBlocksRolling_Duration_PassesWhenBlocksAdvanceDuringObservation(t *testing.T) {
+	// All samples are placed in the future so they are guaranteed to fall
+	// inside the observation window regardless of when Check starts.
+	base := monitoring.Time(time.Now().UnixNano() + int64(time.Hour))
+	blocks := []uint64{1, 2, 2, 2, 2, 2, 2, 3, 4, 5, 6}
+	series := createBlockSeriesAt(t, base, blocks)
 
 	ctrl := gomock.NewController(t)
 	monitor := NewMockMonitoringData(ctrl)
 
-	// this fails because of 1, 1, 1, 1, 1
-	checker := blocksRollingChecker{monitor: monitor, toleranceSamples: 5}
+	// Sliding-window mode (duration == 0) fails on the long flat span.
 	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
 	monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
+	strict := blocksRollingChecker{monitor: monitor, toleranceSamples: 5}
+	if err := strict.Check(t.Context()); err == nil {
+		t.Fatalf("expected sliding-window failure")
+	}
+
+	// Live-observation mode: after the (short) wait, the first in-range
+	// sample has block height 1 and the latest 6, so the network is
+	// considered healthy despite the internal stall.
+	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
+	monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
+	windowed := strict.Configure(CheckerConfig{"duration": int64(time.Millisecond)})
+	if err := windowed.Check(t.Context()); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestBlocksRolling_Duration_FailsWhenBlocksStallDuringObservation(t *testing.T) {
+	// All samples are constant during the observation window: first-in-range
+	// block height equals the latest, so the check must fail.
+	base := monitoring.Time(time.Now().UnixNano() + int64(time.Hour))
+	blocks := []uint64{5, 5, 5, 5, 5}
+	series := createBlockSeriesAt(t, base, blocks)
+
+	ctrl := gomock.NewController(t)
+	monitor := NewMockMonitoringData(ctrl)
+	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
+	monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
+
+	checker := (&blocksRollingChecker{monitor: monitor, toleranceSamples: 5}).
+		Configure(CheckerConfig{"duration": int64(time.Millisecond)})
 	if err := checker.Check(t.Context()); err == nil || err.Error() != "network is down, nodes stopped producing blocks" {
 		t.Errorf("unexpected error: %v", err)
 	}
+}
 
-	configured := checker.Configure(CheckerConfig{"start": int64(5)})
+func TestBlocksRolling_Duration_FailsWhenNoSamplesAppearDuringObservation(t *testing.T) {
+	// All samples sit strictly in the past relative to the observation
+	// window; no in-range sample exists, so progress cannot be confirmed.
+	blocks := []uint64{1, 2, 3, 4, 5}
+	series := createBlockSeries(t, blocks)
+
+	ctrl := gomock.NewController(t)
+	monitor := NewMockMonitoringData(ctrl)
 	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
 	monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
-	if err := configured.Check(t.Context()); err != nil {
+
+	checker := (&blocksRollingChecker{monitor: monitor, toleranceSamples: 5}).
+		Configure(CheckerConfig{"duration": int64(time.Millisecond)})
+	if err := checker.Check(t.Context()); err == nil || err.Error() != "network is down, nodes stopped producing blocks" {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -141,57 +186,6 @@ func TestBlocksRolling_Configure(t *testing.T) {
 	}
 }
 
-// TestBlocksRolling_Start_UsesFirstVsLastComparison verifies that when a
-// non-zero start is set, the checker only compares the first in-range sample
-// to the latest sample instead of applying a sliding sub-window. This makes
-// the check robust against transient stalls inside the window.
-func TestBlocksRolling_Start_UsesFirstVsLastComparison(t *testing.T) {
-	// Long-lived stall in the middle, but overall progress at the ends.
-	// Sliding window (tolerance=5) would fail on the 6-sample flat span,
-	// but the windowed-mode (start > 0) check should pass because the
-	// first in-range sample (2) has a lower block height than the last (6).
-	blocks := []uint64{1, 2, 2, 2, 2, 2, 2, 3, 4, 5, 6}
-	series := createBlockSeries(t, blocks)
-
-	ctrl := gomock.NewController(t)
-	monitor := NewMockMonitoringData(ctrl)
-
-	// Sliding-window mode (start = 0) fails as expected.
-	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
-	monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
-	strict := blocksRollingChecker{monitor: monitor, toleranceSamples: 5}
-	if err := strict.Check(t.Context()); err == nil {
-		t.Fatalf("expected sliding-window failure")
-	}
-
-	// Windowed mode (start = 1) passes because 2 < 6 at the endpoints.
-	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
-	monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
-	windowed := strict.Configure(CheckerConfig{"start": int64(1)})
-	if err := windowed.Check(t.Context()); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
-// TestBlocksRolling_Start_FailsWhenWindowStalls verifies that the windowed
-// mode still fails if the block height did not advance across the window.
-func TestBlocksRolling_Start_FailsWhenWindowStalls(t *testing.T) {
-	// Progress in the first half, then a total stall for the last 5 samples.
-	blocks := []uint64{1, 2, 3, 4, 5, 5, 5, 5, 5, 5}
-	series := createBlockSeries(t, blocks)
-
-	ctrl := gomock.NewController(t)
-	monitor := NewMockMonitoringData(ctrl)
-	monitor.EXPECT().GetNodes().Return([]monitoring.Node{"A"})
-	monitor.EXPECT().GetBlockStatus(gomock.Any()).Return(series)
-
-	checker := (&blocksRollingChecker{monitor: monitor, toleranceSamples: 5}).
-		Configure(CheckerConfig{"start": int64(5)})
-	if err := checker.Check(t.Context()); err == nil || err.Error() != "network is down, nodes stopped producing blocks" {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
 // TestBlocksRolling_ZeroTolerance_ReturnsErrorInsteadOfPanic verifies that
 // configuring tolerance=0 does not cause a divide-by-zero panic in the
 // sliding-window path; the checker must fail cleanly with a descriptive
@@ -209,10 +203,16 @@ func TestBlocksRolling_ZeroTolerance_ReturnsErrorInsteadOfPanic(t *testing.T) {
 
 func createBlockSeries(t *testing.T, blocks []uint64) monitoring.Series[monitoring.Time, monitoring.BlockStatus] {
 	t.Helper()
+	return createBlockSeriesAt(t, 0, blocks)
+}
+
+func createBlockSeriesAt(t *testing.T, base monitoring.Time, blocks []uint64) monitoring.Series[monitoring.Time, monitoring.BlockStatus] {
+	t.Helper()
 
 	series := monitoring.SyncedSeries[monitoring.Time, monitoring.BlockStatus]{}
 	for i, block := range blocks {
-		if err := series.Append(monitoring.Time(i), monitoring.BlockStatus{BlockHeight: block}); err != nil {
+		pos := base + monitoring.Time(i)
+		if err := series.Append(pos, monitoring.BlockStatus{BlockHeight: block}); err != nil {
 			t.Fatalf("failed to append block %d: %v", block, err)
 		}
 	}

--- a/driver/checking/checker.go
+++ b/driver/checking/checker.go
@@ -121,7 +121,7 @@ func (config *CheckerConfig) Check() error {
 	checks := map[string]func(any) bool{
 		"failing":   isBool,
 		"tolerance": isPositiveInt,
-		"start":     isNonNegativeInt64,
+		"duration":  isNonNegativeInt64,
 		"ceiling":   isPositiveInt,
 		"slack":     isPositiveInt,
 		"rules":     isRulesPatch,

--- a/driver/checking/checker.go
+++ b/driver/checking/checker.go
@@ -109,6 +109,7 @@ func (config *CheckerConfig) Check() error {
 
 	isBool := func(v any) bool { _, ok := v.(bool); return ok }
 	isPositiveInt := func(v any) bool { i, ok := v.(int); return ok && i >= 0 }
+	isNonNegativeInt64 := func(v any) bool { i, ok := v.(int64); return ok && i >= 0 }
 	isRulesPatch := func(v any) bool {
 		if _, ok := v.(map[string]any); ok {
 			return true
@@ -120,7 +121,7 @@ func (config *CheckerConfig) Check() error {
 	checks := map[string]func(any) bool{
 		"failing":   isBool,
 		"tolerance": isPositiveInt,
-		"start":     isPositiveInt,
+		"start":     isNonNegativeInt64,
 		"ceiling":   isPositiveInt,
 		"slack":     isPositiveInt,
 		"rules":     isRulesPatch,

--- a/driver/checking/checker_test.go
+++ b/driver/checking/checker_test.go
@@ -11,7 +11,7 @@ func TestCheckerConfig_Success(t *testing.T) {
 	configs := []CheckerConfig{
 		{"failing": true},
 		{"tolerance": 1},
-		{"start": int64(1)},
+		{"duration": int64(1)},
 		{"ceiling": 1},
 		{"slack": 1},
 		{"rules": map[string]any{"Blocks": map[string]any{"MaxBlockGas": 1}}},
@@ -32,9 +32,9 @@ func TestCheckerConfig_Failure(t *testing.T) {
 	configs := []CheckerConfig{
 		{"failing": "false"},
 		{"tolerance": 1.0},
-		{"start": -1},
-		{"start": 1},
-		{"start": int64(-1)},
+		{"duration": -1},
+		{"duration": 1},
+		{"duration": int64(-1)},
 		{"ceiling": nil},
 		{"rules": []any{"invalid"}},
 	}

--- a/driver/checking/checker_test.go
+++ b/driver/checking/checker_test.go
@@ -11,7 +11,7 @@ func TestCheckerConfig_Success(t *testing.T) {
 	configs := []CheckerConfig{
 		{"failing": true},
 		{"tolerance": 1},
-		{"start": 1},
+		{"start": int64(1)},
 		{"ceiling": 1},
 		{"slack": 1},
 		{"rules": map[string]any{"Blocks": map[string]any{"MaxBlockGas": 1}}},
@@ -33,6 +33,8 @@ func TestCheckerConfig_Failure(t *testing.T) {
 		{"failing": "false"},
 		{"tolerance": 1.0},
 		{"start": -1},
+		{"start": 1},
+		{"start": int64(-1)},
 		{"ceiling": nil},
 		{"rules": []any{"invalid"}},
 	}

--- a/driver/executor/sequential.go
+++ b/driver/executor/sequential.go
@@ -657,6 +657,17 @@ func execCheck(ctx context.Context, checkerName string, spec *parser.CheckSpec, 
 			config["tolerance"] = *spec.Tolerance
 		}
 	}
+	if spec.Start != nil {
+		// Translate the scenario-level "look back this far" duration into an
+		// absolute UnixNano timestamp suitable for the checker's `start`
+		// configuration key. Clamp to 0 when the computed start would
+		// underflow (e.g. an unreasonably large lookback duration).
+		lookBackNs := time.Now().UnixNano() - int64(*spec.Start)
+		if lookBackNs < 0 {
+			lookBackNs = 0
+		}
+		config["start"] = lookBackNs
+	}
 	if spec.Ceiling != nil {
 		config["ceiling"] = int(*spec.Ceiling)
 	}

--- a/driver/executor/sequential.go
+++ b/driver/executor/sequential.go
@@ -657,16 +657,11 @@ func execCheck(ctx context.Context, checkerName string, spec *parser.CheckSpec, 
 			config["tolerance"] = *spec.Tolerance
 		}
 	}
-	if spec.Start != nil {
-		// Translate the scenario-level "look back this far" duration into an
-		// absolute UnixNano timestamp suitable for the checker's `start`
-		// configuration key. Clamp to 0 when the computed start would
-		// underflow (e.g. an unreasonably large lookback duration).
-		lookBackNs := time.Now().UnixNano() - int64(*spec.Start)
-		if lookBackNs < 0 {
-			lookBackNs = 0
-		}
-		config["start"] = lookBackNs
+	if spec.Duration != nil {
+		// Forward the observation duration (in nanoseconds) to the checker,
+		// which will actively wait for that long and then verify that block
+		// production progressed during the observation window.
+		config["duration"] = int64(*spec.Duration)
 	}
 	if spec.Ceiling != nil {
 		config["ceiling"] = int(*spec.Ceiling)

--- a/driver/executor/sequential_test.go
+++ b/driver/executor/sequential_test.go
@@ -479,6 +479,85 @@ func TestSequential_Check(t *testing.T) {
 	}
 }
 
+func TestExecCheck_ForwardsStartAsMonitoringTime_WhenBlocksProducedHasStart(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	inner := checking.NewMockChecker(ctrl)
+	configured := checking.NewMockChecker(ctrl)
+
+	lookBack := 30 * time.Second
+
+	// Capture the config passed to Configure and validate the "start" key.
+	before := time.Now()
+	inner.EXPECT().Configure(gomock.Any()).DoAndReturn(
+		func(cfg checking.CheckerConfig) checking.Checker {
+			after := time.Now()
+			v, ok := cfg["start"]
+			if !ok {
+				t.Fatalf("expected 'start' in config, got %v", cfg)
+			}
+			startNanos, ok := v.(int64)
+			if !ok {
+				t.Fatalf("expected 'start' to be int64, got %T", v)
+			}
+			minNanos := before.Add(-lookBack).UnixNano()
+			maxNanos := after.Add(-lookBack).UnixNano()
+			if startNanos < minNanos || startNanos > maxNanos {
+				t.Fatalf("start=%d not within [%d,%d]", startNanos, minNanos, maxNanos)
+			}
+			return configured
+		},
+	)
+	configured.EXPECT().Check(gomock.Any()).Return(nil)
+
+	checks := checking.Checks{"blocksRolling": inner}
+	spec := &parser.CheckSpec{
+		Function: parser.FuncCheckBlocksProduced,
+		Start:    &lookBack,
+	}
+
+	if err := execCheck(t.Context(), "blocksRolling", spec, checks); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestExecCheck_ClampsStartToZero_WhenLookbackExceedsEpoch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	inner := checking.NewMockChecker(ctrl)
+	configured := checking.NewMockChecker(ctrl)
+
+	// A duration comfortably larger than the current time since the Unix
+	// epoch. This would otherwise underflow to a negative value.
+	lookBack := 200 * 365 * 24 * time.Hour
+
+	inner.EXPECT().Configure(gomock.Any()).DoAndReturn(
+		func(cfg checking.CheckerConfig) checking.Checker {
+			v, ok := cfg["start"]
+			if !ok {
+				t.Fatalf("expected 'start' in config, got %v", cfg)
+			}
+			start, ok := v.(int64)
+			if !ok {
+				t.Fatalf("expected 'start' to be int64, got %T", v)
+			}
+			if start != 0 {
+				t.Fatalf("expected start clamped to 0, got %d", start)
+			}
+			return configured
+		},
+	)
+	configured.EXPECT().Check(gomock.Any()).Return(nil)
+
+	checks := checking.Checks{"blocksRolling": inner}
+	spec := &parser.CheckSpec{
+		Function: parser.FuncCheckBlocksProduced,
+		Start:    &lookBack,
+	}
+
+	if err := execCheck(t.Context(), "blocksRolling", spec, checks); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestSequential_ContextCancellation(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	net := driver.NewMockNetwork(ctrl)

--- a/driver/executor/sequential_test.go
+++ b/driver/executor/sequential_test.go
@@ -479,30 +479,25 @@ func TestSequential_Check(t *testing.T) {
 	}
 }
 
-func TestExecCheck_ForwardsStartAsMonitoringTime_WhenBlocksProducedHasStart(t *testing.T) {
+func TestExecCheck_ForwardsDurationAsInt64Nanos_WhenBlocksProducedHasDuration(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	inner := checking.NewMockChecker(ctrl)
 	configured := checking.NewMockChecker(ctrl)
 
-	lookBack := 30 * time.Second
+	duration := 30 * time.Second
 
-	// Capture the config passed to Configure and validate the "start" key.
-	before := time.Now()
 	inner.EXPECT().Configure(gomock.Any()).DoAndReturn(
 		func(cfg checking.CheckerConfig) checking.Checker {
-			after := time.Now()
-			v, ok := cfg["start"]
+			v, ok := cfg["duration"]
 			if !ok {
-				t.Fatalf("expected 'start' in config, got %v", cfg)
+				t.Fatalf("expected 'duration' in config, got %v", cfg)
 			}
-			startNanos, ok := v.(int64)
+			got, ok := v.(int64)
 			if !ok {
-				t.Fatalf("expected 'start' to be int64, got %T", v)
+				t.Fatalf("expected 'duration' to be int64, got %T", v)
 			}
-			minNanos := before.Add(-lookBack).UnixNano()
-			maxNanos := after.Add(-lookBack).UnixNano()
-			if startNanos < minNanos || startNanos > maxNanos {
-				t.Fatalf("start=%d not within [%d,%d]", startNanos, minNanos, maxNanos)
+			if got != int64(duration) {
+				t.Fatalf("expected duration=%d, got %d", int64(duration), got)
 			}
 			return configured
 		},
@@ -512,45 +507,7 @@ func TestExecCheck_ForwardsStartAsMonitoringTime_WhenBlocksProducedHasStart(t *t
 	checks := checking.Checks{"blocksRolling": inner}
 	spec := &parser.CheckSpec{
 		Function: parser.FuncCheckBlocksProduced,
-		Start:    &lookBack,
-	}
-
-	if err := execCheck(t.Context(), "blocksRolling", spec, checks); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestExecCheck_ClampsStartToZero_WhenLookbackExceedsEpoch(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	inner := checking.NewMockChecker(ctrl)
-	configured := checking.NewMockChecker(ctrl)
-
-	// A duration comfortably larger than the current time since the Unix
-	// epoch. This would otherwise underflow to a negative value.
-	lookBack := 200 * 365 * 24 * time.Hour
-
-	inner.EXPECT().Configure(gomock.Any()).DoAndReturn(
-		func(cfg checking.CheckerConfig) checking.Checker {
-			v, ok := cfg["start"]
-			if !ok {
-				t.Fatalf("expected 'start' in config, got %v", cfg)
-			}
-			start, ok := v.(int64)
-			if !ok {
-				t.Fatalf("expected 'start' to be int64, got %T", v)
-			}
-			if start != 0 {
-				t.Fatalf("expected start clamped to 0, got %d", start)
-			}
-			return configured
-		},
-	)
-	configured.EXPECT().Check(gomock.Any()).Return(nil)
-
-	checks := checking.Checks{"blocksRolling": inner}
-	spec := &parser.CheckSpec{
-		Function: parser.FuncCheckBlocksProduced,
-		Start:    &lookBack,
+		Duration: &duration,
 	}
 
 	if err := execCheck(t.Context(), "blocksRolling", spec, checks); err != nil {

--- a/driver/parser/sequential.go
+++ b/driver/parser/sequential.go
@@ -105,6 +105,7 @@ type CheckSpec struct {
 	Function       StepFunction
 	Ceiling        *float64
 	Tolerance      *int
+	Start          *time.Duration
 	Failing        bool
 	Rules          genesis.NetworkRulesPatch
 	ThrottledNodes []string
@@ -199,6 +200,19 @@ func (c *CheckSpec) parseParam(keyNode, valNode *yaml.Node) error {
 			)
 		}
 		c.Tolerance = &v
+	case "start":
+		var s string
+		if err := valNode.Decode(&s); err != nil {
+			return fmt.Errorf("line %d: invalid start: %w", keyNode.Line, err)
+		}
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return fmt.Errorf("line %d: invalid start duration %q: %w", keyNode.Line, s, err)
+		}
+		if d < 0 {
+			return fmt.Errorf("line %d: start duration must be non-negative, got %s", keyNode.Line, d)
+		}
+		c.Start = &d
 	case "ceiling":
 		var v float64
 		if err := valNode.Decode(&v); err != nil {
@@ -619,7 +633,7 @@ var checkFunctionParams = map[StepFunction][]string{
 	FuncCheckBlockHashes:    {"failing"},
 	FuncCheckBlockHeights:   {"tolerance", "failing"},
 	FuncCheckBlocksHalted:   {"failing"},
-	FuncCheckBlocksProduced: {"tolerance", "failing"},
+	FuncCheckBlocksProduced: {"tolerance", "start", "failing"},
 	FuncCheckEventThrottled: {"throttledNodes", "failing"},
 	FuncCheckNetworkRules:   {"rules", "failing"},
 }
@@ -629,6 +643,7 @@ var checkParamDescriptions = map[string]string{
 	"ceiling":        "Maximum allowed value (float64) for a gas rate check.",
 	"failing":        "When true, the check is expected to fail; a passing result is treated as an error.",
 	"rules":          "Expected network rules patch (NetworkRulesPatch field structure).",
+	"start":          "Duration (e.g. \"30s\") to look back from now; older samples are ignored by the check.",
 	"tolerance":      "Allowed deviation (int, in blocks) between nodes for a height/production check.",
 	"throttledNodes": "List of node labels expected to be throttled.",
 }

--- a/driver/parser/sequential.go
+++ b/driver/parser/sequential.go
@@ -105,7 +105,7 @@ type CheckSpec struct {
 	Function       StepFunction
 	Ceiling        *float64
 	Tolerance      *int
-	Start          *time.Duration
+	Duration       *time.Duration
 	Failing        bool
 	Rules          genesis.NetworkRulesPatch
 	ThrottledNodes []string
@@ -200,19 +200,19 @@ func (c *CheckSpec) parseParam(keyNode, valNode *yaml.Node) error {
 			)
 		}
 		c.Tolerance = &v
-	case "start":
+	case "duration":
 		var s string
 		if err := valNode.Decode(&s); err != nil {
-			return fmt.Errorf("line %d: invalid start: %w", keyNode.Line, err)
+			return fmt.Errorf("line %d: invalid duration: %w", keyNode.Line, err)
 		}
 		d, err := time.ParseDuration(s)
 		if err != nil {
-			return fmt.Errorf("line %d: invalid start duration %q: %w", keyNode.Line, s, err)
+			return fmt.Errorf("line %d: invalid duration %q: %w", keyNode.Line, s, err)
 		}
 		if d < 0 {
-			return fmt.Errorf("line %d: start duration must be non-negative, got %s", keyNode.Line, d)
+			return fmt.Errorf("line %d: duration must be non-negative, got %s", keyNode.Line, d)
 		}
-		c.Start = &d
+		c.Duration = &d
 	case "ceiling":
 		var v float64
 		if err := valNode.Decode(&v); err != nil {
@@ -633,7 +633,7 @@ var checkFunctionParams = map[StepFunction][]string{
 	FuncCheckBlockHashes:    {"failing"},
 	FuncCheckBlockHeights:   {"tolerance", "failing"},
 	FuncCheckBlocksHalted:   {"failing"},
-	FuncCheckBlocksProduced: {"tolerance", "start", "failing"},
+	FuncCheckBlocksProduced: {"tolerance", "duration", "failing"},
 	FuncCheckEventThrottled: {"throttledNodes", "failing"},
 	FuncCheckNetworkRules:   {"rules", "failing"},
 }
@@ -646,6 +646,7 @@ var checkParamDescriptions = map[string]string{
 	"start":          "Duration (e.g. \"30s\") to look back from now; older samples are ignored by the check.",
 	"tolerance":      "Allowed deviation (int, in blocks) between nodes for a height/production check.",
 	"throttledNodes": "List of node labels expected to be throttled.",
+	"duration":       "Duration (e.g. \"30s\") to actively observe the network; the check waits this long and then verifies block progress during the observation window.",
 }
 
 // PrintSequentialHelp writes a formatted summary of all available sequential

--- a/driver/parser/sequential_test.go
+++ b/driver/parser/sequential_test.go
@@ -402,14 +402,14 @@ Scenario:
 	require.Equal(t, []string{"validator-A"}, et.ThrottledNodes)
 }
 
-func TestParseSequential_BlocksProduced_ParsesStartDuration(t *testing.T) {
+func TestParseSequential_BlocksProduced_ParsesDuration(t *testing.T) {
 	input := `
-Name: Start Test
+Name: Duration Test
 Scenario:
   - checks:
       - blocksProduced:
         tolerance: 10
-        start: 30s
+        duration: 30s
 `
 	scenario, err := ParseSequentialBytes([]byte(input))
 	require.NoError(t, err)
@@ -419,25 +419,25 @@ Scenario:
 	require.Equal(t, FuncCheckBlocksProduced, check.Function)
 	require.NotNil(t, check.Tolerance)
 	require.Equal(t, 10, *check.Tolerance)
-	require.NotNil(t, check.Start)
-	require.Equal(t, 30*time.Second, *check.Start)
+	require.NotNil(t, check.Duration)
+	require.Equal(t, 30*time.Second, *check.Duration)
 }
 
-func TestParseSequential_BlocksProduced_RejectsInvalidStart(t *testing.T) {
+func TestParseSequential_BlocksProduced_RejectsInvalidDuration(t *testing.T) {
 	cases := map[string]string{
 		"non-duration string": `
 Name: Bad
 Scenario:
   - checks:
       - blocksProduced:
-        start: not-a-duration
+        duration: not-a-duration
 `,
 		"negative duration": `
 Name: Bad
 Scenario:
   - checks:
       - blocksProduced:
-        start: -5s
+        duration: -5s
 `,
 	}
 	for name, input := range cases {

--- a/driver/parser/sequential_test.go
+++ b/driver/parser/sequential_test.go
@@ -402,6 +402,52 @@ Scenario:
 	require.Equal(t, []string{"validator-A"}, et.ThrottledNodes)
 }
 
+func TestParseSequential_BlocksProduced_ParsesStartDuration(t *testing.T) {
+	input := `
+Name: Start Test
+Scenario:
+  - checks:
+      - blocksProduced:
+        tolerance: 10
+        start: 30s
+`
+	scenario, err := ParseSequentialBytes([]byte(input))
+	require.NoError(t, err)
+	require.Len(t, scenario.Steps[0].SubChecks, 1)
+
+	check := scenario.Steps[0].SubChecks[0]
+	require.Equal(t, FuncCheckBlocksProduced, check.Function)
+	require.NotNil(t, check.Tolerance)
+	require.Equal(t, 10, *check.Tolerance)
+	require.NotNil(t, check.Start)
+	require.Equal(t, 30*time.Second, *check.Start)
+}
+
+func TestParseSequential_BlocksProduced_RejectsInvalidStart(t *testing.T) {
+	cases := map[string]string{
+		"non-duration string": `
+Name: Bad
+Scenario:
+  - checks:
+      - blocksProduced:
+        start: not-a-duration
+`,
+		"negative duration": `
+Name: Bad
+Scenario:
+  - checks:
+      - blocksProduced:
+        start: -5s
+`,
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseSequentialBytes([]byte(input))
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestParseSequential_SlopeRate(t *testing.T) {
 	input := `
 Name: Slope Rate Test

--- a/scenarios/release_testing/features/single_proposer/network_recovers_from_blackout.yml
+++ b/scenarios/release_testing/features/single_proposer/network_recovers_from_blackout.yml
@@ -46,8 +46,8 @@ Scenario:
   - checks:
       - blocksProduced:
         tolerance: 10
-        # Ignore samples from before the network recovered so the flat
-        # block-height stretch during the blackout does not fail the check.
-        start: 20s
+        # Actively observe the network for 20 seconds and require that
+        # block production advanced during that window.
+        duration: 20s
 
  # default checks are added automatically.

--- a/scenarios/release_testing/features/single_proposer/network_recovers_from_blackout.yml
+++ b/scenarios/release_testing/features/single_proposer/network_recovers_from_blackout.yml
@@ -1,0 +1,53 @@
+Name: Release Features Single Proposer Network Recovers From Blackout
+
+Description: >-
+  Verifies that a network in single proposer mode recovers after
+  a blackout caused by stopping enough validators to halt consensus.
+  Restarting validators restores block production.
+
+InitialNetworkRules:
+  Upgrades:
+    Sonic: true
+    Allegro: true
+    SingleProposerBlockFormation: true
+
+Scenario:
+  - startNode: validator-1
+    type: validator
+
+  - startNode: validator-2
+    type: validator
+
+  - startNode: validator-3
+    type: validator
+
+  - runApp: load
+    type: counter
+    users: 20
+    rate:
+      constant: 10
+
+  - waitForEpoch
+
+  # Stop validators to break quorum and halt the network.
+  - stopNode: validator-3
+
+  - waitFor: 30s
+
+  - checks:
+      - blocksHalted
+
+  # Restart stopped validators to restore the network.
+  - startNode: validator-3
+    type: validator
+
+  - waitFor: 30s
+
+  - checks:
+      - blocksProduced:
+        tolerance: 10
+        # Ignore samples from before the network recovered so the flat
+        # block-height stretch during the blackout does not fail the check.
+        start: 20s
+
+ # default checks are added automatically.


### PR DESCRIPTION
This PR adds the fixed single proposer blackout scenario to the new release tests.
The `blocksRolling` check is extended with a `start` option, allowing to specify what timeframe should be considered by the check. 