### PR TITLE
Add command line argument to choose sonic version

### DIFF
--- a/driver/docker/images.go
+++ b/driver/docker/images.go
@@ -36,6 +36,37 @@ import (
 // non-local Sonic images on demand.
 const sonicRepositoryURL = "https://github.com/0xsoniclabs/sonic.git"
 
+// DefaultSonicLocalPath is the default path used as the build context when
+// building the "sonic:local" image. It is interpreted relative to the Norma
+// build root (see ResolveBuildRoot) unless overridden with SetSonicLocalPath
+// to point at an arbitrary location on disk.
+const DefaultSonicLocalPath = "sonic"
+
+// sonicLocalPath is the currently configured path used as the docker build
+// context for the "sonic:local" image. It defaults to DefaultSonicLocalPath
+// and can be overridden with SetSonicLocalPath (for example from a CLI flag).
+var sonicLocalPath = DefaultSonicLocalPath
+
+// SetSonicLocalPath configures the path used as the docker build context for
+// the "sonic:local" image. An empty path resets the configuration to the
+// built-in default (DefaultSonicLocalPath).
+//
+// The path may be absolute or relative; when relative it is resolved against
+// the Norma build root at build time.
+func SetSonicLocalPath(path string) {
+	if path == "" {
+		sonicLocalPath = DefaultSonicLocalPath
+		return
+	}
+	sonicLocalPath = path
+}
+
+// SonicLocalPath returns the currently configured path used as the docker
+// build context for the "sonic:local" image.
+func SonicLocalPath() string {
+	return sonicLocalPath
+}
+
 // imageBuildKind describes how an image should be materialized when it is not
 // already available locally.
 type imageBuildKind int
@@ -76,7 +107,8 @@ type imageBuildPlan struct {
 //
 // For Sonic image refs, it lazily builds from the project's Dockerfile:
 //   - sonic: from sonicRepositoryURL
-//   - sonic:local: from local ./sonic
+//   - sonic:local: from the currently configured sonic local path (see
+//     SetSonicLocalPath / SonicLocalPath, default DefaultSonicLocalPath)
 //   - sonic:<tag>: from sonicRepositoryURL#<tag>
 //   - sonic:<commit hash>: from sonicRepositoryURL#<commit hash>
 //
@@ -200,7 +232,9 @@ func buildImage(ctx context.Context, buildRoot, imageRef, clientSrc string) erro
 //
 // Current mapping rules:
 //   - "sonic"       => remote build from sonicRepositoryURL
-//   - "sonic:local" => local build from "sonic"
+//   - "sonic:local" => local build from the currently configured sonic local
+//     path (see SetSonicLocalPath / SonicLocalPath, default
+//     DefaultSonicLocalPath)
 //   - "sonic:<tag>" => remote build from sonicRepositoryURL#<tag>
 //   - "sonic:<commit hash>" => remote build from sonicRepositoryURL#<commit hash>
 //   - everything else => no build strategy (pull)
@@ -211,7 +245,7 @@ func planImage(imageRef string) imageBuildPlan {
 		return imageBuildPlan{kind: imageBuildSonicRemote, clientSrc: sonicRepositoryURL}
 	}
 	if imageRef == "sonic:local" {
-		return imageBuildPlan{kind: imageBuildSonicLocal, clientSrc: "sonic"}
+		return imageBuildPlan{kind: imageBuildSonicLocal, clientSrc: sonicLocalPath}
 	}
 	if imageRef == "sonic:latest" {
 		// "latest" is a Docker tag convention, not a git ref; build from repo HEAD.

--- a/driver/docker/images_test.go
+++ b/driver/docker/images_test.go
@@ -79,6 +79,35 @@ func TestPlanImage(t *testing.T) {
 	}
 }
 
+func TestSetSonicLocalPath_OverridesLocalBuildContext(t *testing.T) {
+	original := SonicLocalPath()
+	t.Cleanup(func() { SetSonicLocalPath(original) })
+
+	if got := SonicLocalPath(); got != DefaultSonicLocalPath {
+		t.Fatalf("unexpected default sonic local path: got %q, want %q",
+			got, DefaultSonicLocalPath)
+	}
+
+	custom := "/tmp/custom-sonic"
+	SetSonicLocalPath(custom)
+	if got := SonicLocalPath(); got != custom {
+		t.Fatalf("SonicLocalPath after set: got %q, want %q", got, custom)
+	}
+
+	plan := planImage("sonic:local")
+	want := imageBuildPlan{kind: imageBuildSonicLocal, clientSrc: custom}
+	if plan != want {
+		t.Fatalf("planImage(sonic:local) after override: got %+v, want %+v",
+			plan, want)
+	}
+
+	SetSonicLocalPath("")
+	if got := SonicLocalPath(); got != DefaultSonicLocalPath {
+		t.Fatalf("SonicLocalPath after reset: got %q, want %q",
+			got, DefaultSonicLocalPath)
+	}
+}
+
 func TestDeduplicateAndSort(t *testing.T) {
 	input := []string{"sonic:v2.1", "", "sonic", "sonic:v2.1", "   ", "alpine"}
 	want := []string{"alpine", "sonic", "sonic:v2.1"}

--- a/driver/globalflags/allglobalflags.go
+++ b/driver/globalflags/allglobalflags.go
@@ -8,14 +8,21 @@ import "github.com/urfave/cli/v2"
 // AllGlobalFlags aggregates all global flags for the application that are
 // common across different commands.
 var AllGlobalFlags = append(
-	[]cli.Flag{},
+	append(
+		[]cli.Flag{},
 
-	// Add flags related to slog configuration
-	AllLoggerFlags...,
+		// Add flags related to slog configuration
+		AllLoggerFlags...,
+	),
+	// Add flags related to sonic build configuration
+	AllSonicFlags...,
 )
 
 // ProcessGlobalFlags processes global flags for the application.
 // It processes the setup of any global flag included in the AllGlobalFlags list.
 func ProcessGlobalFlags(c *cli.Context) error {
-	return SetupLogger(c)
+	if err := SetupLogger(c); err != nil {
+		return err
+	}
+	return SetupSonicPath(c)
 }

--- a/driver/globalflags/sonic.go
+++ b/driver/globalflags/sonic.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package globalflags
+
+import (
+	"github.com/0xsoniclabs/norma/driver/docker"
+	"github.com/urfave/cli/v2"
+)
+
+// SonicPathFlag lets the user override the path used as the docker build
+// context for the "sonic:local" image. When unset, the built-in default from
+// the docker package is used (typically the "sonic" directory inside the
+// Norma build root).
+var SonicPathFlag = cli.StringFlag{
+	Name: "sonic-path",
+	Usage: "path to the sonic source tree used to build the sonic:local " +
+		"image; may be absolute or relative to the norma build root",
+	Value: docker.DefaultSonicLocalPath,
+}
+
+// AllSonicFlags aggregates all Sonic-related global flags.
+var AllSonicFlags = []cli.Flag{
+	&SonicPathFlag,
+}
+
+// SetupSonicPath applies the --sonic-path flag value (if any) to the docker
+// package configuration used when building the sonic:local image.
+func SetupSonicPath(ctx *cli.Context) error {
+	docker.SetSonicLocalPath(ctx.String(SonicPathFlag.Name))
+	return nil
+}


### PR DESCRIPTION
The user can specify which sonic version should be used for `sonic:local` by passing the `--sonic-path` argument. The default is still the sonic submodule.