### PR TITLE
Exit on check failure and timeouts

### DIFF
--- a/driver/executor/run.go
+++ b/driver/executor/run.go
@@ -221,23 +221,23 @@ func executeStep(
 	case parser.FuncStopNode:
 		return execStopNode(ctx, step, net, state)
 	case parser.FuncUndelegate:
-		return execUndelegate(step, net, registry, state)
+		return execUndelegate(ctx, step, net, registry, state)
 	case parser.FuncRunApp:
 		return execRunApp(ctx, step, net, state)
 	case parser.FuncStopApp:
 		return execStopApp(step, state)
 	case parser.FuncUpdateRules:
-		return execUpdateRules(step, net)
+		return execUpdateRules(ctx, step, net)
 	case parser.FuncAdvanceEpoch:
 		if err := waitForBlockProduction(ctx, net); err != nil {
 			return err
 		}
-		if err := net.AdvanceEpoch(1); err != nil {
+		if err := net.AdvanceEpoch(ctx, 1); err != nil {
 			return err
 		}
 		return waitForBlockProduction(ctx, net)
 	case parser.FuncWaitForEpoch:
-		return net.WaitForEpochChange()
+		return net.WaitForEpochChange(ctx)
 	case parser.FuncChecks:
 		for i, spec := range step.SubChecks {
 			checkerName, ok := checkFunctionToCheckerName[spec.Function]
@@ -329,7 +329,7 @@ func execStartNode(
 					instanceName,
 				)
 			} else {
-				id, err := registry.registerNewValidator(stakeAmount)
+				id, err := registry.registerNewValidator(ctx, stakeAmount)
 				if err != nil {
 					return fmt.Errorf("failed to register validator %s: %w",
 						instanceName, err,
@@ -504,6 +504,7 @@ func execStopNode(
 
 // execUndelegate undelegates stake from one or more validator nodes.
 func execUndelegate(
+	ctx context.Context,
 	step *parser.Step,
 	net driver.Network,
 	registry validatorRegistry,
@@ -536,7 +537,7 @@ func execUndelegate(
 			stakeAmount = *target.Stake
 		}
 		// stakeAmount=0 → UnregisterValidatorNode queries self-stake on-chain
-		if err := registry.unregisterValidator(*id, stakeAmount); err != nil {
+		if err := registry.unregisterValidator(ctx, *id, stakeAmount); err != nil {
 			return fmt.Errorf("failed to unregister validator %s: %w", target.Node, err)
 		}
 	}
@@ -613,9 +614,9 @@ func execStopApp(step *parser.Step, state *runState) error {
 }
 
 // execUpdateRules applies network rule updates.
-func execUpdateRules(step *parser.Step, net driver.Network) error {
+func execUpdateRules(ctx context.Context, step *parser.Step, net driver.Network) error {
 	rules := driver.NetworkRules(step.Rules)
-	if err := net.ApplyNetworkRules(rules); err != nil {
+	if err := net.ApplyNetworkRules(ctx, rules); err != nil {
 		return fmt.Errorf("failed to apply network rules: %w", err)
 	}
 

--- a/driver/executor/run_test.go
+++ b/driver/executor/run_test.go
@@ -59,10 +59,10 @@ func TestRun_StartAndStopNode(t *testing.T) {
 
 	validatorId := 2
 	gomock.InOrder(
-		registry.EXPECT().registerNewValidator(uint64(0)).Return(validatorId, nil),
+		registry.EXPECT().registerNewValidator(gomock.Any(), uint64(0)).Return(validatorId, nil),
 		net.EXPECT().CreateNode(gomock.Any()).Return(node, nil),
 		node.EXPECT().GetValidatorId().Return(&validatorId),
-		registry.EXPECT().unregisterValidator(validatorId, gomock.Any()).Return(nil),
+		registry.EXPECT().unregisterValidator(gomock.Any(), validatorId, gomock.Any()).Return(nil),
 		net.EXPECT().RemoveNode(node).Return(nil),
 		node.EXPECT().Stop(gomock.Any()).Return(nil),
 		node.EXPECT().Cleanup(gomock.Any()).Return(nil),
@@ -110,7 +110,7 @@ func TestRun_StartNode_ForwardsCustomStake(t *testing.T) {
 
 	gomock.InOrder(
 		registry.EXPECT().
-			registerNewValidator(customStake).
+			registerNewValidator(gomock.Any(), customStake).
 			Return(validatorId, nil),
 		net.EXPECT().CreateNode(gomock.Any()).Return(node, nil),
 	)
@@ -151,12 +151,12 @@ func TestRun_UndelegateSingleInstanceWithSuffix(t *testing.T) {
 
 	validatorId := 2
 	gomock.InOrder(
-		registry.EXPECT().registerNewValidator(uint64(0)).
+		registry.EXPECT().registerNewValidator(gomock.Any(), uint64(0)).
 			Return(validatorId, nil),
 		net.EXPECT().CreateNode(gomock.Any()).Return(node, nil),
 		node.EXPECT().GetValidatorId().Return(&validatorId),
 		registry.EXPECT().
-			unregisterValidator(validatorId, uint64(0)).Return(nil),
+			unregisterValidator(gomock.Any(), validatorId, uint64(0)).Return(nil),
 	)
 
 	instances := 1
@@ -215,8 +215,8 @@ func TestRun_UndelegateMultiInstance(t *testing.T) {
 			node1.EXPECT().DialRpc(gomock.Any()).Return(nil, fmt.Errorf("not ready")).AnyTimes()
 
 			instances := 2
-			registry.EXPECT().registerNewValidator(gomock.Any()).Return(2, nil)
-			registry.EXPECT().registerNewValidator(gomock.Any()).Return(3, nil)
+			registry.EXPECT().registerNewValidator(gomock.Any(), gomock.Any()).Return(2, nil)
+			registry.EXPECT().registerNewValidator(gomock.Any(), gomock.Any()).Return(3, nil)
 			net.EXPECT().CreateNode(gomock.Any()).DoAndReturn(func(config *driver.NodeConfig) (driver.Node, error) {
 				if config.Name == "validators-0" {
 					return node0, nil
@@ -227,7 +227,7 @@ func TestRun_UndelegateMultiInstance(t *testing.T) {
 			if !tc.expectErr {
 				validatorId0 := 2
 				node0.EXPECT().GetValidatorId().Return(&validatorId0)
-				registry.EXPECT().unregisterValidator(validatorId0, uint64(0)).Return(nil)
+				registry.EXPECT().unregisterValidator(gomock.Any(), validatorId0, uint64(0)).Return(nil)
 			}
 
 			scenario := parser.Scenario{
@@ -271,7 +271,7 @@ func TestRun_StopNodeWithoutUndelegate(t *testing.T) {
 
 	validatorId := 2
 	gomock.InOrder(
-		registry.EXPECT().registerNewValidator(gomock.Any()).Return(validatorId, nil),
+		registry.EXPECT().registerNewValidator(gomock.Any(), gomock.Any()).Return(validatorId, nil),
 		net.EXPECT().CreateNode(gomock.Any()).Return(node, nil),
 		// No unregister call expected
 		net.EXPECT().RemoveNode(node).Return(nil),
@@ -317,7 +317,7 @@ func TestRun_RejoinNode(t *testing.T) {
 	validatorId := 2
 	gomock.InOrder(
 		// First start: registers as new validator
-		registry.EXPECT().registerNewValidator(gomock.Any()).Return(validatorId, nil),
+		registry.EXPECT().registerNewValidator(gomock.Any(), gomock.Any()).Return(validatorId, nil),
 		net.EXPECT().CreateNode(gomock.Any()).Do(func(config *driver.NodeConfig) {
 			if config.ValidatorId == nil || *config.ValidatorId != validatorId {
 				t.Errorf("first start: expected ValidatorId=%d, got %v", validatorId, config.ValidatorId)
@@ -404,7 +404,7 @@ func TestRun_UpdateRules(t *testing.T) {
 	net.EXPECT().DialRandomRpc().Return(nil, fmt.Errorf("no nodes")).AnyTimes()
 	baseFee := genesis.BigIntValue(*big.NewInt(3000000000))
 
-	net.EXPECT().ApplyNetworkRules(driver.NetworkRules{
+	net.EXPECT().ApplyNetworkRules(gomock.Any(), driver.NetworkRules{
 		Economy: &genesis.EconomyPatch{
 			MinBaseFee: &baseFee,
 		},
@@ -434,7 +434,7 @@ func TestRun_AdvanceEpoch(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	net := driver.NewMockNetwork(ctrl)
 
-	net.EXPECT().AdvanceEpoch(1).Return(nil)
+	net.EXPECT().AdvanceEpoch(gomock.Any(), 1).Return(nil)
 	// DialRandomRpc returns error so waitForBlockProduction is skipped.
 	net.EXPECT().DialRandomRpc().Return(nil, fmt.Errorf("no nodes")).AnyTimes()
 
@@ -517,7 +517,7 @@ func TestRun_MultiInstanceNode(t *testing.T) {
 	ids := make(chan int, 2)
 	ids <- 2
 	ids <- 3
-	registry.EXPECT().registerNewValidator(uint64(0)).DoAndReturn(func(stake uint64) (int, error) {
+	registry.EXPECT().registerNewValidator(gomock.Any(), uint64(0)).DoAndReturn(func(ctx context.Context, stake uint64) (int, error) {
 		return <-ids, nil
 	}).Times(2)
 

--- a/driver/executor/validator_registry.go
+++ b/driver/executor/validator_registry.go
@@ -17,6 +17,7 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/0xsoniclabs/norma/driver"
@@ -28,8 +29,8 @@ import (
 // validatorRegistry abstracts how an executor registers and unregisters
 // validator nodes with the network.
 type validatorRegistry interface {
-	registerNewValidator(stake uint64) (int, error)
-	unregisterValidator(validatorId int, stake uint64) error
+	registerNewValidator(ctx context.Context, stake uint64) (int, error)
+	unregisterValidator(ctx context.Context, validatorId int, stake uint64) error
 }
 
 // netBasedValidatorRegistry is the production implementation of
@@ -39,26 +40,26 @@ type netBasedValidatorRegistry struct {
 	net driver.Network
 }
 
-func (a netBasedValidatorRegistry) registerNewValidator(stake uint64) (int, error) {
+func (a netBasedValidatorRegistry) registerNewValidator(ctx context.Context, stake uint64) (int, error) {
 	rpcClient, err := a.net.DialRandomRpc()
 	if err != nil {
 		return 0, fmt.Errorf("failed to connect to RPC; %v", err)
 	}
 	defer rpcClient.Close()
-	id, err := network.RegisterValidatorNode(rpcClient, stake)
+	id, err := network.RegisterValidatorNode(ctx, rpcClient, stake)
 	if err != nil {
 		return 0, fmt.Errorf("failed to register validator node; %v", err)
 	}
 	return id, nil
 }
 
-func (a netBasedValidatorRegistry) unregisterValidator(validatorId int, stake uint64) error {
+func (a netBasedValidatorRegistry) unregisterValidator(ctx context.Context, validatorId int, stake uint64) error {
 	rpcClient, err := a.net.DialRandomRpc()
 	if err != nil {
 		return fmt.Errorf("failed to connect to RPC; %v", err)
 	}
 	defer rpcClient.Close()
-	err = network.UnregisterValidatorNode(rpcClient, validatorId, stake)
+	err = network.UnregisterValidatorNode(ctx, rpcClient, validatorId, stake)
 	if err != nil {
 		return fmt.Errorf("failed to unregister validator node; %v", err)
 	}

--- a/driver/executor/validator_registry_mock.go
+++ b/driver/executor/validator_registry_mock.go
@@ -10,6 +10,7 @@
 package executor
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -40,30 +41,30 @@ func (m *MockvalidatorRegistry) EXPECT() *MockvalidatorRegistryMockRecorder {
 }
 
 // registerNewValidator mocks base method.
-func (m *MockvalidatorRegistry) registerNewValidator(stake uint64) (int, error) {
+func (m *MockvalidatorRegistry) registerNewValidator(ctx context.Context, stake uint64) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "registerNewValidator", stake)
+	ret := m.ctrl.Call(m, "registerNewValidator", ctx, stake)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // registerNewValidator indicates an expected call of registerNewValidator.
-func (mr *MockvalidatorRegistryMockRecorder) registerNewValidator(stake any) *gomock.Call {
+func (mr *MockvalidatorRegistryMockRecorder) registerNewValidator(ctx, stake any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "registerNewValidator", reflect.TypeOf((*MockvalidatorRegistry)(nil).registerNewValidator), stake)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "registerNewValidator", reflect.TypeOf((*MockvalidatorRegistry)(nil).registerNewValidator), ctx, stake)
 }
 
 // unregisterValidator mocks base method.
-func (m *MockvalidatorRegistry) unregisterValidator(validatorId int, stake uint64) error {
+func (m *MockvalidatorRegistry) unregisterValidator(ctx context.Context, validatorId int, stake uint64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "unregisterValidator", validatorId, stake)
+	ret := m.ctrl.Call(m, "unregisterValidator", ctx, validatorId, stake)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // unregisterValidator indicates an expected call of unregisterValidator.
-func (mr *MockvalidatorRegistryMockRecorder) unregisterValidator(validatorId, stake any) *gomock.Call {
+func (mr *MockvalidatorRegistryMockRecorder) unregisterValidator(ctx, validatorId, stake any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "unregisterValidator", reflect.TypeOf((*MockvalidatorRegistry)(nil).unregisterValidator), validatorId, stake)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "unregisterValidator", reflect.TypeOf((*MockvalidatorRegistry)(nil).unregisterValidator), ctx, validatorId, stake)
 }

--- a/driver/network.go
+++ b/driver/network.go
@@ -96,13 +96,13 @@ type Network interface {
 	DialRandomRpc() (rpc.Client, error)
 
 	// ApplyNetworkRules applies the given network rules to the network.
-	ApplyNetworkRules(rules NetworkRules) error
+	ApplyNetworkRules(ctx context.Context, rules NetworkRules) error
 
 	// AdvanceEpoch advances an epoch by the given number.
-	AdvanceEpoch(epochIncrement int) error
+	AdvanceEpoch(ctx context.Context, epochIncrement int) error
 
 	// WaitForEpochChange waits until the epoch changes.
-	WaitForEpochChange() error
+	WaitForEpochChange(ctx context.Context) error
 }
 
 // NetworkConfig is a collection of network parameters to be used by factories

--- a/driver/network/backend.go
+++ b/driver/network/backend.go
@@ -17,6 +17,7 @@
 package network
 
 import (
+	"context"
 	"encoding/hex"
 	"strings"
 
@@ -32,8 +33,9 @@ import (
 type ContractBackend interface {
 	bind.ContractBackend
 	// WaitTransactionReceipt waits for the receipt of the given transaction hash to be available.
-	// The function times out after 10 seconds.
-	WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error)
+	// The function returns early if the context is cancelled, and otherwise times out
+	// after a fixed period.
+	WaitTransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 
 	// GetNetworkRules returns network rules for the selected block (for example: "latest").
 	GetNetworkRules(block string) (opera.Rules, error)

--- a/driver/network/backend_mock.go
+++ b/driver/network/backend_mock.go
@@ -225,16 +225,16 @@ func (mr *MockContractBackendMockRecorder) SuggestGasTipCap(ctx any) *gomock.Cal
 }
 
 // WaitTransactionReceipt mocks base method.
-func (m *MockContractBackend) WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error) {
+func (m *MockContractBackend) WaitTransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitTransactionReceipt", txHash)
+	ret := m.ctrl.Call(m, "WaitTransactionReceipt", ctx, txHash)
 	ret0, _ := ret[0].(*types.Receipt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WaitTransactionReceipt indicates an expected call of WaitTransactionReceipt.
-func (mr *MockContractBackendMockRecorder) WaitTransactionReceipt(txHash any) *gomock.Call {
+func (mr *MockContractBackendMockRecorder) WaitTransactionReceipt(ctx, txHash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitTransactionReceipt", reflect.TypeOf((*MockContractBackend)(nil).WaitTransactionReceipt), txHash)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitTransactionReceipt", reflect.TypeOf((*MockContractBackend)(nil).WaitTransactionReceipt), ctx, txHash)
 }

--- a/driver/network/epoch.go
+++ b/driver/network/epoch.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	big "math/big"
@@ -19,8 +20,8 @@ import (
 )
 
 // AdvanceEpoch triggers the sealing of an epoch advancing it by the given number.
-// The function blocks until the final epoch has been reached
-func AdvanceEpoch(client rpc.Client, epochIncrement int) error {
+// The function blocks until the final epoch has been reached.
+func AdvanceEpoch(ctx context.Context, client rpc.Client, epochIncrement int) error {
 	contract, err := driverauth100.NewContract(driverauth.ContractAddress, client)
 	if err != nil {
 		return fmt.Errorf("failed to get driver auth contract representation; %v", err)
@@ -40,6 +41,7 @@ func AdvanceEpoch(client rpc.Client, epochIncrement int) error {
 	if err != nil {
 		return fmt.Errorf("failed to create txOpts; %v", err)
 	}
+	txOpts.Context = ctx
 	txOpts.GasTipCap = systemTxGasTipCap
 	txOpts.GasLimit = systemTxGasLimit
 
@@ -48,7 +50,7 @@ func AdvanceEpoch(client rpc.Client, epochIncrement int) error {
 		return fmt.Errorf("failed to advance epoch; %v", err)
 	}
 
-	rec, err := client.WaitTransactionReceipt(tx.Hash())
+	rec, err := client.WaitTransactionReceipt(ctx, tx.Hash())
 	if err != nil {
 		return fmt.Errorf("failed to get receipt; %v", err)
 	}
@@ -60,6 +62,9 @@ func AdvanceEpoch(client rpc.Client, epochIncrement int) error {
 	// wait until the new epoch has actually started
 	start := time.Now()
 	for time.Since(start) < 60*time.Second {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("aborted while waiting for epoch to advance: %w", err)
+		}
 		newEpoch, err := GetCurrentEpoch(client)
 		if err != nil {
 			return fmt.Errorf("failed to get current epoch after advancing: %w", err)
@@ -68,7 +73,11 @@ func AdvanceEpoch(client rpc.Client, epochIncrement int) error {
 			logEpochSummary(client)
 			return nil
 		}
-		time.Sleep(100 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("aborted while waiting for epoch to advance: %w", ctx.Err())
+		case <-time.After(100 * time.Millisecond):
+		}
 	}
 
 	return fmt.Errorf("failed to advance epoch: waited too long for the epoch to be advanced")
@@ -76,7 +85,7 @@ func AdvanceEpoch(client rpc.Client, epochIncrement int) error {
 
 // WaitForEpochChange waits until the current epoch changes. It polls the
 // network until a new epoch is observed or a timeout of 60 seconds is reached.
-func WaitForEpochChange(client rpc.Client) error {
+func WaitForEpochChange(ctx context.Context, client rpc.Client) error {
 	currentEpoch, err := GetCurrentEpoch(client)
 	if err != nil {
 		return fmt.Errorf("failed to get current epoch: %w", err)
@@ -84,6 +93,9 @@ func WaitForEpochChange(client rpc.Client) error {
 
 	start := time.Now()
 	for time.Since(start) < 60*time.Second {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("aborted while waiting for epoch to change: %w", err)
+		}
 		newEpoch, err := GetCurrentEpoch(client)
 		if err != nil {
 			return fmt.Errorf("failed to get epoch while waiting: %w", err)
@@ -93,7 +105,11 @@ func WaitForEpochChange(client rpc.Client) error {
 			logEpochSummary(client)
 			return nil
 		}
-		time.Sleep(100 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("aborted while waiting for epoch to change: %w", ctx.Err())
+		case <-time.After(100 * time.Millisecond):
+		}
 	}
 
 	return fmt.Errorf("timed out waiting for epoch to change from %d", uint64(currentEpoch))

--- a/driver/network/epoch_test.go
+++ b/driver/network/epoch_test.go
@@ -37,7 +37,7 @@ func TestAdvanceEpoch_Success(t *testing.T) {
 	client.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).Return(&header, nil)
 	client.EXPECT().PendingNonceAt(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
 	client.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return(nil)
-	client.EXPECT().WaitTransactionReceipt(gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusSuccessful}, nil)
+	client.EXPECT().WaitTransactionReceipt(gomock.Any(), gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusSuccessful}, nil)
 
 	// Report the updated epoch after advancing.
 	client.EXPECT().Call(gomock.Any(), "eth_currentEpoch").DoAndReturn(
@@ -52,7 +52,7 @@ func TestAdvanceEpoch_Success(t *testing.T) {
 	client.EXPECT().CallContract(any, any, any).Return(nil, nil)
 	client.EXPECT().CodeAt(any, any, any).Return(bytecode, nil)
 
-	if err := AdvanceEpoch(client, 1); err != nil {
+	if err := AdvanceEpoch(t.Context(), client, 1); err != nil {
 		t.Errorf("failed to advance epoch: %v", err)
 	}
 }

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -454,11 +454,11 @@ func (n *LocalNetwork) ensureAppContext() error {
 	if n.appContext != nil {
 		return nil
 	}
-	ctx, err := app.NewContext(n, n.primaryAccount, n.config.NetworkRules)
+	appCtx, err := app.NewContext(n.ctx, n, n.primaryAccount, n.config.NetworkRules)
 	if err != nil {
 		return fmt.Errorf("failed to create app context: %w", err)
 	}
-	n.appContext = ctx
+	n.appContext = appCtx
 	return nil
 }
 

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -360,34 +360,34 @@ func (n *LocalNetwork) DialRandomRpc() (rpcdriver.Client, error) {
 	return nil, fmt.Errorf("no reachable node found among %d active nodes", len(reliable))
 }
 
-func (n *LocalNetwork) ApplyNetworkRules(rules driver.NetworkRules) error {
+func (n *LocalNetwork) ApplyNetworkRules(ctx context.Context, rules driver.NetworkRules) error {
 	client, err := n.DialRandomRpc()
 	if err != nil {
 		return fmt.Errorf("failed to connect to network: %w", err)
 	}
 	defer client.Close()
 
-	return network.ApplyNetworkRules(client, rules)
+	return network.ApplyNetworkRules(ctx, client, rules)
 }
 
-func (n *LocalNetwork) AdvanceEpoch(epochIncrement int) error {
+func (n *LocalNetwork) AdvanceEpoch(ctx context.Context, epochIncrement int) error {
 	client, err := n.DialRandomRpc()
 	if err != nil {
 		return fmt.Errorf("failed to connect to network: %w", err)
 	}
 	defer client.Close()
 
-	return network.AdvanceEpoch(client, epochIncrement)
+	return network.AdvanceEpoch(ctx, client, epochIncrement)
 }
 
-func (n *LocalNetwork) WaitForEpochChange() error {
+func (n *LocalNetwork) WaitForEpochChange(ctx context.Context) error {
 	client, err := n.DialRandomRpc()
 	if err != nil {
 		return fmt.Errorf("failed to connect to network: %w", err)
 	}
 	defer client.Close()
 
-	return network.WaitForEpochChange(client)
+	return network.WaitForEpochChange(ctx, client)
 }
 
 // treasureAccountPrivateKey is an account with tokens that can be used to

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -636,7 +636,7 @@ func TestLocalNetworkApplyNetworkRules_Success(t *testing.T) {
 		},
 	}
 
-	if err := net.ApplyNetworkRules(rules); err != nil {
+	if err := net.ApplyNetworkRules(t.Context(), rules); err != nil {
 		t.Errorf("failed to apply network rules: %v", err)
 	}
 
@@ -676,7 +676,7 @@ func TestLocalNetworkAdvanceEpoch_Success(t *testing.T) {
 	}
 
 	epochIncrement := 3 // takes ~5-6 seconds per increment
-	if err := net.AdvanceEpoch(epochIncrement); err != nil {
+	if err := net.AdvanceEpoch(t.Context(), epochIncrement); err != nil {
 		t.Errorf("failed to advance epoch: %v", err)
 	}
 

--- a/driver/network/rules.go
+++ b/driver/network/rules.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -15,7 +16,7 @@ import (
 )
 
 // ApplyNetworkRules updates the network rules on the network.
-func ApplyNetworkRules(backend ContractBackend, rules genesis.NetworkRulesPatch) error {
+func ApplyNetworkRules(ctx context.Context, backend ContractBackend, rules genesis.NetworkRulesPatch) error {
 	// Bind contract to update network rules
 	contract, err := driverauth100.NewContract(driverauth.ContractAddress, backend)
 	if err != nil {
@@ -34,6 +35,7 @@ func ApplyNetworkRules(backend ContractBackend, rules genesis.NetworkRulesPatch)
 	if err != nil {
 		return fmt.Errorf("failed to create txOpts; %v", err)
 	}
+	txOpts.Context = ctx
 	txOpts.GasTipCap = systemTxGasTipCap
 	txOpts.GasLimit = systemTxGasLimit
 
@@ -42,7 +44,7 @@ func ApplyNetworkRules(backend ContractBackend, rules genesis.NetworkRulesPatch)
 		return fmt.Errorf("failed to update network rules; %v", err)
 	}
 
-	rec, err := backend.WaitTransactionReceipt(tx.Hash())
+	rec, err := backend.WaitTransactionReceipt(ctx, tx.Hash())
 	if err != nil {
 		return fmt.Errorf("failed to get receipt; %v", err)
 	}

--- a/driver/network/rules_test.go
+++ b/driver/network/rules_test.go
@@ -21,7 +21,7 @@ func TestApplyNetworkRules_Success(t *testing.T) {
 	backend.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).Return(&header, nil)
 	backend.EXPECT().PendingNonceAt(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
 	backend.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return(nil)
-	backend.EXPECT().WaitTransactionReceipt(gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusSuccessful}, nil)
+	backend.EXPECT().WaitTransactionReceipt(gomock.Any(), gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusSuccessful}, nil)
 
 	fee := genesis.BigIntValue(*big.NewInt(456))
 	rules := genesis.NetworkRulesPatch{
@@ -30,7 +30,7 @@ func TestApplyNetworkRules_Success(t *testing.T) {
 		},
 	}
 
-	if err := ApplyNetworkRules(backend, rules); err != nil {
+	if err := ApplyNetworkRules(t.Context(), backend, rules); err != nil {
 		t.Errorf("failed to apply network rules: %v", err)
 	}
 }

--- a/driver/network/validator.go
+++ b/driver/network/validator.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"math/big"
@@ -22,7 +23,7 @@ const defaultStakePerValidator = uint64(5_000_000)
 
 // RegisterValidatorNode registers a validator in the SFC contract.
 // If stake is 0, the default stake of 5,000,000 S is used.
-func RegisterValidatorNode(backend ContractBackend, stake uint64) (int, error) {
+func RegisterValidatorNode(ctx context.Context, backend ContractBackend, stake uint64) (int, error) {
 	// get a representation of the deployed contract
 	SFCContract, err := sfc100.NewContract(sfc.ContractAddress, backend)
 	if err != nil {
@@ -59,7 +60,7 @@ func RegisterValidatorNode(backend ContractBackend, stake uint64) (int, error) {
 		return 0, fmt.Errorf("failed to create validator; %v", err)
 	}
 
-	receipt, err := backend.WaitTransactionReceipt(tx.Hash())
+	receipt, err := backend.WaitTransactionReceipt(ctx, tx.Hash())
 	if err != nil {
 		return 0, fmt.Errorf("failed to create validator, receipt error: %v", err)
 	}
@@ -79,7 +80,7 @@ func RegisterValidatorNode(backend ContractBackend, stake uint64) (int, error) {
 // UnregisterValidatorNode undelegates a validator's self-stake from the SFC
 // contract. If stake is 0, the currently staked amount is queried on-chain via
 // GetSelfStake and used as the undelegate amount.
-func UnregisterValidatorNode(client rpc.Client, validatorId int, stake uint64) error {
+func UnregisterValidatorNode(ctx context.Context, client rpc.Client, validatorId int, stake uint64) error {
 	slog.Info("start unregistering validator node", "validator_id", validatorId)
 
 	// get a representation of the deployed contract
@@ -114,7 +115,7 @@ func UnregisterValidatorNode(client rpc.Client, validatorId int, stake uint64) e
 		return fmt.Errorf("failed to undelegate validator stake; %v", err)
 	}
 
-	receipt, err := client.WaitTransactionReceipt(tx.Hash())
+	receipt, err := client.WaitTransactionReceipt(ctx, tx.Hash())
 	if err != nil {
 		return fmt.Errorf("failed to unregister validator, receipt error: %v", err)
 	}

--- a/driver/network/validator.go
+++ b/driver/network/validator.go
@@ -42,6 +42,7 @@ func RegisterValidatorNode(ctx context.Context, backend ContractBackend, stake u
 	if err != nil {
 		return 0, fmt.Errorf("failed to create txOpts; %v", err)
 	}
+	txOpts.Context = ctx
 	txOpts.GasTipCap = systemTxGasTipCap
 	txOpts.GasLimit = systemTxGasLimit
 
@@ -94,6 +95,7 @@ func UnregisterValidatorNode(ctx context.Context, client rpc.Client, validatorId
 	if err != nil {
 		return fmt.Errorf("failed to create txOpts; %v", err)
 	}
+	txOpts.Context = ctx
 	txOpts.GasTipCap = systemTxGasTipCap
 	txOpts.GasLimit = systemTxGasLimit
 

--- a/driver/network/validator_test.go
+++ b/driver/network/validator_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"testing"
@@ -12,9 +13,9 @@ import (
 
 func TestRegisterValidatorNode_Success(t *testing.T) {
 	mockBackendForCreateValidator(t, func(backend *MockContractBackend) {
-		backend.EXPECT().WaitTransactionReceipt(gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusSuccessful}, nil)
+		backend.EXPECT().WaitTransactionReceipt(gomock.Any(), gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusSuccessful}, nil)
 
-		valId, err := RegisterValidatorNode(backend, 0)
+		valId, err := RegisterValidatorNode(context.Background(), backend, 0)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -26,9 +27,9 @@ func TestRegisterValidatorNode_Success(t *testing.T) {
 
 func TestRegisterValidatorNode_Failure(t *testing.T) {
 	mockBackendForCreateValidator(t, func(backend *MockContractBackend) {
-		backend.EXPECT().WaitTransactionReceipt(gomock.Any()).Return(nil, fmt.Errorf("failed to get receipt")).AnyTimes()
+		backend.EXPECT().WaitTransactionReceipt(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("failed to get receipt")).AnyTimes()
 
-		if _, err := RegisterValidatorNode(backend, 0); err == nil {
+		if _, err := RegisterValidatorNode(context.Background(), backend, 0); err == nil {
 			t.Errorf("expected error, got %v", err)
 		}
 	})
@@ -36,9 +37,9 @@ func TestRegisterValidatorNode_Failure(t *testing.T) {
 
 func TestRegisterValidatorNode_Failure_TransactionReverted(t *testing.T) {
 	mockBackendForCreateValidator(t, func(backend *MockContractBackend) {
-		backend.EXPECT().WaitTransactionReceipt(gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusFailed}, nil).AnyTimes()
+		backend.EXPECT().WaitTransactionReceipt(gomock.Any(), gomock.Any()).Return(&types.Receipt{Status: types.ReceiptStatusFailed}, nil).AnyTimes()
 
-		if _, err := RegisterValidatorNode(backend, 0); err == nil {
+		if _, err := RegisterValidatorNode(context.Background(), backend, 0); err == nil {
 			t.Errorf("expected error, got %v", err)
 		}
 	})

--- a/driver/network_mock.go
+++ b/driver/network_mock.go
@@ -43,31 +43,31 @@ func (m *MockNetwork) EXPECT() *MockNetworkMockRecorder {
 }
 
 // AdvanceEpoch mocks base method.
-func (m *MockNetwork) AdvanceEpoch(epochIncrement int) error {
+func (m *MockNetwork) AdvanceEpoch(ctx context.Context, epochIncrement int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AdvanceEpoch", epochIncrement)
+	ret := m.ctrl.Call(m, "AdvanceEpoch", ctx, epochIncrement)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AdvanceEpoch indicates an expected call of AdvanceEpoch.
-func (mr *MockNetworkMockRecorder) AdvanceEpoch(epochIncrement any) *gomock.Call {
+func (mr *MockNetworkMockRecorder) AdvanceEpoch(ctx, epochIncrement any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdvanceEpoch", reflect.TypeOf((*MockNetwork)(nil).AdvanceEpoch), epochIncrement)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdvanceEpoch", reflect.TypeOf((*MockNetwork)(nil).AdvanceEpoch), ctx, epochIncrement)
 }
 
 // ApplyNetworkRules mocks base method.
-func (m *MockNetwork) ApplyNetworkRules(rules NetworkRules) error {
+func (m *MockNetwork) ApplyNetworkRules(ctx context.Context, rules NetworkRules) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplyNetworkRules", rules)
+	ret := m.ctrl.Call(m, "ApplyNetworkRules", ctx, rules)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ApplyNetworkRules indicates an expected call of ApplyNetworkRules.
-func (mr *MockNetworkMockRecorder) ApplyNetworkRules(rules any) *gomock.Call {
+func (mr *MockNetworkMockRecorder) ApplyNetworkRules(ctx, rules any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyNetworkRules", reflect.TypeOf((*MockNetwork)(nil).ApplyNetworkRules), rules)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyNetworkRules", reflect.TypeOf((*MockNetwork)(nil).ApplyNetworkRules), ctx, rules)
 }
 
 // CreateApplication mocks base method.
@@ -208,17 +208,17 @@ func (mr *MockNetworkMockRecorder) UnregisterListener(arg0 any) *gomock.Call {
 }
 
 // WaitForEpochChange mocks base method.
-func (m *MockNetwork) WaitForEpochChange() error {
+func (m *MockNetwork) WaitForEpochChange(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForEpochChange")
+	ret := m.ctrl.Call(m, "WaitForEpochChange", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WaitForEpochChange indicates an expected call of WaitForEpochChange.
-func (mr *MockNetworkMockRecorder) WaitForEpochChange() *gomock.Call {
+func (mr *MockNetworkMockRecorder) WaitForEpochChange(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForEpochChange", reflect.TypeOf((*MockNetwork)(nil).WaitForEpochChange))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForEpochChange", reflect.TypeOf((*MockNetwork)(nil).WaitForEpochChange), ctx)
 }
 
 // MockNetworkListener is a mock of NetworkListener interface.

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -361,7 +361,7 @@ func dumpNodeLogs(ctx context.Context, net driver.Network) {
 				slog.Error("failed to stream log", "node", node.GetLabel(), "error", err)
 				return
 			}
-			data, err := io.ReadAll(reader)
+			data, err := io.ReadAll(io.LimitReader(reader, 1<<20))
 			_ = reader.Close()
 
 			if len(data) > 0 {

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/0xsoniclabs/norma/driver/checking"
@@ -339,23 +340,39 @@ func openBrowser(s string) error {
 	return cmd.Start()
 }
 
+// logDumpTimeout bounds each node log read, since StreamLog follows the
+// container and never reaches EOF for a running node. Var so tests can shorten it.
+var logDumpTimeout = 20 * time.Second
+
 // dumpNodeLogs prints the logs of all active nodes to help diagnose failures.
 func dumpNodeLogs(ctx context.Context, net driver.Network) {
 	nodes := net.GetActiveNodes()
+	var wg sync.WaitGroup
 	for _, node := range nodes {
-		reader, err := node.StreamLog(ctx)
-		if err != nil {
-			slog.Error("failed to stream log", "node", node.GetLabel(), "error", err)
-			continue
-		}
-		data, err := io.ReadAll(reader)
-		_ = reader.Close()
-		if err != nil {
-			slog.Error("failed to read log", "node", node.GetLabel(), "error", err)
-			continue
-		}
-		slog.Error("node log on failure", "node", node.GetLabel(), "log", string(data))
+		wg.Add(1)
+		go func(node driver.Node) {
+			defer wg.Done()
+
+			logCtx, cancel := context.WithTimeout(ctx, logDumpTimeout)
+			defer cancel()
+
+			reader, err := node.StreamLog(logCtx)
+			if err != nil {
+				slog.Error("failed to stream log", "node", node.GetLabel(), "error", err)
+				return
+			}
+			data, err := io.ReadAll(reader)
+			_ = reader.Close()
+
+			if len(data) > 0 {
+				slog.Error("node log on failure", "node", node.GetLabel(), "log", string(data))
+			}
+			if err != nil && logCtx.Err() == nil {
+				slog.Error("failed to read log", "node", node.GetLabel(), "error", err)
+			}
+		}(node)
 	}
+	wg.Wait()
 }
 
 func appendScenarioStepTimings(

--- a/driver/norma/run_test.go
+++ b/driver/norma/run_test.go
@@ -26,17 +26,6 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-// ctxBlockingReader mimics a docker follow log stream on a running container:
-// Read never returns EOF and only unblocks when the context is cancelled.
-type ctxBlockingReader struct{ ctx context.Context }
-
-func (r *ctxBlockingReader) Read([]byte) (int, error) {
-	<-r.ctx.Done()
-	return 0, r.ctx.Err()
-}
-
-func (r *ctxBlockingReader) Close() error { return nil }
-
 // TestDumpNodeLogs_BoundedForRunningNode is a regression test: dumpNodeLogs must
 // return even when a node's log stream never reaches EOF.
 func TestDumpNodeLogs_BoundedForRunningNode(t *testing.T) {
@@ -67,3 +56,14 @@ func TestDumpNodeLogs_BoundedForRunningNode(t *testing.T) {
 		t.Fatal("dumpNodeLogs blocked on a running node's follow stream")
 	}
 }
+
+// ctxBlockingReader mimics a docker follow log stream on a running container:
+// Read never returns EOF and only unblocks when the context is cancelled.
+type ctxBlockingReader struct{ ctx context.Context }
+
+func (r *ctxBlockingReader) Read([]byte) (int, error) {
+	<-r.ctx.Done()
+	return 0, r.ctx.Err()
+}
+
+func (r *ctxBlockingReader) Close() error { return nil }

--- a/driver/norma/run_test.go
+++ b/driver/norma/run_test.go
@@ -1,0 +1,69 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/0xsoniclabs/norma/driver"
+	"go.uber.org/mock/gomock"
+)
+
+// ctxBlockingReader mimics a docker follow log stream on a running container:
+// Read never returns EOF and only unblocks when the context is cancelled.
+type ctxBlockingReader struct{ ctx context.Context }
+
+func (r *ctxBlockingReader) Read([]byte) (int, error) {
+	<-r.ctx.Done()
+	return 0, r.ctx.Err()
+}
+
+func (r *ctxBlockingReader) Close() error { return nil }
+
+// TestDumpNodeLogs_BoundedForRunningNode is a regression test: dumpNodeLogs must
+// return even when a node's log stream never reaches EOF.
+func TestDumpNodeLogs_BoundedForRunningNode(t *testing.T) {
+	prev := logDumpTimeout
+	logDumpTimeout = 100 * time.Millisecond
+	defer func() { logDumpTimeout = prev }()
+
+	ctrl := gomock.NewController(t)
+	node := driver.NewMockNode(ctrl)
+	node.EXPECT().GetLabel().Return("validator-0").AnyTimes()
+	node.EXPECT().StreamLog(gomock.Any()).DoAndReturn(
+		func(ctx context.Context) (io.ReadCloser, error) {
+			return &ctxBlockingReader{ctx: ctx}, nil
+		})
+
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().GetActiveNodes().Return([]driver.Node{node})
+
+	done := make(chan struct{})
+	go func() {
+		dumpNodeLogs(context.Background(), net)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("dumpNodeLogs blocked on a running node's follow stream")
+	}
+}

--- a/driver/rpc/rpc.go
+++ b/driver/rpc/rpc.go
@@ -55,8 +55,8 @@ type Client interface {
 	// WaitTransactionReceipt waits for the transaction receipt of the given transaction hash.
 	// It returns an error if the receipt could not be obtained within a certain time frame.
 	// This method retries with exponential backoff to fetch the transaction receipt,
-	//  until a certain timeout is reached.
-	WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error)
+	//  until a certain timeout is reached or the context is cancelled.
+	WaitTransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 
 	// GetTransactionPoolStatus queries the transaction pool for the given transaction hash
 	// and returns whether it is pending, queued, or not present in the pool.
@@ -109,15 +109,22 @@ func (r Impl) Call(result interface{}, method string, args ...interface{}) error
 	return r.rpcClient.Call(result, method, args...)
 }
 
-func (r Impl) WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error) {
+func (r Impl) WaitTransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 	// Wait for the response with some exponential backoff.
 	const maxDelay = 5 * time.Second
 	begin := time.Now()
 	delay := time.Millisecond
 	for time.Since(begin) < r.txReceiptTimeout {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("aborted while waiting for transaction receipt: %w", err)
+		}
 		receipt, err := r.transactionReceipt(txHash)
 		if errors.Is(err, ethereum.NotFound) {
-			time.Sleep(delay)
+			select {
+			case <-ctx.Done():
+				return nil, fmt.Errorf("aborted while waiting for transaction receipt: %w", ctx.Err())
+			case <-time.After(delay):
+			}
 			delay = 2 * delay
 			if delay > maxDelay {
 				delay = maxDelay

--- a/driver/rpc/rpc_mock.go
+++ b/driver/rpc/rpc_mock.go
@@ -362,18 +362,18 @@ func (mr *MockClientMockRecorder) WaitForBundleInfo(ctx, planHash any) *gomock.C
 }
 
 // WaitTransactionReceipt mocks base method.
-func (m *MockClient) WaitTransactionReceipt(txHash common.Hash) (*types.Receipt, error) {
+func (m *MockClient) WaitTransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitTransactionReceipt", txHash)
+	ret := m.ctrl.Call(m, "WaitTransactionReceipt", ctx, txHash)
 	ret0, _ := ret[0].(*types.Receipt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WaitTransactionReceipt indicates an expected call of WaitTransactionReceipt.
-func (mr *MockClientMockRecorder) WaitTransactionReceipt(txHash any) *gomock.Call {
+func (mr *MockClientMockRecorder) WaitTransactionReceipt(ctx, txHash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitTransactionReceipt", reflect.TypeOf((*MockClient)(nil).WaitTransactionReceipt), txHash)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitTransactionReceipt", reflect.TypeOf((*MockClient)(nil).WaitTransactionReceipt), ctx, txHash)
 }
 
 // MockethRpcClient is a mock of ethRpcClient interface.

--- a/driver/rpc/rpc_test.go
+++ b/driver/rpc/rpc_test.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"strings"
@@ -49,7 +50,7 @@ func TestRpcClientImpl_WaitTransactionReceipt_Success(t *testing.T) {
 			return nil
 		})
 
-	receipt, err := client.WaitTransactionReceipt(common.Hash{})
+	receipt, err := client.WaitTransactionReceipt(context.Background(), common.Hash{})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -84,7 +85,7 @@ func TestRpcClientImpl_WaitTransactionReceipt_Timeout(t *testing.T) {
 		Call(gomock.Any(), "txpool_content", gomock.Any()).
 		MinTimes(1)
 
-	if _, err := client.WaitTransactionReceipt(common.Hash{}); err == nil || err.Error() != "failed to get transaction receipt: timeout, transaction pool status: not present" {
+	if _, err := client.WaitTransactionReceipt(context.Background(), common.Hash{}); err == nil || err.Error() != "failed to get transaction receipt: timeout, transaction pool status: not present" {
 		t.Fatalf("expected timeout error, got %v", err)
 	}
 }
@@ -107,7 +108,7 @@ func TestRpcClientImpl_WaitTransactionReceipt_Error(t *testing.T) {
 		Return(injectedError).
 		Times(1)
 
-	if _, err := client.WaitTransactionReceipt(common.Hash{}); !errors.Is(err, injectedError) {
+	if _, err := client.WaitTransactionReceipt(context.Background(), common.Hash{}); !errors.Is(err, injectedError) {
 		t.Fatalf("expected error %v, got %v", injectedError, err)
 	}
 }

--- a/load/app/app_test.go
+++ b/load/app/app_test.go
@@ -127,7 +127,7 @@ func TestGenerators(t *testing.T) {
 			primaryAccount, err := app.NewAccount(0, PrivateKey, FakeNetworkID)
 			require.NoError(t, err, "failed to create primary account")
 
-			appCtx, err := app.NewContext(net, primaryAccount, rules)
+			appCtx, err := app.NewContext(context.Background(), net, primaryAccount, rules)
 			require.NoError(t, err, "failed to create application context")
 
 			for name, test := range tests {
@@ -191,7 +191,7 @@ func TestGenerators_Subsidies(t *testing.T) {
 	primaryAccount, err := app.NewAccount(0, PrivateKey, FakeNetworkID)
 	require.NoError(t, err, "failed to create primary account")
 
-	appCtx, err := app.NewContext(net, primaryAccount, rules)
+	appCtx, err := app.NewContext(context.Background(), net, primaryAccount, rules)
 	require.NoError(t, err, "failed to create application context")
 
 	subsidiesApp, err := app.NewSubsidiesApplication(appCtx, 0, 0)

--- a/load/app/bls12_add_app_test.go
+++ b/load/app/bls12_add_app_test.go
@@ -57,7 +57,7 @@ func TestBls12AddApplication(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctxt, err := app.NewContext(net, primaryAccount, rules)
+	ctxt, err := app.NewContext(context.Background(), net, primaryAccount, rules)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/load/app/bundle_app_test.go
+++ b/load/app/bundle_app_test.go
@@ -38,7 +38,7 @@ func TestGenerators_Bundles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	appCtx, err := app.NewContext(net, primaryAccount, rules)
+	appCtx, err := app.NewContext(context.Background(), net, primaryAccount, rules)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/load/app/context.go
+++ b/load/app/context.go
@@ -52,15 +52,22 @@ type RpcClientFactory interface {
 }
 
 // NewContext initializes an application context bound to a random RPC client,
-// treasury account, and the scenario network rules patch.
-func NewContext(factory RpcClientFactory, treasury *Account, networkRules genesis.NetworkRulesPatch) (AppContext, error) {
+// treasury account, and the scenario network rules patch. The provided context
+// is used for the network operations performed through this app context, so
+// cancelling it (for example on a check failure or timeout) aborts pending
+// receipt waits and RPC calls.
+func NewContext(ctx context.Context, factory RpcClientFactory, treasury *Account, networkRules genesis.NetworkRulesPatch) (AppContext, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	rpcClient, err := factory.DialRandomRpc()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to network: %w", err)
 	}
 
-	// Create a context to interact with the network.
 	res := &appContext{
+		ctx:          ctx,
 		rpcClient:    rpcClient,
 		treasury:     treasury,
 		networkRules: networkRules,
@@ -70,6 +77,7 @@ func NewContext(factory RpcClientFactory, treasury *Account, networkRules genesi
 }
 
 type appContext struct {
+	ctx          context.Context  // < bounds network operations to the scenario lifetime
 	rpcClient    rpc.Client       // < access to the network
 	treasury     *Account         // < the account paying for management tasks
 	helper       *contract.Helper // < a contract used for on-chain operations
@@ -101,7 +109,7 @@ func (c *appContext) GetNetworkRules() genesis.NetworkRulesPatch {
 func (c *appContext) GetTransactOptions(account *Account) (*bind.TransactOpts, error) {
 	client := c.rpcClient
 
-	ctxt := context.Background()
+	ctxt := c.ctx
 	chainId, err := client.ChainID(ctxt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain ID: %w", err)
@@ -126,9 +134,10 @@ func (c *appContext) GetTransactOptions(account *Account) (*bind.TransactOpts, e
 	return txOpts, nil
 }
 
-// GetReceipt blocks until the receipt is available or the RPC client times out.
+// GetReceipt blocks until the receipt is available, the context is cancelled,
+// or the RPC client times out.
 func (c *appContext) GetReceipt(txHash common.Hash) (*types.Receipt, error) {
-	return c.rpcClient.WaitTransactionReceipt(context.Background(), txHash)
+	return c.rpcClient.WaitTransactionReceipt(c.ctx, txHash)
 }
 
 // Apply sends a transaction to the network using the network's validator account
@@ -189,7 +198,7 @@ func (c *appContext) FundAccounts(accounts []common.Address, value *big.Int) err
 		}
 		txs = append(txs, tx)
 
-		nonce, err := c.rpcClient.PendingNonceAt(context.Background(), c.GetTreasure().address)
+		nonce, err := c.rpcClient.PendingNonceAt(c.ctx, c.GetTreasure().address)
 		if err != nil {
 			return fmt.Errorf("failed to refresh pending nonce: %w", err)
 		}

--- a/load/app/context.go
+++ b/load/app/context.go
@@ -57,6 +57,10 @@ type RpcClientFactory interface {
 // cancelling it (for example on a check failure or timeout) aborts pending
 // receipt waits and RPC calls.
 func NewContext(ctx context.Context, factory RpcClientFactory, treasury *Account, networkRules genesis.NetworkRulesPatch) (AppContext, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context cannot be nil")
+	}
+
 	rpcClient, err := factory.DialRandomRpc()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to network: %w", err)

--- a/load/app/context.go
+++ b/load/app/context.go
@@ -57,10 +57,6 @@ type RpcClientFactory interface {
 // cancelling it (for example on a check failure or timeout) aborts pending
 // receipt waits and RPC calls.
 func NewContext(ctx context.Context, factory RpcClientFactory, treasury *Account, networkRules genesis.NetworkRulesPatch) (AppContext, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
 	rpcClient, err := factory.DialRandomRpc()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to network: %w", err)

--- a/load/app/context.go
+++ b/load/app/context.go
@@ -128,7 +128,7 @@ func (c *appContext) GetTransactOptions(account *Account) (*bind.TransactOpts, e
 
 // GetReceipt blocks until the receipt is available or the RPC client times out.
 func (c *appContext) GetReceipt(txHash common.Hash) (*types.Receipt, error) {
-	return c.rpcClient.WaitTransactionReceipt(txHash)
+	return c.rpcClient.WaitTransactionReceipt(context.Background(), txHash)
 }
 
 // Apply sends a transaction to the network using the network's validator account

--- a/load/app/context_test.go
+++ b/load/app/context_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -21,7 +22,7 @@ func TestNewContext_DoesNotDeployHelperContract(t *testing.T) {
 	// NewContext should succeed without any contract deployment calls.
 	// If it tried to deploy, it would call GetTransactOptions which needs
 	// ChainID, SuggestGasPrice, PendingNonceAt — none of which are mocked.
-	ctx, err := NewContext(factory, nil, genesis.NetworkRulesPatch{})
+	ctx, err := NewContext(context.Background(), factory, nil, genesis.NetworkRulesPatch{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -41,7 +42,7 @@ func TestFundAccounts_AttemptsToDeployHelperOnFirstCall(t *testing.T) {
 	factory := NewMockRpcClientFactory(ctrl)
 	factory.EXPECT().DialRandomRpc().Return(mockRpc, nil)
 
-	ctx, err := NewContext(factory, nil, genesis.NetworkRulesPatch{})
+	ctx, err := NewContext(context.Background(), factory, nil, genesis.NetworkRulesPatch{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/load/app/large_contract_app_test.go
+++ b/load/app/large_contract_app_test.go
@@ -17,6 +17,7 @@
 package app_test
 
 import (
+	"context"
 	"math/big"
 	"strings"
 	"testing"
@@ -60,7 +61,7 @@ func TestLargeContractDeploymentFailsWithoutBrio(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctxt, err := app.NewContext(net, primaryAccount, rules)
+	ctxt, err := app.NewContext(context.Background(), net, primaryAccount, rules)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/load/controller/controller_test.go
+++ b/load/controller/controller_test.go
@@ -85,7 +85,7 @@ func TestLoadGeneration_CanRealizeConstantTrafficShape(t *testing.T) {
 			clientFactory.EXPECT().DialRandomRpc().AnyTimes().Return(rpcClient, nil)
 
 			shaper := shaper.NewConstantShaper(float64(rate))
-			appContext, err := app.NewContext(clientFactory, treasure, driver.NetworkRules{})
+			appContext, err := app.NewContext(context.Background(), clientFactory, treasure, driver.NetworkRules{})
 			if err != nil {
 				t.Fatalf("failed to create app context: %v", err)
 			}

--- a/load/controller/controller_test.go
+++ b/load/controller/controller_test.go
@@ -67,7 +67,7 @@ func TestLoadGeneration_CanRealizeConstantTrafficShape(t *testing.T) {
 			rpcClient.EXPECT().PendingNonceAt(gomock.Any(), gomock.Any()).AnyTimes().Return(uint64(0), nil)
 			rpcClient.EXPECT().EstimateGas(gomock.Any(), gomock.Any()).AnyTimes().Return(uint64(100), nil)
 			rpcClient.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
-			rpcClient.EXPECT().WaitTransactionReceipt(gomock.Any()).AnyTimes().Return(&types.Receipt{
+			rpcClient.EXPECT().WaitTransactionReceipt(gomock.Any(), gomock.Any()).AnyTimes().Return(&types.Receipt{
 				Status: types.ReceiptStatusSuccessful,
 			}, nil)
 			rpcClient.EXPECT().Close().AnyTimes().Return()

--- a/load/controller/rpc_test.go
+++ b/load/controller/rpc_test.go
@@ -52,7 +52,7 @@ func TestTrafficGenerating(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	appContext, err := app.NewContext(net, primaryAccount, driver.NetworkRules{})
+	appContext, err := app.NewContext(context.Background(), net, primaryAccount, driver.NetworkRules{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR improves the behavior of norma in case of a failure or timeout. 
Several functions did not handle a canceled context correctly.
Checks now exit the scenario in case of a failure. 