### PR TITLE
Fix rules upgrade scenario

### DIFF
--- a/scenarios/rules_upgrades/allegro_to_brio_mixed_versions_v215_forks.yml
+++ b/scenarios/rules_upgrades/allegro_to_brio_mixed_versions_v215_forks.yml
@@ -25,6 +25,7 @@ Scenario:
     type: validator
     imageName: "sonic:v2.1.6"
     stake: 2000000
+    failing: true
 
   - startNode: validator-v215
     type: validator


### PR DESCRIPTION
The scenario enables brio, therefore nodes with sonic:v2.1.6 need to be marked as failing.