### PR TITLE
Ensure validators are actual validators

### DIFF
--- a/SCENARIO_SPECIFICATION.md
+++ b/SCENARIO_SPECIFICATION.md
@@ -430,6 +430,13 @@ function name or a mapping.
 > emission — a validator that just joined, or whose empty events the event
 > throttler suppresses, is a full member yet emits rarely. See
 > [`validators_are_really_validators.yml`](scenarios/examples/validators_are_really_validators.yml).
+>
+> Every running validator node has to be a member, so the check does not fit a
+> scenario that leaves one running after taking it out of the set: a node that
+> has been [`undelegate`](#4-step-functions)d but not yet stopped fails it, by
+> design, because it is no longer in the set. Place the check where the running
+> validators are the ones the scenario means to have, or use `failing: true` on
+> nodes that are expected to have left.
 
 ---
 

--- a/SCENARIO_SPECIFICATION.md
+++ b/SCENARIO_SPECIFICATION.md
@@ -470,23 +470,27 @@ and emits no events until the epoch it was created in is sealed. Left alone
 it would sit in the network as an observer while the genesis validators
 carried the whole consensus load.
 
-So `startNode` seals the epoch itself and then waits until the validators it
-registered are reported in the active set, failing the step if they never
-arrive. The seal happens *after* the new nodes are up and synced (§6.3),
-because a validator gains stake weight the moment it joins the set —
-admitting it earlier would deprive the network of that share of its online
-stake.
+So `startNode` reads the validator set, seals an epoch if a validator it
+started is missing from it, and waits until all of them are reported in it,
+failing the step if they never arrive. The seal happens *after* the new nodes
+are up and synced (§6.3), because a validator gains stake weight the moment it
+joins the set — admitting it earlier would deprive the network of that share
+of its online stake.
 
-Two cases register nothing and are therefore not affected: genesis
-validators, whose pre-assigned IDs are reused, and rejoins (a `startNode`
-reusing an earlier identifier), which keep their preserved validator ID and
-are already in the set.
+Membership is read rather than assumed, so a rejoin (a `startNode` reusing an
+earlier identifier) is held to the same guarantee as a first start. It keeps
+its preserved validator ID and normally is still in the set, which costs the
+scenario nothing but that read; if it is not — its stake was undelegated while
+it was down, say — the step fails instead of letting the node rejoin as an
+observer. Genesis validators, whose pre-assigned IDs are reused, are in the
+set from the first block and are not checked.
 
 A `startNode` with `failing: true` is registered but not activated, as it is
 also excluded from the waits of §6.2 and §6.3: a node that may never come up
 must not be the subject of an assertion. Such a validator joins at the next
-epoch the scenario seals, so the guarantee above covers working nodes only —
-which is also why [`validatorsActive`](#5-check-functions) skips them.
+epoch the scenario seals, or at the next `startNode` that has to seal one, so
+the guarantee above covers working nodes only — which is also why
+[`validatorsActive`](#5-check-functions) skips them.
 
 The [`validatorsActive`](#5-check-functions) check asserts this end to end.
 

--- a/SCENARIO_SPECIFICATION.md
+++ b/SCENARIO_SPECIFICATION.md
@@ -380,14 +380,15 @@ The canonical Go type is
 Checks appear as items inside a `checks:` step. Each entry is either a bare
 function name or a mapping.
 
-| Function         | Purpose                                                         | Parameters                       |
-| ---------------- | --------------------------------------------------------------- | -------------------------------- |
-| `blockGasRate`   | Assert block gas rate ≤ ceiling.                                | `ceiling`, `failing`             |
-| `blockHashes`    | Assert all nodes agree on block hashes.                         | `failing`                        |
-| `blockHeights`   | Assert all nodes are within tolerance of the same height.       | `tolerance`, `failing`           |
-| `blocksHalted`   | Assert block production has halted.                             | `failing`                        |
-| `blocksProduced` | Assert all nodes produce blocks within tolerance over duration. | `tolerance`, `duration`, `failing` |
-| `networkRules`   | Assert the active rules on all nodes match the given patch.     | `rules`, `failing`               |
+| Function           | Purpose                                                         | Parameters                       |
+| ------------------ | --------------------------------------------------------------- | -------------------------------- |
+| `blockGasRate`     | Assert block gas rate ≤ ceiling.                                | `ceiling`, `failing`             |
+| `blockHashes`      | Assert all nodes agree on block hashes.                         | `failing`                        |
+| `blockHeights`     | Assert all nodes are within tolerance of the same height.       | `tolerance`, `failing`           |
+| `blocksHalted`     | Assert block production has halted.                             | `failing`                        |
+| `blocksProduced`   | Assert all nodes produce blocks within tolerance over duration. | `tolerance`, `duration`, `failing` |
+| `networkRules`     | Assert the active rules on all nodes match the given patch.     | `rules`, `failing`               |
+| `validatorsActive` | Assert every running validator is in the epoch's validator set. | `failing`                        |
 
 ### Parameter reference
 
@@ -419,7 +420,16 @@ function name or a mapping.
             MaxEpochDuration: 10s
           Blocks:
             MaxBlockGas: 10_000_000_000
+    - validatorsActive
 ```
+
+> `validatorsActive` asserts the guarantee described in
+> [§6.4](#64-validator-activation): a node started as `type: validator` is
+> really a validator. It compares the running validator nodes against the
+> validator set of the epoch being built, rather than observing event
+> emission — a validator that just joined, or whose empty events the event
+> throttler suppresses, is a full member yet emits rarely. See
+> [`validators_are_really_validators.yml`](scenarios/examples/validators_are_really_validators.yml).
 
 ---
 
@@ -447,12 +457,38 @@ node to reach the current network block height before proceeding. This
 means the network must already have a live block source before adding
 observers or RPC nodes.
 
-### 6.4 Genesis validators
+### 6.4 Validator activation
 
-Nodes named in the genesis (via the driver’s genesis validator map) are
-started **without** an on-chain registration step, and their pre-assigned
-validator IDs are reused. This lets a scenario’s first `startNode` step
-simply reference a genesis validator by label.
+Every node started as `type: validator` is guaranteed to be a validator in
+the network by the time the step completes — a scenario needs no epoch
+handling of its own for that.
+
+Only the first `startNode` step forms the genesis validator set. A validator
+introduced by any later step is created in the SFC contract instead, and SFC
+validator sets are **per-epoch**: such a validator carries no stake weight
+and emits no events until the epoch it was created in is sealed. Left alone
+it would sit in the network as an observer while the genesis validators
+carried the whole consensus load.
+
+So `startNode` seals the epoch itself and then waits until the validators it
+registered are reported in the active set, failing the step if they never
+arrive. The seal happens *after* the new nodes are up and synced (§6.3),
+because a validator gains stake weight the moment it joins the set —
+admitting it earlier would deprive the network of that share of its online
+stake.
+
+Two cases register nothing and are therefore not affected: genesis
+validators, whose pre-assigned IDs are reused, and rejoins (a `startNode`
+reusing an earlier identifier), which keep their preserved validator ID and
+are already in the set.
+
+A `startNode` with `failing: true` is registered but not activated, as it is
+also excluded from the waits of §6.2 and §6.3: a node that may never come up
+must not be the subject of an assertion. Such a validator joins at the next
+epoch the scenario seals, so the guarantee above covers working nodes only —
+which is also why [`validatorsActive`](#5-check-functions) skips them.
+
+The [`validatorsActive`](#5-check-functions) check asserts this end to end.
 
 ### 6.5 Error surfaces
 

--- a/driver/checking/event_throttled.go
+++ b/driver/checking/event_throttled.go
@@ -190,7 +190,7 @@ func dialFirstReachable(
 			return client, nil
 		}
 	}
-	return nil, fmt.Errorf("no reachable node for DAG query")
+	return nil, fmt.Errorf("no reachable node among %d active nodes", len(nodes))
 }
 
 // rawEvent is the wire representation of a DAG event as returned by

--- a/driver/checking/validators_active.go
+++ b/driver/checking/validators_active.go
@@ -22,12 +22,24 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/monitoring"
 	"github.com/0xsoniclabs/norma/driver/network"
 	"github.com/0xsoniclabs/norma/driver/rpc"
 )
+
+// defaultValidatorsActiveTimeout bounds how long Check waits for the queried
+// node to report a validator set holding every running validator. The set is
+// written at the epoch seal and read per node, so a node that has just started,
+// or one that briefly lags the node which observed the seal, is behind for a
+// moment without anything being wrong.
+const defaultValidatorsActiveTimeout = 30 * time.Second
+
+// validatorsActivePollInterval is the delay between convergence polls. Var so
+// tests can shorten it.
+var validatorsActivePollInterval = 500 * time.Millisecond
 
 func init() {
 	RegisterNetworkCheck("validatorsActive",
@@ -40,6 +52,7 @@ func newValidatorsActiveChecker(net driver.Network) *validatorsActiveChecker {
 	return &validatorsActiveChecker{
 		net:                 net,
 		getActiveValidators: network.GetActiveValidatorIDs,
+		timeout:             defaultValidatorsActiveTimeout,
 	}
 }
 
@@ -61,39 +74,74 @@ type validatorsActiveChecker struct {
 	// getActiveValidators reads the current epoch's validator set.
 	// Overridable for tests.
 	getActiveValidators func(rpc.Client) ([]int, error)
+	// timeout bounds convergence polling. Zero means a single attempt.
+	timeout time.Duration
 }
 
 func (c *validatorsActiveChecker) Configure(CheckerConfig) Checker {
-	return c
+	return &validatorsActiveChecker{
+		net:                 c.net,
+		getActiveValidators: c.getActiveValidators,
+		timeout:             c.timeout,
+	}
 }
 
 func (c *validatorsActiveChecker) Check(ctx context.Context) error {
+	// Which nodes are running is the driver's own bookkeeping rather than
+	// network state, so these two failures are not something the network can
+	// converge out of and are reported without polling.
 	nodes := c.net.GetActiveNodes()
 	if len(nodes) == 0 {
 		return fmt.Errorf("no active nodes")
 	}
-
 	expected := expectedValidatorLabels(nodes)
 	if len(expected) == 0 {
 		return fmt.Errorf("no active validator nodes")
 	}
 
+	// The membership of a node in the set is on-chain state, so a disagreement
+	// is either permanent or a lag of at most a moment. Poll until it is gone,
+	// and only report what the deadline still finds.
+	deadline := time.Now().Add(c.timeout)
+	ticker := time.NewTicker(validatorsActivePollInterval)
+	defer ticker.Stop()
+
+	for {
+		active, err := c.readActiveValidators(ctx, nodes)
+		if err == nil {
+			err = verifyAllActive(expected, active)
+			if err == nil {
+				slog.Info("validator set",
+					"active_validators", active,
+					"running_validators", expected,
+				)
+				return nil
+			}
+		}
+		// A non-positive timeout leaves the deadline in the past, which makes
+		// this the single attempt such a checker is configured for.
+		if !time.Now().Before(deadline) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// readActiveValidators reads the validator set of the epoch currently being
+// built from the first node that answers.
+func (c *validatorsActiveChecker) readActiveValidators(
+	ctx context.Context, nodes []driver.Node,
+) ([]int, error) {
 	client, err := dialFirstReachable(ctx, nodes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer client.Close()
-
-	active, err := c.getActiveValidators(client)
-	if err != nil {
-		return err
-	}
-	slog.Info("validator set",
-		"active_validators", active,
-		"running_validators", expected,
-	)
-
-	return verifyAllActive(expected, active)
+	return c.getActiveValidators(client)
 }
 
 // expectedValidatorLabels maps the validator id of every running validator

--- a/driver/checking/validators_active.go
+++ b/driver/checking/validators_active.go
@@ -1,0 +1,133 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package checking
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+
+	"github.com/0xsoniclabs/norma/driver"
+	"github.com/0xsoniclabs/norma/driver/monitoring"
+	"github.com/0xsoniclabs/norma/driver/network"
+	"github.com/0xsoniclabs/norma/driver/rpc"
+)
+
+func init() {
+	RegisterNetworkCheck("validatorsActive",
+		func(net driver.Network, _ *monitoring.Monitor) Checker {
+			return newValidatorsActiveChecker(net)
+		})
+}
+
+func newValidatorsActiveChecker(net driver.Network) *validatorsActiveChecker {
+	return &validatorsActiveChecker{
+		net:                 net,
+		getActiveValidators: network.GetActiveValidatorIDs,
+	}
+}
+
+// validatorsActiveChecker verifies that every running validator node really
+// takes part in consensus, by requiring its validator id to appear in the
+// validator set of the epoch currently being built.
+//
+// Registering a validator in the SFC contract does not make it one: validator
+// sets are per-epoch, so a validator created mid-epoch carries no stake weight
+// until that epoch is sealed. A node missing from the set is an observer that
+// merely looks like a validator, and the remaining validators carry its share
+// of the consensus load.
+//
+// Membership is checked rather than observed event emission, which is a flaky
+// proxy: a validator that recently joined, or one whose empty events are
+// suppressed by the event throttler, is a full member yet emits rarely.
+type validatorsActiveChecker struct {
+	net driver.Network
+	// getActiveValidators reads the current epoch's validator set.
+	// Overridable for tests.
+	getActiveValidators func(rpc.Client) ([]int, error)
+}
+
+func (c *validatorsActiveChecker) Configure(CheckerConfig) Checker {
+	return c
+}
+
+func (c *validatorsActiveChecker) Check(ctx context.Context) error {
+	nodes := c.net.GetActiveNodes()
+	if len(nodes) == 0 {
+		return fmt.Errorf("no active nodes")
+	}
+
+	expected := expectedValidatorLabels(nodes)
+	if len(expected) == 0 {
+		return fmt.Errorf("no active validator nodes")
+	}
+
+	client, err := dialFirstReachable(ctx, nodes)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	active, err := c.getActiveValidators(client)
+	if err != nil {
+		return err
+	}
+	slog.Info("validator set",
+		"active_validators", active,
+		"running_validators", expected,
+	)
+
+	return verifyAllActive(expected, active)
+}
+
+// expectedValidatorLabels maps the validator id of every running validator
+// node to its label. Nodes expected to fail are skipped, since they may
+// legitimately have left the validator set already.
+func expectedValidatorLabels(nodes []driver.Node) map[int]string {
+	labels := make(map[int]string, len(nodes))
+	for _, n := range nodes {
+		if n.IsExpectedFailure() {
+			continue
+		}
+		if id := n.GetValidatorId(); id != nil {
+			labels[*id] = n.GetLabel()
+		}
+	}
+	return labels
+}
+
+// verifyAllActive fails when a running validator node is absent from the
+// current epoch's validator set.
+func verifyAllActive(expected map[int]string, active []int) error {
+	missing := make([]string, 0, len(expected))
+	for id, label := range expected {
+		if !slices.Contains(active, id) {
+			missing = append(missing, fmt.Sprintf("%s (validator %d)", label, id))
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	slices.Sort(missing)
+	return fmt.Errorf(
+		"%d of %d running validator nodes are not in the validator set and "+
+			"so take no part in consensus: %s; the active set is %v",
+		len(missing), len(expected), strings.Join(missing, ", "), active,
+	)
+}

--- a/driver/checking/validators_active.go
+++ b/driver/checking/validators_active.go
@@ -69,6 +69,12 @@ func newValidatorsActiveChecker(net driver.Network) *validatorsActiveChecker {
 // Membership is checked rather than observed event emission, which is a flaky
 // proxy: a validator that recently joined, or one whose empty events are
 // suppressed by the event throttler, is a full member yet emits rarely.
+//
+// The requirement runs in one direction only — every running validator node
+// must be in the set, not the reverse — but it does hold for all of them, so a
+// scenario that leaves a validator running after taking it out of the set fails
+// this check by design. An undelegated node that has not been stopped yet is
+// the usual case; nodes expected to fail are the one exemption.
 type validatorsActiveChecker struct {
 	net driver.Network
 	// getActiveValidators reads the current epoch's validator set.

--- a/driver/checking/validators_active_test.go
+++ b/driver/checking/validators_active_test.go
@@ -1,0 +1,189 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package checking
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/0xsoniclabs/norma/driver"
+	"github.com/0xsoniclabs/norma/driver/rpc"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestVerifyAllActive_Passes_WhenEveryValidatorIsInTheSet(t *testing.T) {
+	err := verifyAllActive(
+		map[int]string{1: "alpha", 2: "beta"},
+		[]int{1, 2, 3},
+	)
+	require.NoError(t, err)
+}
+
+func TestVerifyAllActive_Fails_WhenAValidatorIsNotInTheSet(t *testing.T) {
+	err := verifyAllActive(
+		map[int]string{1: "genesis-validator", 2: "joining-validator"},
+		[]int{1},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "1 of 2 running validator nodes")
+	require.Contains(t, err.Error(), "joining-validator (validator 2)")
+	require.Contains(t, err.Error(), "active set is [1]")
+	require.NotContains(t, err.Error(), "genesis-validator")
+}
+
+func TestVerifyAllActive_Fails_WhenTheSetIsEmpty(t *testing.T) {
+	err := verifyAllActive(map[int]string{1: "alpha", 2: "beta"}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "2 of 2 running validator nodes")
+}
+
+func TestVerifyAllActive_ListsMissingValidators_InStableOrder(t *testing.T) {
+	expected := map[int]string{1: "alpha", 2: "beta", 3: "gamma"}
+	for range 10 {
+		err := verifyAllActive(expected, []int{1})
+		require.Error(t, err)
+		require.Contains(t, err.Error(),
+			"beta (validator 2), gamma (validator 3)")
+	}
+}
+
+// A validator emitting rarely — because it just joined, or because the event
+// throttler suppresses its empty events — is still a full member.
+func TestVerifyAllActive_Passes_ForAMemberThatEmitsRarely(t *testing.T) {
+	require.NoError(t, verifyAllActive(
+		map[int]string{1: "alpha", 4: "joining-pair-1"},
+		[]int{1, 2, 3, 4},
+	))
+}
+
+func TestExpectedValidatorLabels_SkipsNonValidatorsAndExpectedFailures(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	validator := driver.NewMockNode(ctrl)
+	observer := driver.NewMockNode(ctrl)
+	failing := driver.NewMockNode(ctrl)
+
+	id := 1
+	validator.EXPECT().IsExpectedFailure().Return(false)
+	validator.EXPECT().GetValidatorId().Return(&id)
+	validator.EXPECT().GetLabel().Return("alpha")
+
+	observer.EXPECT().IsExpectedFailure().Return(false)
+	observer.EXPECT().GetValidatorId().Return(nil)
+
+	// An expected failure may legitimately have left the set, so it must not
+	// be consulted for a validator id at all.
+	failing.EXPECT().IsExpectedFailure().Return(true)
+
+	labels := expectedValidatorLabels(
+		[]driver.Node{validator, observer, failing},
+	)
+	require.Equal(t, map[int]string{1: "alpha"}, labels)
+}
+
+func TestValidatorsActiveChecker_Fails_WhenNetworkHasNoNodes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().GetActiveNodes().Return(nil)
+
+	err := newValidatorsActiveChecker(net).Check(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no active nodes")
+}
+
+func TestValidatorsActiveChecker_Fails_WhenNetworkHasNoValidators(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	observer := driver.NewMockNode(ctrl)
+	observer.EXPECT().IsExpectedFailure().Return(false)
+	observer.EXPECT().GetValidatorId().Return(nil)
+
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().GetActiveNodes().Return([]driver.Node{observer})
+
+	err := newValidatorsActiveChecker(net).Check(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no active validator nodes")
+}
+
+func TestValidatorsActiveChecker_ReportsValidatorMissingFromTheSet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	checker, client := checkerWithNodes(ctrl, map[int]string{
+		1: "genesis-validator",
+		2: "joining-validator",
+	})
+	client.EXPECT().Close()
+	checker.getActiveValidators = func(rpc.Client) ([]int, error) {
+		return []int{1}, nil
+	}
+
+	err := checker.Check(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "joining-validator (validator 2)")
+}
+
+func TestValidatorsActiveChecker_Passes_WhenAllValidatorsAreInTheSet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	checker, client := checkerWithNodes(ctrl, map[int]string{
+		1: "alpha", 2: "beta",
+	})
+	client.EXPECT().Close()
+	checker.getActiveValidators = func(rpc.Client) ([]int, error) {
+		return []int{1, 2}, nil
+	}
+
+	require.NoError(t, checker.Check(context.Background()))
+}
+
+func TestValidatorsActiveChecker_PropagatesValidatorSetReadFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	checker, client := checkerWithNodes(ctrl, map[int]string{1: "alpha"})
+	client.EXPECT().Close()
+	checker.getActiveValidators = func(rpc.Client) ([]int, error) {
+		return nil, fmt.Errorf("SFC unreachable")
+	}
+
+	err := checker.Check(context.Background())
+	require.ErrorContains(t, err, "SFC unreachable")
+}
+
+// checkerWithNodes builds a checker over a network of validator nodes with the
+// given validator id to label mapping, all reachable over the returned client.
+func checkerWithNodes(
+	ctrl *gomock.Controller, validators map[int]string,
+) (*validatorsActiveChecker, *rpc.MockClient) {
+	client := rpc.NewMockClient(ctrl)
+
+	nodes := make([]driver.Node, 0, len(validators))
+	for id, label := range validators {
+		id := id
+		node := driver.NewMockNode(ctrl)
+		node.EXPECT().IsExpectedFailure().Return(false).AnyTimes()
+		node.EXPECT().GetValidatorId().Return(&id)
+		node.EXPECT().GetLabel().Return(label)
+		// dialFirstReachable stops at the first node that answers, and the node
+		// order follows map iteration, so let any of them serve the dial.
+		node.EXPECT().DialRpc(gomock.Any()).Return(client, nil).AnyTimes()
+		nodes = append(nodes, node)
+	}
+
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().GetActiveNodes().Return(nodes)
+
+	checker := newValidatorsActiveChecker(net)
+	return checker, client
+}

--- a/driver/checking/validators_active_test.go
+++ b/driver/checking/validators_active_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/rpc"
@@ -122,11 +123,10 @@ func TestValidatorsActiveChecker_Fails_WhenNetworkHasNoValidators(t *testing.T) 
 
 func TestValidatorsActiveChecker_ReportsValidatorMissingFromTheSet(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	checker, client := checkerWithNodes(ctrl, map[int]string{
+	checker := checkerWithNodes(ctrl, map[int]string{
 		1: "genesis-validator",
 		2: "joining-validator",
 	})
-	client.EXPECT().Close()
 	checker.getActiveValidators = func(rpc.Client) ([]int, error) {
 		return []int{1}, nil
 	}
@@ -138,10 +138,9 @@ func TestValidatorsActiveChecker_ReportsValidatorMissingFromTheSet(t *testing.T)
 
 func TestValidatorsActiveChecker_Passes_WhenAllValidatorsAreInTheSet(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	checker, client := checkerWithNodes(ctrl, map[int]string{
+	checker := checkerWithNodes(ctrl, map[int]string{
 		1: "alpha", 2: "beta",
 	})
-	client.EXPECT().Close()
 	checker.getActiveValidators = func(rpc.Client) ([]int, error) {
 		return []int{1, 2}, nil
 	}
@@ -151,8 +150,7 @@ func TestValidatorsActiveChecker_Passes_WhenAllValidatorsAreInTheSet(t *testing.
 
 func TestValidatorsActiveChecker_PropagatesValidatorSetReadFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	checker, client := checkerWithNodes(ctrl, map[int]string{1: "alpha"})
-	client.EXPECT().Close()
+	checker := checkerWithNodes(ctrl, map[int]string{1: "alpha"})
 	checker.getActiveValidators = func(rpc.Client) ([]int, error) {
 		return nil, fmt.Errorf("SFC unreachable")
 	}
@@ -161,16 +159,92 @@ func TestValidatorsActiveChecker_PropagatesValidatorSetReadFailure(t *testing.T)
 	require.ErrorContains(t, err, "SFC unreachable")
 }
 
+// A node queried right after the epoch seal can still report the previous
+// validator set, which is a lag and not a validator sitting out consensus.
+func TestValidatorsActiveChecker_Passes_OnceALaggingNodeCatchesUp(t *testing.T) {
+	pollFast(t)
+	ctrl := gomock.NewController(t)
+	checker := checkerWithNodes(ctrl, map[int]string{1: "alpha", 2: "beta"})
+	checker.timeout = time.Minute
+
+	reads := 0
+	checker.getActiveValidators = func(rpc.Client) ([]int, error) {
+		reads++
+		if reads < 3 {
+			return []int{1}, nil
+		}
+		return []int{1, 2}, nil
+	}
+
+	require.NoError(t, checker.Check(context.Background()))
+	require.Equal(t, 3, reads)
+}
+
+func TestValidatorsActiveChecker_Fails_WhenTheLagOutlastsTheTimeout(t *testing.T) {
+	pollFast(t)
+	ctrl := gomock.NewController(t)
+	checker := checkerWithNodes(ctrl, map[int]string{1: "alpha", 2: "beta"})
+	checker.timeout = 100 * time.Millisecond
+
+	reads := 0
+	checker.getActiveValidators = func(rpc.Client) ([]int, error) {
+		reads++
+		return []int{1}, nil
+	}
+
+	err := checker.Check(context.Background())
+	require.ErrorContains(t, err, "beta (validator 2)")
+	require.Greater(t, reads, 1, "the check gave up without polling")
+}
+
+// A read failure is retried like any other disagreement: a node that is
+// restarting or briefly unresponsive recovers within the timeout.
+func TestValidatorsActiveChecker_Passes_OnceAFailingReadRecovers(t *testing.T) {
+	pollFast(t)
+	ctrl := gomock.NewController(t)
+	checker := checkerWithNodes(ctrl, map[int]string{1: "alpha"})
+	checker.timeout = time.Minute
+
+	reads := 0
+	checker.getActiveValidators = func(rpc.Client) ([]int, error) {
+		reads++
+		if reads < 2 {
+			return nil, fmt.Errorf("SFC unreachable")
+		}
+		return []int{1}, nil
+	}
+
+	require.NoError(t, checker.Check(context.Background()))
+}
+
+func TestValidatorsActiveChecker_Aborts_WhenTheContextIsCancelled(t *testing.T) {
+	pollFast(t)
+	ctrl := gomock.NewController(t)
+	checker := checkerWithNodes(ctrl, map[int]string{1: "alpha", 2: "beta"})
+	checker.timeout = time.Minute
+
+	ctx, cancel := context.WithCancel(context.Background())
+	checker.getActiveValidators = func(rpc.Client) ([]int, error) {
+		cancel()
+		return []int{1}, nil
+	}
+
+	require.ErrorIs(t, checker.Check(ctx), context.Canceled)
+}
+
 // checkerWithNodes builds a checker over a network of validator nodes with the
 // given validator id to label mapping, all reachable over the returned client.
+// The checker makes a single attempt; tests that exercise the convergence poll
+// set a timeout themselves.
 func checkerWithNodes(
 	ctrl *gomock.Controller, validators map[int]string,
-) (*validatorsActiveChecker, *rpc.MockClient) {
+) *validatorsActiveChecker {
 	client := rpc.NewMockClient(ctrl)
+	// Every read closes its client, and a polling checker reads repeatedly.
+	client.EXPECT().Close().MinTimes(1)
 
 	nodes := make([]driver.Node, 0, len(validators))
 	for id, label := range validators {
-		id := id
 		node := driver.NewMockNode(ctrl)
 		node.EXPECT().IsExpectedFailure().Return(false).AnyTimes()
 		node.EXPECT().GetValidatorId().Return(&id)
@@ -185,5 +259,14 @@ func checkerWithNodes(
 	net.EXPECT().GetActiveNodes().Return(nodes)
 
 	checker := newValidatorsActiveChecker(net)
-	return checker, client
+	checker.timeout = 0
+	return checker
+}
+
+// pollFast shortens the convergence poll interval for the duration of a test.
+func pollFast(t *testing.T) {
+	t.Helper()
+	original := validatorsActivePollInterval
+	validatorsActivePollInterval = time.Millisecond
+	t.Cleanup(func() { validatorsActivePollInterval = original })
 }

--- a/driver/executor/run.go
+++ b/driver/executor/run.go
@@ -309,6 +309,10 @@ func execStartNode(
 	// safe for concurrent use, so we do this before the parallel fan-out.
 	instanceNames := make([]string, instances)
 	validatorIds := make([]*int, instances)
+	// Validators newly created in the SFC contract by this step. They only
+	// join the validator set once the epoch is sealed, which happens below
+	// after their nodes are up.
+	registered := make([]int, 0, instances)
 	for instance := range instances {
 		instanceName := name
 		if instances > 1 {
@@ -336,6 +340,7 @@ func execStartNode(
 					)
 				}
 				validatorIds[instance] = &id
+				registered = append(registered, id)
 			}
 		}
 	}
@@ -392,6 +397,21 @@ func execStartNode(
 			if err := waitForNodeSync(ctx, node, targetBlock+1); err != nil {
 				slog.Warn("node sync wait failed", "node", node.GetLabel(), "error", err)
 			}
+		}
+	}
+
+	// Sealing happens only now that the nodes are up and synced: a validator
+	// gains stake weight the moment it joins the set, so admitting it earlier
+	// would deprive the network of that share of its online stake. Genesis
+	// validators and rejoins register nothing and are already in the set.
+	//
+	// Nodes expected to fail are left out, as they are for the sync wait above
+	// and the between-step block production wait: a node that may never come
+	// up must not be the subject of an assertion. They join at the next seal
+	// the scenario performs, as they did before activation existed.
+	if len(registered) > 0 && !step.Failing {
+		if err := registry.activateValidators(ctx, registered); err != nil {
+			return fmt.Errorf("failed to activate validators for %s: %w", name, err)
 		}
 	}
 
@@ -625,13 +645,14 @@ func execUpdateRules(ctx context.Context, step *parser.Step, net driver.Network)
 
 // checkFunctionToCheckerName maps check step functions to their checker names.
 var checkFunctionToCheckerName = map[parser.StepFunction]string{
-	parser.FuncCheckBlockGasRate:   "blockGasRate",
-	parser.FuncCheckBlockHashes:    "blocksHashes",
-	parser.FuncCheckBlockHeights:   "blockHeight",
-	parser.FuncCheckBlocksHalted:   "blocksHalted",
-	parser.FuncCheckBlocksProduced: "blocksRolling",
-	parser.FuncCheckEventThrottled: "eventThrottled",
-	parser.FuncCheckNetworkRules:   "networkRules",
+	parser.FuncCheckBlockGasRate:     "blockGasRate",
+	parser.FuncCheckBlockHashes:      "blocksHashes",
+	parser.FuncCheckBlockHeights:     "blockHeight",
+	parser.FuncCheckBlocksHalted:     "blocksHalted",
+	parser.FuncCheckBlocksProduced:   "blocksRolling",
+	parser.FuncCheckEventThrottled:   "eventThrottled",
+	parser.FuncCheckNetworkRules:     "networkRules",
+	parser.FuncCheckValidatorsActive: "validatorsActive",
 }
 
 // execCheck runs a named checker with configuration from the check spec.

--- a/driver/executor/run.go
+++ b/driver/executor/run.go
@@ -309,10 +309,12 @@ func execStartNode(
 	// safe for concurrent use, so we do this before the parallel fan-out.
 	instanceNames := make([]string, instances)
 	validatorIds := make([]*int, instances)
-	// Validators newly created in the SFC contract by this step. They only
-	// join the validator set once the epoch is sealed, which happens below
-	// after their nodes are up.
-	registered := make([]int, 0, instances)
+	// Validators this step has to see in the validator set before it completes:
+	// the ones it creates in the SFC contract, which only join once the epoch is
+	// sealed, and the ones a rejoining node brings back, which are expected to
+	// be in it already. Genesis validators are left out — they are in the set
+	// from the first block on.
+	mustBeActive := make([]int, 0, instances)
 	for instance := range instances {
 		instanceName := name
 		if instances > 1 {
@@ -328,6 +330,9 @@ func execStartNode(
 			if id, ok := state.validatorIds[instanceName]; ok {
 				// Reuse existing ID (genesis validator or rejoin).
 				validatorIds[instance] = &id
+				if isRejoin {
+					mustBeActive = append(mustBeActive, id)
+				}
 			} else if isRejoin {
 				return fmt.Errorf("validator %s is rejoining but has no preserved validator ID",
 					instanceName,
@@ -340,7 +345,7 @@ func execStartNode(
 					)
 				}
 				validatorIds[instance] = &id
-				registered = append(registered, id)
+				mustBeActive = append(mustBeActive, id)
 			}
 		}
 	}
@@ -400,17 +405,16 @@ func execStartNode(
 		}
 	}
 
-	// Sealing happens only now that the nodes are up and synced: a validator
+	// Activation happens only now that the nodes are up and synced: a validator
 	// gains stake weight the moment it joins the set, so admitting it earlier
-	// would deprive the network of that share of its online stake. Genesis
-	// validators and rejoins register nothing and are already in the set.
+	// would deprive the network of that share of its online stake.
 	//
 	// Nodes expected to fail are left out, as they are for the sync wait above
 	// and the between-step block production wait: a node that may never come
 	// up must not be the subject of an assertion. They join at the next seal
 	// the scenario performs, as they did before activation existed.
-	if len(registered) > 0 && !step.Failing {
-		if err := registry.activateValidators(ctx, registered); err != nil {
+	if len(mustBeActive) > 0 && !step.Failing {
+		if err := registry.ensureValidatorsActive(ctx, mustBeActive); err != nil {
 			return fmt.Errorf("failed to activate validators for %s: %w", name, err)
 		}
 	}

--- a/driver/executor/run_test.go
+++ b/driver/executor/run_test.go
@@ -61,6 +61,7 @@ func TestRun_StartAndStopNode(t *testing.T) {
 	gomock.InOrder(
 		registry.EXPECT().registerNewValidator(gomock.Any(), uint64(0)).Return(validatorId, nil),
 		net.EXPECT().CreateNode(gomock.Any()).Return(node, nil),
+		registry.EXPECT().activateValidators(gomock.Any(), []int{validatorId}).Return(nil),
 		node.EXPECT().GetValidatorId().Return(&validatorId),
 		registry.EXPECT().unregisterValidator(gomock.Any(), validatorId, gomock.Any()).Return(nil),
 		net.EXPECT().RemoveNode(node).Return(nil),
@@ -113,6 +114,8 @@ func TestRun_StartNode_ForwardsCustomStake(t *testing.T) {
 			registerNewValidator(gomock.Any(), customStake).
 			Return(validatorId, nil),
 		net.EXPECT().CreateNode(gomock.Any()).Return(node, nil),
+		registry.EXPECT().
+			activateValidators(gomock.Any(), []int{validatorId}).Return(nil),
 	)
 
 	stake := customStake
@@ -154,6 +157,8 @@ func TestRun_UndelegateSingleInstanceWithSuffix(t *testing.T) {
 		registry.EXPECT().registerNewValidator(gomock.Any(), uint64(0)).
 			Return(validatorId, nil),
 		net.EXPECT().CreateNode(gomock.Any()).Return(node, nil),
+		registry.EXPECT().
+			activateValidators(gomock.Any(), []int{validatorId}).Return(nil),
 		node.EXPECT().GetValidatorId().Return(&validatorId),
 		registry.EXPECT().
 			unregisterValidator(gomock.Any(), validatorId, uint64(0)).Return(nil),
@@ -223,6 +228,8 @@ func TestRun_UndelegateMultiInstance(t *testing.T) {
 				}
 				return node1, nil
 			}).Times(2)
+			// Both instances are admitted to the validator set by a single seal.
+			registry.EXPECT().activateValidators(gomock.Any(), []int{2, 3}).Return(nil)
 
 			if !tc.expectErr {
 				validatorId0 := 2
@@ -273,6 +280,7 @@ func TestRun_StopNodeWithoutUndelegate(t *testing.T) {
 	gomock.InOrder(
 		registry.EXPECT().registerNewValidator(gomock.Any(), gomock.Any()).Return(validatorId, nil),
 		net.EXPECT().CreateNode(gomock.Any()).Return(node, nil),
+		registry.EXPECT().activateValidators(gomock.Any(), []int{validatorId}).Return(nil),
 		// No unregister call expected
 		net.EXPECT().RemoveNode(node).Return(nil),
 		node.EXPECT().Stop(gomock.Any()).Return(nil),
@@ -323,11 +331,14 @@ func TestRun_RejoinNode(t *testing.T) {
 				t.Errorf("first start: expected ValidatorId=%d, got %v", validatorId, config.ValidatorId)
 			}
 		}).Return(node1, nil),
+		registry.EXPECT().activateValidators(gomock.Any(), []int{validatorId}).Return(nil),
 		// Stop without undelegate
 		net.EXPECT().RemoveNode(node1).Return(nil),
 		node1.EXPECT().Stop(gomock.Any()).Return(nil),
 		node1.EXPECT().Cleanup(gomock.Any()).Return(nil),
-		// Rejoin: no registration, but validator ID is preserved
+		// Rejoin: no registration, but validator ID is preserved. The
+		// validator is still in the set, so no further activation is
+		// expected — a second call would fail this test.
 		net.EXPECT().CreateNode(gomock.Any()).Do(func(config *driver.NodeConfig) {
 			if config.ValidatorId == nil || *config.ValidatorId != validatorId {
 				t.Errorf("rejoin: expected ValidatorId=%d, got %v", validatorId, config.ValidatorId)
@@ -531,6 +542,8 @@ func TestRun_MultiInstanceNode(t *testing.T) {
 			return nil, fmt.Errorf("unexpected node name %q", config.Name)
 		}
 	}).Times(2)
+
+	registry.EXPECT().activateValidators(gomock.Any(), []int{2, 3}).Return(nil)
 
 	instances := 2
 	scenario := parser.Scenario{

--- a/driver/executor/run_test.go
+++ b/driver/executor/run_test.go
@@ -61,7 +61,7 @@ func TestRun_StartAndStopNode(t *testing.T) {
 	gomock.InOrder(
 		registry.EXPECT().registerNewValidator(gomock.Any(), uint64(0)).Return(validatorId, nil),
 		net.EXPECT().CreateNode(gomock.Any()).Return(node, nil),
-		registry.EXPECT().activateValidators(gomock.Any(), []int{validatorId}).Return(nil),
+		registry.EXPECT().ensureValidatorsActive(gomock.Any(), []int{validatorId}).Return(nil),
 		node.EXPECT().GetValidatorId().Return(&validatorId),
 		registry.EXPECT().unregisterValidator(gomock.Any(), validatorId, gomock.Any()).Return(nil),
 		net.EXPECT().RemoveNode(node).Return(nil),
@@ -115,7 +115,7 @@ func TestRun_StartNode_ForwardsCustomStake(t *testing.T) {
 			Return(validatorId, nil),
 		net.EXPECT().CreateNode(gomock.Any()).Return(node, nil),
 		registry.EXPECT().
-			activateValidators(gomock.Any(), []int{validatorId}).Return(nil),
+			ensureValidatorsActive(gomock.Any(), []int{validatorId}).Return(nil),
 	)
 
 	stake := customStake
@@ -158,7 +158,7 @@ func TestRun_UndelegateSingleInstanceWithSuffix(t *testing.T) {
 			Return(validatorId, nil),
 		net.EXPECT().CreateNode(gomock.Any()).Return(node, nil),
 		registry.EXPECT().
-			activateValidators(gomock.Any(), []int{validatorId}).Return(nil),
+			ensureValidatorsActive(gomock.Any(), []int{validatorId}).Return(nil),
 		node.EXPECT().GetValidatorId().Return(&validatorId),
 		registry.EXPECT().
 			unregisterValidator(gomock.Any(), validatorId, uint64(0)).Return(nil),
@@ -229,7 +229,7 @@ func TestRun_UndelegateMultiInstance(t *testing.T) {
 				return node1, nil
 			}).Times(2)
 			// Both instances are admitted to the validator set by a single seal.
-			registry.EXPECT().activateValidators(gomock.Any(), []int{2, 3}).Return(nil)
+			registry.EXPECT().ensureValidatorsActive(gomock.Any(), []int{2, 3}).Return(nil)
 
 			if !tc.expectErr {
 				validatorId0 := 2
@@ -280,7 +280,7 @@ func TestRun_StopNodeWithoutUndelegate(t *testing.T) {
 	gomock.InOrder(
 		registry.EXPECT().registerNewValidator(gomock.Any(), gomock.Any()).Return(validatorId, nil),
 		net.EXPECT().CreateNode(gomock.Any()).Return(node, nil),
-		registry.EXPECT().activateValidators(gomock.Any(), []int{validatorId}).Return(nil),
+		registry.EXPECT().ensureValidatorsActive(gomock.Any(), []int{validatorId}).Return(nil),
 		// No unregister call expected
 		net.EXPECT().RemoveNode(node).Return(nil),
 		node.EXPECT().Stop(gomock.Any()).Return(nil),
@@ -331,19 +331,21 @@ func TestRun_RejoinNode(t *testing.T) {
 				t.Errorf("first start: expected ValidatorId=%d, got %v", validatorId, config.ValidatorId)
 			}
 		}).Return(node1, nil),
-		registry.EXPECT().activateValidators(gomock.Any(), []int{validatorId}).Return(nil),
+		registry.EXPECT().ensureValidatorsActive(gomock.Any(), []int{validatorId}).Return(nil),
 		// Stop without undelegate
 		net.EXPECT().RemoveNode(node1).Return(nil),
 		node1.EXPECT().Stop(gomock.Any()).Return(nil),
 		node1.EXPECT().Cleanup(gomock.Any()).Return(nil),
-		// Rejoin: no registration, but validator ID is preserved. The
-		// validator is still in the set, so no further activation is
-		// expected — a second call would fail this test.
+		// Rejoin: no registration, but validator ID is preserved.
 		net.EXPECT().CreateNode(gomock.Any()).Do(func(config *driver.NodeConfig) {
 			if config.ValidatorId == nil || *config.ValidatorId != validatorId {
 				t.Errorf("rejoin: expected ValidatorId=%d, got %v", validatorId, config.ValidatorId)
 			}
 		}).Return(node2, nil),
+		// The preserved validator is expected to be in the set, but that is
+		// checked rather than assumed: a node whose validator was undelegated
+		// while it was down would otherwise rejoin as an observer.
+		registry.EXPECT().ensureValidatorsActive(gomock.Any(), []int{validatorId}).Return(nil),
 	)
 
 	scenario := parser.Scenario{
@@ -543,7 +545,7 @@ func TestRun_MultiInstanceNode(t *testing.T) {
 		}
 	}).Times(2)
 
-	registry.EXPECT().activateValidators(gomock.Any(), []int{2, 3}).Return(nil)
+	registry.EXPECT().ensureValidatorsActive(gomock.Any(), []int{2, 3}).Return(nil)
 
 	instances := 2
 	scenario := parser.Scenario{

--- a/driver/executor/validator_registry.go
+++ b/driver/executor/validator_registry.go
@@ -19,6 +19,9 @@ package executor
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"slices"
+	"time"
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/network"
@@ -26,10 +29,15 @@ import (
 
 //go:generate mockgen -source validator_registry.go -destination validator_registry_mock.go -package executor
 
-// validatorRegistry abstracts how an executor registers and unregisters
-// validator nodes with the network.
+// validatorActivationTimeout bounds how long activateValidators waits for a
+// sealed epoch to propagate to the node it queries. Var so tests can shorten it.
+var validatorActivationTimeout = 30 * time.Second
+
+// validatorRegistry abstracts how an executor registers, activates and
+// unregisters validator nodes with the network.
 type validatorRegistry interface {
 	registerNewValidator(ctx context.Context, stake uint64) (int, error)
+	activateValidators(ctx context.Context, validatorIds []int) error
 	unregisterValidator(ctx context.Context, validatorId int, stake uint64) error
 }
 
@@ -51,6 +59,79 @@ func (a netBasedValidatorRegistry) registerNewValidator(ctx context.Context, sta
 		return 0, fmt.Errorf("failed to register validator node; %v", err)
 	}
 	return id, nil
+}
+
+// activateValidators seals the current epoch so that the given freshly
+// registered validators join the validator set, then waits until they are
+// reported as active.
+//
+// Registering a validator through the SFC contract is not enough to make it
+// part of consensus: validator sets are per-epoch, so a validator created
+// mid-epoch emits nothing and carries no stake weight until that epoch is
+// sealed. Sealing here is what makes a node started as "type: validator"
+// actually be a validator.
+func (a netBasedValidatorRegistry) activateValidators(ctx context.Context, validatorIds []int) error {
+	if len(validatorIds) == 0 {
+		return nil
+	}
+
+	if err := a.net.AdvanceEpoch(ctx, 1); err != nil {
+		return fmt.Errorf(
+			"failed to seal epoch to activate validators %v; %w",
+			validatorIds, err,
+		)
+	}
+
+	rpcClient, err := a.net.DialRandomRpc()
+	if err != nil {
+		return fmt.Errorf("failed to connect to RPC; %v", err)
+	}
+	defer rpcClient.Close()
+
+	// AdvanceEpoch confirms the seal on the node it dialed itself, which need
+	// not be the node queried here, so poll until the set has caught up. A
+	// failed read is treated like a set that has not caught up yet, since a
+	// node that is restarting or briefly unresponsive recovers well within the
+	// timeout; it is only reported once the deadline expires.
+	deadline := time.Now().Add(validatorActivationTimeout)
+	for {
+		active, readErr := network.GetActiveValidatorIDs(rpcClient)
+
+		missing := make([]int, 0, len(validatorIds))
+		for _, id := range validatorIds {
+			if !slices.Contains(active, id) {
+				missing = append(missing, id)
+			}
+		}
+		if readErr == nil && len(missing) == 0 {
+			slog.Info("validators joined the validator set",
+				"validators", validatorIds,
+				"active_validators", active,
+			)
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			if readErr != nil {
+				return fmt.Errorf(
+					"failed to read the validator set while waiting %s for "+
+						"validators %v to join; %w",
+					validatorActivationTimeout, validatorIds, readErr,
+				)
+			}
+			return fmt.Errorf(
+				"validators %v did not join the validator set within %s of "+
+					"sealing the epoch; active validators are %v",
+				missing, validatorActivationTimeout, active,
+			)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
 }
 
 func (a netBasedValidatorRegistry) unregisterValidator(ctx context.Context, validatorId int, stake uint64) error {

--- a/driver/executor/validator_registry.go
+++ b/driver/executor/validator_registry.go
@@ -29,7 +29,7 @@ import (
 
 //go:generate mockgen -source validator_registry.go -destination validator_registry_mock.go -package executor
 
-// validatorActivationTimeout bounds how long activateValidators waits for a
+// validatorActivationTimeout bounds how long ensureValidatorsActive waits for a
 // sealed epoch to propagate to the node it queries. Var so tests can shorten it.
 var validatorActivationTimeout = 30 * time.Second
 
@@ -37,7 +37,7 @@ var validatorActivationTimeout = 30 * time.Second
 // unregisters validator nodes with the network.
 type validatorRegistry interface {
 	registerNewValidator(ctx context.Context, stake uint64) (int, error)
-	activateValidators(ctx context.Context, validatorIds []int) error
+	ensureValidatorsActive(ctx context.Context, validatorIds []int) error
 	unregisterValidator(ctx context.Context, validatorId int, stake uint64) error
 }
 
@@ -61,18 +61,51 @@ func (a netBasedValidatorRegistry) registerNewValidator(ctx context.Context, sta
 	return id, nil
 }
 
-// activateValidators seals the current epoch so that the given freshly
-// registered validators join the validator set, then waits until they are
-// reported as active.
+// ensureValidatorsActive makes the given validators take part in consensus. It
+// seals the current epoch when any of them is missing from the validator set,
+// and returns once all of them are reported in it.
 //
 // Registering a validator through the SFC contract is not enough to make it
 // part of consensus: validator sets are per-epoch, so a validator created
 // mid-epoch emits nothing and carries no stake weight until that epoch is
 // sealed. Sealing here is what makes a node started as "type: validator"
 // actually be a validator.
-func (a netBasedValidatorRegistry) activateValidators(ctx context.Context, validatorIds []int) error {
+//
+// Membership is read rather than inferred from what was just registered, so
+// that the ones a caller only expects to be members are held to it too. A
+// rejoining node's validator is normally still in the set and then costs no
+// more than that read, but one whose stake was undelegated, or one registered
+// by a step that was allowed to fail, is not — and is admitted here instead of
+// silently running as an observer.
+func (a netBasedValidatorRegistry) ensureValidatorsActive(ctx context.Context, validatorIds []int) error {
 	if len(validatorIds) == 0 {
 		return nil
+	}
+
+	rpcClient, err := a.net.DialRandomRpc()
+	if err != nil {
+		return fmt.Errorf("failed to connect to RPC; %v", err)
+	}
+	defer rpcClient.Close()
+
+	if active, err := network.GetActiveValidatorIDs(rpcClient); err == nil &&
+		len(missingValidators(validatorIds, active)) == 0 {
+		slog.Info("validators are already in the validator set",
+			"validators", validatorIds,
+			"active_validators", active,
+		)
+		return nil
+	}
+
+	// Sealing an epoch means landing a transaction, which a network that is not
+	// producing blocks cannot do. Wait for a block first, as the advanceEpoch
+	// step does, so that a stalled network is reported as one rather than as a
+	// transaction that never got its receipt.
+	if err := waitForBlockProduction(ctx, a.net); err != nil {
+		return fmt.Errorf(
+			"no block produced to seal an epoch on for validators %v; %w",
+			validatorIds, err,
+		)
 	}
 
 	if err := a.net.AdvanceEpoch(ctx, 1); err != nil {
@@ -82,12 +115,6 @@ func (a netBasedValidatorRegistry) activateValidators(ctx context.Context, valid
 		)
 	}
 
-	rpcClient, err := a.net.DialRandomRpc()
-	if err != nil {
-		return fmt.Errorf("failed to connect to RPC; %v", err)
-	}
-	defer rpcClient.Close()
-
 	// AdvanceEpoch confirms the seal on the node it dialed itself, which need
 	// not be the node queried here, so poll until the set has caught up. A
 	// failed read is treated like a set that has not caught up yet, since a
@@ -96,13 +123,7 @@ func (a netBasedValidatorRegistry) activateValidators(ctx context.Context, valid
 	deadline := time.Now().Add(validatorActivationTimeout)
 	for {
 		active, readErr := network.GetActiveValidatorIDs(rpcClient)
-
-		missing := make([]int, 0, len(validatorIds))
-		for _, id := range validatorIds {
-			if !slices.Contains(active, id) {
-				missing = append(missing, id)
-			}
-		}
+		missing := missingValidators(validatorIds, active)
 		if readErr == nil && len(missing) == 0 {
 			slog.Info("validators joined the validator set",
 				"validators", validatorIds,
@@ -132,6 +153,18 @@ func (a netBasedValidatorRegistry) activateValidators(ctx context.Context, valid
 		case <-time.After(200 * time.Millisecond):
 		}
 	}
+}
+
+// missingValidators returns the ids from want that the given validator set does
+// not contain, preserving the order they were asked for in.
+func missingValidators(want, active []int) []int {
+	missing := make([]int, 0, len(want))
+	for _, id := range want {
+		if !slices.Contains(active, id) {
+			missing = append(missing, id)
+		}
+	}
+	return missing
 }
 
 func (a netBasedValidatorRegistry) unregisterValidator(ctx context.Context, validatorId int, stake uint64) error {

--- a/driver/executor/validator_registry_mock.go
+++ b/driver/executor/validator_registry_mock.go
@@ -40,6 +40,20 @@ func (m *MockvalidatorRegistry) EXPECT() *MockvalidatorRegistryMockRecorder {
 	return m.recorder
 }
 
+// activateValidators mocks base method.
+func (m *MockvalidatorRegistry) activateValidators(ctx context.Context, validatorIds []int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "activateValidators", ctx, validatorIds)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// activateValidators indicates an expected call of activateValidators.
+func (mr *MockvalidatorRegistryMockRecorder) activateValidators(ctx, validatorIds any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "activateValidators", reflect.TypeOf((*MockvalidatorRegistry)(nil).activateValidators), ctx, validatorIds)
+}
+
 // registerNewValidator mocks base method.
 func (m *MockvalidatorRegistry) registerNewValidator(ctx context.Context, stake uint64) (int, error) {
 	m.ctrl.T.Helper()

--- a/driver/executor/validator_registry_mock.go
+++ b/driver/executor/validator_registry_mock.go
@@ -40,18 +40,18 @@ func (m *MockvalidatorRegistry) EXPECT() *MockvalidatorRegistryMockRecorder {
 	return m.recorder
 }
 
-// activateValidators mocks base method.
-func (m *MockvalidatorRegistry) activateValidators(ctx context.Context, validatorIds []int) error {
+// ensureValidatorsActive mocks base method.
+func (m *MockvalidatorRegistry) ensureValidatorsActive(ctx context.Context, validatorIds []int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "activateValidators", ctx, validatorIds)
+	ret := m.ctrl.Call(m, "ensureValidatorsActive", ctx, validatorIds)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// activateValidators indicates an expected call of activateValidators.
-func (mr *MockvalidatorRegistryMockRecorder) activateValidators(ctx, validatorIds any) *gomock.Call {
+// ensureValidatorsActive indicates an expected call of ensureValidatorsActive.
+func (mr *MockvalidatorRegistryMockRecorder) ensureValidatorsActive(ctx, validatorIds any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "activateValidators", reflect.TypeOf((*MockvalidatorRegistry)(nil).activateValidators), ctx, validatorIds)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ensureValidatorsActive", reflect.TypeOf((*MockvalidatorRegistry)(nil).ensureValidatorsActive), ctx, validatorIds)
 }
 
 // registerNewValidator mocks base method.

--- a/driver/executor/validator_registry_test.go
+++ b/driver/executor/validator_registry_test.go
@@ -30,77 +30,144 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestActivateValidators_DoesNothing_WhenNothingWasRegistered(t *testing.T) {
+func TestEnsureValidatorsActive_DoesNothing_WhenNoValidatorIsGiven(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	// Any call on the network would be an unexpected call on this mock.
 	net := driver.NewMockNetwork(ctrl)
 
 	registry := netBasedValidatorRegistry{net: net}
-	require.NoError(t, registry.activateValidators(context.Background(), nil))
+	require.NoError(t, registry.ensureValidatorsActive(context.Background(), nil))
 }
 
-func TestActivateValidators_Fails_WhenEpochCannotBeSealed(t *testing.T) {
+func TestEnsureValidatorsActive_Fails_WhenNoNodeIsReachable(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	net := driver.NewMockNetwork(ctrl)
-	net.EXPECT().AdvanceEpoch(gomock.Any(), 1).
-		Return(fmt.Errorf("network is halted"))
-
-	registry := netBasedValidatorRegistry{net: net}
-	err := registry.activateValidators(context.Background(), []int{2, 3})
-	require.ErrorContains(t, err, "[2 3]")
-	require.ErrorContains(t, err, "network is halted")
-}
-
-func TestActivateValidators_Fails_WhenNoNodeIsReachable(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	net := driver.NewMockNetwork(ctrl)
-	net.EXPECT().AdvanceEpoch(gomock.Any(), 1).Return(nil)
+	// Without a node to ask, there is nothing to seal an epoch for either.
 	net.EXPECT().DialRandomRpc().Return(nil, fmt.Errorf("no nodes"))
 
 	registry := netBasedValidatorRegistry{net: net}
-	err := registry.activateValidators(context.Background(), []int{2})
+	err := registry.ensureValidatorsActive(context.Background(), []int{2})
 	require.ErrorContains(t, err, "no nodes")
 }
 
-func TestActivateValidators_Succeeds_WhenValidatorsAreInTheActiveSet(t *testing.T) {
+// The case of a rejoining node, whose validator never left the set: reading it
+// is enough, and sealing an epoch for it would cost the scenario an epoch it
+// did not ask for. An AdvanceEpoch call would be unexpected on this mock.
+func TestEnsureValidatorsActive_SealsNothing_WhenValidatorsAreAlreadyInTheSet(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	set := []int64{1, 2, 3}
+	client := sfcClientReporting(t, ctrl, 7, &set)
 	net := driver.NewMockNetwork(ctrl)
-	client := sfcClientReporting(t, ctrl, 7, []int64{1, 2, 3})
-	net.EXPECT().AdvanceEpoch(gomock.Any(), 1).Return(nil)
 	net.EXPECT().DialRandomRpc().Return(client, nil)
-	client.EXPECT().Close()
 
 	registry := netBasedValidatorRegistry{net: net}
 	require.NoError(t,
-		registry.activateValidators(context.Background(), []int{2, 3}))
+		registry.ensureValidatorsActive(context.Background(), []int{2, 3}))
 }
 
-func TestActivateValidators_Fails_WhenAValidatorNeverJoinsTheSet(t *testing.T) {
+func TestEnsureValidatorsActive_SealsAnEpoch_WhenAValidatorIsMissing(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	// Validator 3 has been registered but not yet admitted to the set.
+	set := []int64{1, 2}
+	client := sfcClientReporting(t, ctrl, 7, &set)
+	client.EXPECT().BlockNumber(gomock.Any()).
+		DoAndReturn(growingBlockHeight()).AnyTimes()
 	net := driver.NewMockNetwork(ctrl)
-	// Validator 3 is missing from the sealed epoch's validator set.
-	client := sfcClientReporting(t, ctrl, 7, []int64{1, 2})
+	net.EXPECT().DialRandomRpc().Return(client, nil).AnyTimes()
+	net.EXPECT().AdvanceEpoch(gomock.Any(), 1).
+		DoAndReturn(func(context.Context, int) error {
+			set = append(set, 3)
+			return nil
+		})
+
+	registry := netBasedValidatorRegistry{net: net}
+	require.NoError(t,
+		registry.ensureValidatorsActive(context.Background(), []int{2, 3}))
+}
+
+// Sealing an epoch means landing a transaction, so a network that is not
+// producing blocks is reported as such instead of as a missing receipt.
+func TestEnsureValidatorsActive_Fails_WhenNoBlockIsProduced(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	set := []int64{1}
+	client := sfcClientReporting(t, ctrl, 7, &set)
+	client.EXPECT().BlockNumber(gomock.Any()).
+		Return(uint64(0), fmt.Errorf("network is halted"))
+	net := driver.NewMockNetwork(ctrl)
+	// No AdvanceEpoch: the seal is never attempted.
+	net.EXPECT().DialRandomRpc().Return(client, nil).AnyTimes()
+
+	registry := netBasedValidatorRegistry{net: net}
+	err := registry.ensureValidatorsActive(context.Background(), []int{2})
+	require.ErrorContains(t, err, "no block produced to seal an epoch on")
+	require.ErrorContains(t, err, "[2]")
+	require.ErrorContains(t, err, "network is halted")
+}
+
+func TestEnsureValidatorsActive_Fails_WhenEpochCannotBeSealed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	set := []int64{1}
+	client := sfcClientReporting(t, ctrl, 7, &set)
+	client.EXPECT().BlockNumber(gomock.Any()).
+		DoAndReturn(growingBlockHeight()).AnyTimes()
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().DialRandomRpc().Return(client, nil).AnyTimes()
+	net.EXPECT().AdvanceEpoch(gomock.Any(), 1).
+		Return(fmt.Errorf("epoch seal rejected"))
+
+	registry := netBasedValidatorRegistry{net: net}
+	err := registry.ensureValidatorsActive(context.Background(), []int{2, 3})
+	require.ErrorContains(t, err, "[2 3]")
+	require.ErrorContains(t, err, "epoch seal rejected")
+}
+
+// A validator that is missing and stays missing after the seal — undelegated,
+// say — is reported instead of quietly running as an observer.
+func TestEnsureValidatorsActive_Fails_WhenAValidatorNeverJoinsTheSet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	set := []int64{1, 2}
+	client := sfcClientReporting(t, ctrl, 7, &set)
+	client.EXPECT().BlockNumber(gomock.Any()).
+		DoAndReturn(growingBlockHeight()).AnyTimes()
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().DialRandomRpc().Return(client, nil).AnyTimes()
 	net.EXPECT().AdvanceEpoch(gomock.Any(), 1).Return(nil)
-	net.EXPECT().DialRandomRpc().Return(client, nil)
-	client.EXPECT().Close()
 
 	// Negative, so the deadline is unambiguously in the past after the first
 	// poll and the test does not depend on the clock advancing.
 	original := validatorActivationTimeout
 	validatorActivationTimeout = -1
-	defer func() { validatorActivationTimeout = original }()
+	t.Cleanup(func() { validatorActivationTimeout = original })
 
 	registry := netBasedValidatorRegistry{net: net}
-	err := registry.activateValidators(context.Background(), []int{2, 3})
+	err := registry.ensureValidatorsActive(context.Background(), []int{2, 3})
 	require.ErrorContains(t, err, "validators [3] did not join")
 	require.ErrorContains(t, err, "active validators are [1 2]")
 }
 
+func TestMissingValidators_ReportsWhatTheSetDoesNotHold(t *testing.T) {
+	require.Empty(t, missingValidators([]int{2, 3}, []int{1, 2, 3}))
+	require.Equal(t, []int{3}, missingValidators([]int{2, 3}, []int{1, 2}))
+	require.Equal(t, []int{2, 3}, missingValidators([]int{2, 3}, nil))
+}
+
+// growingBlockHeight answers BlockNumber with an ever-growing height, which is
+// what waitForBlockProduction waits for.
+func growingBlockHeight() func(context.Context) (uint64, error) {
+	height := uint64(0)
+	return func(context.Context) (uint64, error) {
+		height++
+		return height, nil
+	}
+}
+
 // sfcClientReporting returns an RPC client mock that answers SFC
 // currentEpoch() and getEpochValidatorIDs() calls with the given values, so
-// that network.GetActiveValidatorIDs sees the described validator set.
+// that network.GetActiveValidatorIDs sees the described validator set. The
+// validator set is read through the pointer on every call, so a test can let an
+// epoch seal change it.
 func sfcClientReporting(
-	t *testing.T, ctrl *gomock.Controller, epoch int64, validators []int64,
+	t *testing.T, ctrl *gomock.Controller, epoch int64, validators *[]int64,
 ) *rpc.MockClient {
 	t.Helper()
 
@@ -113,14 +180,9 @@ func sfcClientReporting(
 	epochOut, err := currentEpoch.Outputs.Pack(big.NewInt(epoch))
 	require.NoError(t, err)
 
-	ids := make([]*big.Int, 0, len(validators))
-	for _, v := range validators {
-		ids = append(ids, big.NewInt(v))
-	}
-	validatorsOut, err := epochValidators.Outputs.Pack(ids)
-	require.NoError(t, err)
-
 	client := rpc.NewMockClient(ctrl)
+	// The set is read once per attempt, and every read closes its client.
+	client.EXPECT().Close().MinTimes(1)
 	client.EXPECT().CodeAt(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return([]byte{1}, nil).AnyTimes()
 	client.EXPECT().
@@ -134,7 +196,11 @@ func sfcClientReporting(
 				return epochOut, nil
 			case len(call.Data) >= 4 &&
 				string(call.Data[:4]) == string(epochValidators.ID):
-				return validatorsOut, nil
+				ids := make([]*big.Int, 0, len(*validators))
+				for _, v := range *validators {
+					ids = append(ids, big.NewInt(v))
+				}
+				return epochValidators.Outputs.Pack(ids)
 			}
 			return nil, fmt.Errorf("unexpected contract call")
 		}).AnyTimes()

--- a/driver/executor/validator_registry_test.go
+++ b/driver/executor/validator_registry_test.go
@@ -1,0 +1,142 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package executor
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/norma/driver"
+	"github.com/0xsoniclabs/norma/driver/rpc"
+	"github.com/0xsoniclabs/sonic/gossip/contract/sfc100"
+	"github.com/ethereum/go-ethereum"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestActivateValidators_DoesNothing_WhenNothingWasRegistered(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	// Any call on the network would be an unexpected call on this mock.
+	net := driver.NewMockNetwork(ctrl)
+
+	registry := netBasedValidatorRegistry{net: net}
+	require.NoError(t, registry.activateValidators(context.Background(), nil))
+}
+
+func TestActivateValidators_Fails_WhenEpochCannotBeSealed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().AdvanceEpoch(gomock.Any(), 1).
+		Return(fmt.Errorf("network is halted"))
+
+	registry := netBasedValidatorRegistry{net: net}
+	err := registry.activateValidators(context.Background(), []int{2, 3})
+	require.ErrorContains(t, err, "[2 3]")
+	require.ErrorContains(t, err, "network is halted")
+}
+
+func TestActivateValidators_Fails_WhenNoNodeIsReachable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().AdvanceEpoch(gomock.Any(), 1).Return(nil)
+	net.EXPECT().DialRandomRpc().Return(nil, fmt.Errorf("no nodes"))
+
+	registry := netBasedValidatorRegistry{net: net}
+	err := registry.activateValidators(context.Background(), []int{2})
+	require.ErrorContains(t, err, "no nodes")
+}
+
+func TestActivateValidators_Succeeds_WhenValidatorsAreInTheActiveSet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	client := sfcClientReporting(t, ctrl, 7, []int64{1, 2, 3})
+	net.EXPECT().AdvanceEpoch(gomock.Any(), 1).Return(nil)
+	net.EXPECT().DialRandomRpc().Return(client, nil)
+	client.EXPECT().Close()
+
+	registry := netBasedValidatorRegistry{net: net}
+	require.NoError(t,
+		registry.activateValidators(context.Background(), []int{2, 3}))
+}
+
+func TestActivateValidators_Fails_WhenAValidatorNeverJoinsTheSet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	// Validator 3 is missing from the sealed epoch's validator set.
+	client := sfcClientReporting(t, ctrl, 7, []int64{1, 2})
+	net.EXPECT().AdvanceEpoch(gomock.Any(), 1).Return(nil)
+	net.EXPECT().DialRandomRpc().Return(client, nil)
+	client.EXPECT().Close()
+
+	// Negative, so the deadline is unambiguously in the past after the first
+	// poll and the test does not depend on the clock advancing.
+	original := validatorActivationTimeout
+	validatorActivationTimeout = -1
+	defer func() { validatorActivationTimeout = original }()
+
+	registry := netBasedValidatorRegistry{net: net}
+	err := registry.activateValidators(context.Background(), []int{2, 3})
+	require.ErrorContains(t, err, "validators [3] did not join")
+	require.ErrorContains(t, err, "active validators are [1 2]")
+}
+
+// sfcClientReporting returns an RPC client mock that answers SFC
+// currentEpoch() and getEpochValidatorIDs() calls with the given values, so
+// that network.GetActiveValidatorIDs sees the described validator set.
+func sfcClientReporting(
+	t *testing.T, ctrl *gomock.Controller, epoch int64, validators []int64,
+) *rpc.MockClient {
+	t.Helper()
+
+	sfcAbi, err := sfc100.ContractMetaData.GetAbi()
+	require.NoError(t, err)
+
+	currentEpoch := sfcAbi.Methods["currentEpoch"]
+	epochValidators := sfcAbi.Methods["getEpochValidatorIDs"]
+
+	epochOut, err := currentEpoch.Outputs.Pack(big.NewInt(epoch))
+	require.NoError(t, err)
+
+	ids := make([]*big.Int, 0, len(validators))
+	for _, v := range validators {
+		ids = append(ids, big.NewInt(v))
+	}
+	validatorsOut, err := epochValidators.Outputs.Pack(ids)
+	require.NoError(t, err)
+
+	client := rpc.NewMockClient(ctrl)
+	client.EXPECT().CodeAt(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]byte{1}, nil).AnyTimes()
+	client.EXPECT().
+		CallContract(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(
+			_ context.Context, call ethereum.CallMsg, _ *big.Int,
+		) ([]byte, error) {
+			switch {
+			case len(call.Data) >= 4 &&
+				string(call.Data[:4]) == string(currentEpoch.ID):
+				return epochOut, nil
+			case len(call.Data) >= 4 &&
+				string(call.Data[:4]) == string(epochValidators.ID):
+				return validatorsOut, nil
+			}
+			return nil, fmt.Errorf("unexpected contract call")
+		}).AnyTimes()
+	return client
+}

--- a/driver/network/epoch.go
+++ b/driver/network/epoch.go
@@ -123,29 +123,62 @@ func GetCurrentEpoch(client rpc.Client) (hexutil.Uint64, error) {
 	return currentEpoch, nil
 }
 
+// GetActiveValidatorIDs returns the ids of the validators taking part in
+// consensus in the epoch currently being built. SFC validator sets are
+// per-epoch: a validator registered mid-epoch is absent from this set until
+// that epoch is sealed.
+func GetActiveValidatorIDs(client rpc.Client) ([]int, error) {
+	sfcContract, err := sfc100.NewContract(sfc.ContractAddress, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get SFC contract representation; %v", err)
+	}
+
+	epoch, err := sfcContract.CurrentEpoch(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current epoch: %w", err)
+	}
+
+	return getValidatorIDsOfEpoch(sfcContract, epoch)
+}
+
+// getValidatorIDsOfEpoch returns the ids of the validators of the given epoch.
+// Callers that already know the epoch use this to avoid reading it twice, which
+// would let the two reads straddle a seal and report a mismatched pair.
+func getValidatorIDsOfEpoch(
+	sfcContract *sfc100.Contract, epoch *big.Int,
+) ([]int, error) {
+	validators, err := sfcContract.GetEpochValidatorIDs(nil, epoch)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get epoch validator IDs for epoch %v: %w", epoch, err,
+		)
+	}
+
+	ids := make([]int, 0, len(validators))
+	for _, id := range validators {
+		ids = append(ids, int(id.Int64()))
+	}
+	return ids, nil
+}
+
 func logEpochSummary(client rpc.Client) {
 	// get a representation of the deployed contract
-	sfc, err := sfc100.NewContract(sfc.ContractAddress, client)
+	sfcContract, err := sfc100.NewContract(sfc.ContractAddress, client)
 	if err != nil {
 		slog.Error("failed to get SFC contract representation", "error", err)
 		return
 	}
 
-	epoch, err := sfc.CurrentEpoch(nil)
+	epoch, err := sfcContract.CurrentEpoch(nil)
 	if err != nil {
 		slog.Error("failed to get current epoch", "error", err)
 		return
 	}
 
-	validators, err := sfc.GetEpochValidatorIDs(nil, epoch)
+	validatorIds, err := getValidatorIDsOfEpoch(sfcContract, epoch)
 	if err != nil {
-		slog.Error("failed to get epoch validator IDs", "epoch", epoch, "error", err)
+		slog.Error("failed to get active validators", "error", err)
 		return
-	}
-
-	validatorIds := []int{}
-	for _, id := range validators {
-		validatorIds = append(validatorIds, int(id.Int64()))
 	}
 
 	slog.Info("epoch summary",

--- a/driver/parser/scenario.go
+++ b/driver/parser/scenario.go
@@ -46,13 +46,14 @@ const (
 	FuncWaitFor      StepFunction = "waitFor"
 
 	// Check functions used as items inside a checks: step.
-	FuncCheckBlockGasRate   StepFunction = "blockGasRate"
-	FuncCheckBlockHashes    StepFunction = "blockHashes"
-	FuncCheckBlockHeights   StepFunction = "blockHeights"
-	FuncCheckBlocksHalted   StepFunction = "blocksHalted"
-	FuncCheckBlocksProduced StepFunction = "blocksProduced"
-	FuncCheckEventThrottled StepFunction = "eventThrottled"
-	FuncCheckNetworkRules   StepFunction = "networkRules"
+	FuncCheckBlockGasRate     StepFunction = "blockGasRate"
+	FuncCheckBlockHashes      StepFunction = "blockHashes"
+	FuncCheckBlockHeights     StepFunction = "blockHeights"
+	FuncCheckBlocksHalted     StepFunction = "blocksHalted"
+	FuncCheckBlocksProduced   StepFunction = "blocksProduced"
+	FuncCheckEventThrottled   StepFunction = "eventThrottled"
+	FuncCheckNetworkRules     StepFunction = "networkRules"
+	FuncCheckValidatorsActive StepFunction = "validatorsActive"
 )
 
 // allStepFunctions lists every known top-level step function constant.
@@ -78,6 +79,7 @@ var allCheckFunctions = [...]StepFunction{
 	FuncCheckBlocksProduced,
 	FuncCheckEventThrottled,
 	FuncCheckNetworkRules,
+	FuncCheckValidatorsActive,
 }
 
 // toStepFunction returns the StepFunction for a given string, or an error if not recognized.
@@ -625,6 +627,8 @@ var checkFunctionDescriptions = map[StepFunction]string{
 	FuncCheckBlocksProduced: "Assert that all nodes have produced blocks within tolerance.",
 	FuncCheckEventThrottled: "Assert that validators listed in throttledNodes emit events at a significantly lower rate than the rest.",
 	FuncCheckNetworkRules:   "Assert that the active network rules on all nodes match the expected rules patch.",
+
+	FuncCheckValidatorsActive: "Assert that every running validator node is in the current epoch's validator set.",
 }
 
 // checkFunctionParams lists the optional parameters accepted by each sub-check function.
@@ -636,6 +640,8 @@ var checkFunctionParams = map[StepFunction][]string{
 	FuncCheckBlocksProduced: {"tolerance", "duration", "failing"},
 	FuncCheckEventThrottled: {"throttledNodes", "failing"},
 	FuncCheckNetworkRules:   {"rules", "failing"},
+
+	FuncCheckValidatorsActive: {"failing"},
 }
 
 // checkParamDescriptions provides a human-readable description for each sub-check parameter.

--- a/scenarios/examples/validator_rotation_distributed_proposer.yml
+++ b/scenarios/examples/validator_rotation_distributed_proposer.yml
@@ -25,17 +25,11 @@ Scenario:
   - startNode: val-g1-2
     type: validator
 
-  - advanceEpoch  # val-g1-2 joined
-
   - startNode: val-g1-3
     type: validator
 
-  - advanceEpoch  # val-g1-3 joined
-
   - startNode: val-g2-1
     type: validator
-
-  - advanceEpoch  # val-g2-1 joined
 
   - undelegate:
     - node: val-g1-1
@@ -47,8 +41,6 @@ Scenario:
   - startNode: val-g2-2
     type: validator
 
-  - advanceEpoch  # val-g2-2 joined
-
   - undelegate:
     - node: val-g1-2
 
@@ -58,8 +50,6 @@ Scenario:
 
   - startNode: val-g2-3
     type: validator
-
-  - advanceEpoch  # val-g2-3 joined
 
   - undelegate:
     - node: val-g1-3

--- a/scenarios/examples/validator_rotation_single_proposer.yml
+++ b/scenarios/examples/validator_rotation_single_proposer.yml
@@ -24,17 +24,11 @@ Scenario:
   - startNode: val-g1-2
     type: validator
 
-  - advanceEpoch  # val-g1-2 joined
-
   - startNode: val-g1-3
     type: validator
 
-  - advanceEpoch  # val-g1-3 joined
-
   - startNode: val-g2-1
     type: validator
-
-  - advanceEpoch  # val-g2-1 joined
 
   - undelegate:
     - node: val-g1-1
@@ -46,8 +40,6 @@ Scenario:
   - startNode: val-g2-2
     type: validator
 
-  - advanceEpoch  # val-g2-2 joined
-
   - undelegate:
     - node: val-g1-2
 
@@ -57,8 +49,6 @@ Scenario:
 
   - startNode: val-g2-3
     type: validator
-
-  - advanceEpoch  # val-g2-3 joined
 
   - undelegate:
     - node: val-g1-3

--- a/scenarios/examples/validators_are_really_validators.yml
+++ b/scenarios/examples/validators_are_really_validators.yml
@@ -1,0 +1,35 @@
+# This scenario verifies that every node started as "type: validator" really
+# is a validator in the network, with no epoch handling in the scenario itself.
+#
+# Only the first startNode step forms the genesis validator set; later
+# validators are registered through the SFC contract, and SFC validator sets
+# are per-epoch. startNode therefore seals the epoch once its nodes are up, so
+# the validators it registered join the set instead of idling as observers
+# while the genesis validators carry the whole consensus load.
+
+Name: Validators Are Really Validators
+Description: >-
+  Verifies that every node started as type validator joins
+  the validator set, whether it comes from genesis, a later
+  step, or a multi-instance step.
+
+InitialNetworkRules:
+  Epochs:
+    MaxEpochDuration: 1000s
+    MaxEpochGas: 10_000_000_000
+
+Scenario:
+  - startNode: genesis-validator
+    type: validator
+
+  - startNode: joining-validator
+    type: validator
+
+  - startNode: joining-pair
+    type: validator
+    instances: 2
+
+  # All four validators must be in the validator set. No advanceEpoch here:
+  # making that true is startNode's job.
+  - checks:
+      - validatorsActive


### PR DESCRIPTION
This PR ensures that when a node is started as a validator, it is part of the active validator set by advancing the epoch.