### PR TITLE
Poll network rules check until all nodes converge

### DIFF
--- a/driver/checking/network_rules.go
+++ b/driver/checking/network_rules.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/monitoring"
@@ -15,9 +16,18 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// defaultNetworkRulesTimeout bounds how long Check waits for a rule update to
+// propagate to all nodes. Rules apply per node at the epoch seal, so a node
+// can briefly lag the one observed by waitForEpoch.
+const defaultNetworkRulesTimeout = 30 * time.Second
+
+// networkRulesPollInterval is the delay between convergence polls. Var so tests
+// can shorten it.
+var networkRulesPollInterval = 500 * time.Millisecond
+
 func init() {
 	RegisterNetworkCheck("networkRules", func(net driver.Network, monitor *monitoring.Monitor) Checker {
-		return &networkRulesChecker{net: net}
+		return &networkRulesChecker{net: net, timeout: defaultNetworkRulesTimeout}
 	})
 }
 
@@ -27,6 +37,8 @@ type networkRulesChecker struct {
 	net          driver.Network
 	rulesPatch   genesis.NetworkRulesPatch
 	configureErr error
+	// timeout bounds convergence polling. Zero means a single attempt.
+	timeout time.Duration
 }
 
 // Configure returns a copy of the checker with an optional rules patch from config.
@@ -39,6 +51,11 @@ func (c *networkRulesChecker) Configure(config CheckerConfig) Checker {
 		net:          c.net,
 		rulesPatch:   c.rulesPatch,
 		configureErr: c.configureErr,
+		timeout:      c.timeout,
+	}
+
+	if d, exist := config["duration"]; exist {
+		configured.timeout = time.Duration(d.(int64))
 	}
 
 	rules, exists := config["rules"]
@@ -65,6 +82,33 @@ func (c *networkRulesChecker) Check(ctx context.Context) error {
 		return nil
 	}
 
+	if c.timeout <= 0 {
+		return c.checkOnce(ctx)
+	}
+
+	deadline := time.Now().Add(c.timeout)
+	logged := false
+	for {
+		err := c.checkOnce(ctx)
+		if err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return err
+		}
+		if !logged {
+			slog.Info("network rules not yet applied on all nodes; waiting for convergence", "timeout", c.timeout)
+			logged = true
+		}
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(networkRulesPollInterval):
+		}
+	}
+}
+
+func (c *networkRulesChecker) checkOnce(ctx context.Context) error {
 	nodes := c.net.GetActiveNodes()
 	slog.Info("checking applied network rules for nodes", "count", len(nodes))
 

--- a/driver/checking/network_rules.go
+++ b/driver/checking/network_rules.go
@@ -54,10 +54,6 @@ func (c *networkRulesChecker) Configure(config CheckerConfig) Checker {
 		timeout:      c.timeout,
 	}
 
-	if d, exist := config["duration"]; exist {
-		configured.timeout = time.Duration(d.(int64))
-	}
-
 	rules, exists := config["rules"]
 	if !exists {
 		return configured
@@ -88,6 +84,9 @@ func (c *networkRulesChecker) Check(ctx context.Context) error {
 
 	deadline := time.Now().Add(c.timeout)
 	logged := false
+	ticker := time.NewTicker(networkRulesPollInterval)
+	defer ticker.Stop()
+
 	for {
 		err := c.checkOnce(ctx)
 		if err == nil {
@@ -102,8 +101,8 @@ func (c *networkRulesChecker) Check(ctx context.Context) error {
 		}
 		select {
 		case <-ctx.Done():
-			return err
-		case <-time.After(networkRulesPollInterval):
+			return ctx.Err()
+		case <-ticker.C:
 		}
 	}
 }

--- a/driver/checking/network_rules.go
+++ b/driver/checking/network_rules.go
@@ -3,7 +3,6 @@ package checking
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"maps"
 	"reflect"
 	"sort"
@@ -83,7 +82,6 @@ func (c *networkRulesChecker) Check(ctx context.Context) error {
 	}
 
 	deadline := time.Now().Add(c.timeout)
-	logged := false
 	ticker := time.NewTicker(networkRulesPollInterval)
 	defer ticker.Stop()
 
@@ -95,10 +93,6 @@ func (c *networkRulesChecker) Check(ctx context.Context) error {
 		if time.Now().After(deadline) {
 			return err
 		}
-		if !logged {
-			slog.Info("network rules not yet applied on all nodes; waiting for convergence", "timeout", c.timeout)
-			logged = true
-		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -109,7 +103,6 @@ func (c *networkRulesChecker) Check(ctx context.Context) error {
 
 func (c *networkRulesChecker) checkOnce(ctx context.Context) error {
 	nodes := c.net.GetActiveNodes()
-	slog.Info("checking applied network rules for nodes", "count", len(nodes))
 
 	expectedFailures := make(map[string]struct{})
 	gotFailures := make(map[string]struct{})

--- a/driver/checking/network_rules_test.go
+++ b/driver/checking/network_rules_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/rpc"
@@ -150,6 +151,70 @@ func TestNetworkRulesChecker_Check_ExpectedFailingNode(t *testing.T) {
 
 	if err := checker.Check(t.Context()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNetworkRulesChecker_Check_ConvergesAfterLag(t *testing.T) {
+	prev := networkRulesPollInterval
+	networkRulesPollInterval = time.Millisecond
+	defer func() { networkRulesPollInterval = prev }()
+
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	node := driver.NewMockNode(ctrl)
+	rpcClient := rpc.NewMockClient(ctrl)
+
+	old := opera.FakeNetRules(opera.GetSonicUpgrades())
+	updated := old
+	patch := genesis.NetworkRulesPatch{Blocks: &genesis.BlocksPatch{MaxBlockGas: new(uint64(20500000000))}}
+	if err := genesis.ApplyNetworkRulesPatch(&updated, patch); err != nil {
+		t.Fatalf("failed to prepare updated rules: %v", err)
+	}
+
+	net.EXPECT().GetActiveNodes().Return([]driver.Node{node}).AnyTimes()
+	node.EXPECT().IsExpectedFailure().AnyTimes().Return(false)
+	node.EXPECT().GetLabel().AnyTimes().Return("node-1")
+	node.EXPECT().DialRpc(gomock.Any()).Return(rpcClient, nil).AnyTimes()
+	rpcClient.EXPECT().Close().AnyTimes()
+	// The node reports the old rules first, then converges to the new ones.
+	gomock.InOrder(
+		rpcClient.EXPECT().GetNetworkRules("latest").Return(old, nil),
+		rpcClient.EXPECT().GetNetworkRules("latest").Return(updated, nil),
+	)
+
+	checker := &networkRulesChecker{net: net, rulesPatch: patch, timeout: 5 * time.Second}
+	if err := checker.Check(t.Context()); err != nil {
+		t.Fatalf("expected convergence, got: %v", err)
+	}
+}
+
+func TestNetworkRulesChecker_Check_ReturnsMismatchAfterTimeout(t *testing.T) {
+	prev := networkRulesPollInterval
+	networkRulesPollInterval = time.Millisecond
+	defer func() { networkRulesPollInterval = prev }()
+
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	node := driver.NewMockNode(ctrl)
+	rpcClient := rpc.NewMockClient(ctrl)
+
+	old := opera.FakeNetRules(opera.GetSonicUpgrades())
+
+	net.EXPECT().GetActiveNodes().Return([]driver.Node{node}).AnyTimes()
+	node.EXPECT().IsExpectedFailure().AnyTimes().Return(false)
+	node.EXPECT().GetLabel().AnyTimes().Return("node-1")
+	node.EXPECT().DialRpc(gomock.Any()).Return(rpcClient, nil).AnyTimes()
+	rpcClient.EXPECT().GetNetworkRules("latest").Return(old, nil).AnyTimes()
+	rpcClient.EXPECT().Close().AnyTimes()
+
+	checker := &networkRulesChecker{
+		net:        net,
+		rulesPatch: genesis.NetworkRulesPatch{Blocks: &genesis.BlocksPatch{MaxBlockGas: new(uint64(20500000000))}},
+		timeout:    20 * time.Millisecond,
+	}
+	err := checker.Check(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "applied network rules mismatch") {
+		t.Fatalf("expected mismatch error after timeout, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
The `networkRules` check took a single instantaneous snapshot of each node's applied rules. But a rules update applies per node at the epoch seal, and `waitForEpoch` only waits for one (random) node to advance, so immediately afterward a slower node can still report the pre-update rules.