### PR TITLE
Fix killed node logs

### DIFF
--- a/driver/monitoring/node_log_provider.go
+++ b/driver/monitoring/node_log_provider.go
@@ -39,11 +39,9 @@ type LogListener interface {
 }
 
 // NodeRestartListener is an optional interface a LogListener may implement
-// to learn that a node rejoined the network after its client process was
-// restarted. Such a node replays blocks it has already reported, which is
-// indistinguishable from a genuine inconsistency without this signal.
+// to be told when a node's client goes offline and when a known node comes
+// back online; a returning client replays blocks it has already reported.
 type NodeRestartListener interface {
-	// OnNodeRestart is triggered when a known node comes back online.
 	OnNodeRestart(node Node)
 }
 
@@ -70,10 +68,14 @@ type NodeLogDispatcher struct {
 	logDir  string
 	wg      sync.WaitGroup
 
-	// knownNodes records the nodes seen so far, so that a second
-	// AfterNodeCreation for the same node can be recognised as a restart.
-	knownNodes     map[Node]bool
-	knownNodesLock sync.Mutex
+	nodes     map[Node]*nodeLogState
+	nodesLock sync.Mutex
+}
+
+// nodeLogState records which node object's log stream is being consumed;
+// source is nil while none is.
+type nodeLogState struct {
+	source driver.Node
 }
 
 // NewNodeLogDispatcher creates a new instance of this registry, which is filled
@@ -86,10 +88,10 @@ func NewNodeLogDispatcher(network driver.Network, outputDir string) (*NodeLogDis
 	}
 
 	res := &NodeLogDispatcher{
-		network:    network,
-		listeners:  make(map[LogListener]bool, 50),
-		logDir:     logDir,
-		knownNodes: make(map[Node]bool, 50),
+		network:   network,
+		listeners: make(map[LogListener]bool, 50),
+		logDir:    logDir,
+		nodes:     make(map[Node]*nodeLogState, 50),
 	}
 
 	// listen for new Nodes
@@ -123,36 +125,50 @@ func (n *NodeLogDispatcher) UnregisterLogListener(listener LogListener) {
 }
 
 func (n *NodeLogDispatcher) AfterNodeCreation(node driver.Node) {
-	nodeId := node.GetLabel()
+	nodeId := Node(node.GetLabel())
 
-	// A node we have seen before is rejoining rather than joining, which
-	// listeners need to know to interpret its replayed blocks.
-	n.knownNodesLock.Lock()
-	restarted := n.knownNodes[Node(nodeId)]
-	n.knownNodes[Node(nodeId)] = true
-	n.knownNodesLock.Unlock()
-	if restarted {
-		n.notifyNodeRestart(Node(nodeId))
+	n.nodesLock.Lock()
+	state, known := n.nodes[nodeId]
+	if !known {
+		state = &nodeLogState{}
+		n.nodes[nodeId] = state
+	}
+	consuming := state.source == node
+	n.nodesLock.Unlock()
+
+	if known {
+		n.notifyNodeRestart(nodeId)
 	}
 
-	n.wg.Add(1)
+	// The stream of a client restarted in place stays open and keeps
+	// delivering the new client's blocks; a second reader would report
+	// every block twice.
+	if consuming {
+		return
+	}
 
-	// Start a goroutine collecting the log and writing it into a file.
-	go n.runLogCollector(node)
-
-	// Start a goroutine parsing the log and dispatching block information.
 	logStream, err := node.StreamLog(context.Background())
 	if err != nil {
 		slog.Error(
 			"failed to obtain logs of node, will not be able to track blocks",
 			"error", err)
-		return // do not start dispatch on error
+		return
 	}
+	n.nodesLock.Lock()
+	state.source = node
+	n.nodesLock.Unlock()
+
 	n.wg.Add(1)
-	n.startDispatcher(Node(nodeId), logStream)
+	go n.runLogCollector(node)
+
+	n.wg.Add(1)
+	n.startDispatcher(nodeId, node, logStream, state)
 }
 
-func (n *NodeLogDispatcher) BeforeNodeRemoval(_ driver.Node) {
+// BeforeNodeRemoval prepares listeners for replayed blocks before the
+// stopped client comes back and starts speaking.
+func (n *NodeLogDispatcher) BeforeNodeRemoval(node driver.Node) {
+	n.notifyNodeRestart(Node(node.GetLabel()))
 }
 
 // notifyNodeRestart informs every listener that opted into restart
@@ -171,9 +187,16 @@ func (n *NodeLogDispatcher) AfterApplicationCreation(driver.Application) {
 	// ignored
 }
 
-func (n *NodeLogDispatcher) startDispatcher(node Node, reader io.ReadCloser) {
+func (n *NodeLogDispatcher) startDispatcher(nodeId Node, source driver.Node, reader io.ReadCloser, state *nodeLogState) {
 	go func() {
 		defer n.wg.Done()
+		defer func() {
+			n.nodesLock.Lock()
+			if state.source == source {
+				state.source = nil
+			}
+			n.nodesLock.Unlock()
+		}()
 		defer func() {
 			_ = reader.Close()
 		}()
@@ -181,7 +204,7 @@ func (n *NodeLogDispatcher) startDispatcher(node Node, reader io.ReadCloser) {
 		for b := range ch {
 			n.listenersLock.Lock()
 			for k := range n.listeners {
-				k.OnBlock(node, b)
+				k.OnBlock(nodeId, b)
 			}
 			n.listenersLock.Unlock()
 		}

--- a/driver/monitoring/node_log_provider_test.go
+++ b/driver/monitoring/node_log_provider_test.go
@@ -142,3 +142,143 @@ func (l *testBlockNodeListener) getBlocks(node Node) []Block {
 
 	return l.data[node]
 }
+
+func TestNodeLogDispatcher_InPlaceRestartAttachesNoSecondReader(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().RegisterListener(gomock.Any())
+	net.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{})
+
+	dispatchReader, dispatchWriter := io.Pipe()
+	collectReader, collectWriter := io.Pipe()
+
+	node := driver.NewMockNode(ctrl)
+	node.EXPECT().GetLabel().AnyTimes().Return(string(Node1TestId))
+	gomock.InOrder(
+		node.EXPECT().StreamLog(gomock.Any()).Return(dispatchReader, nil),
+		node.EXPECT().StreamLog(gomock.Any()).Return(collectReader, nil),
+	)
+
+	reg, err := NewNodeLogDispatcher(net, t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create log dispatcher: %v", err)
+	}
+	listener := newRestartRecordingListener()
+	reg.RegisterLogListener(listener)
+
+	reg.AfterNodeCreation(node)
+
+	// In-place restart: the stream is still open, so no new readers may
+	// attach (the mock rejects further StreamLog calls).
+	reg.AfterNodeCreation(node)
+
+	if _, err := dispatchWriter.Write([]byte(Node1TestLog)); err != nil {
+		t.Fatalf("failed to write log: %v", err)
+	}
+	_ = dispatchWriter.Close()
+	_ = collectWriter.Close()
+	reg.WaitForLogsToBeConsumed()
+
+	if got := listener.getRestarts(); len(got) != 1 || got[0] != Node1TestId {
+		t.Errorf("expected one restart notification for %v, got %v", Node1TestId, got)
+	}
+	blockEqual(t, Node1TestId, listener.getBlocks(Node1TestId), NodeBlockTestData[Node1TestId])
+}
+
+func TestNodeLogDispatcher_ReattachesWhenRejoiningAfterStreamEnd(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().RegisterListener(gomock.Any())
+	net.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{})
+
+	first := driver.NewMockNode(ctrl)
+	first.EXPECT().GetLabel().AnyTimes().Return(string(Node1TestId))
+	first.EXPECT().StreamLog(gomock.Any()).Times(2).DoAndReturn(func(context.Context) (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader(Node1TestLog)), nil
+	})
+
+	reg, err := NewNodeLogDispatcher(net, t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create log dispatcher: %v", err)
+	}
+	listener := newRestartRecordingListener()
+	reg.RegisterLogListener(listener)
+
+	reg.AfterNodeCreation(first)
+	reg.WaitForLogsToBeConsumed()
+
+	// Rejoin after the container was recreated: fresh readers must attach.
+	second := driver.NewMockNode(ctrl)
+	second.EXPECT().GetLabel().AnyTimes().Return(string(Node1TestId))
+	second.EXPECT().StreamLog(gomock.Any()).Times(2).DoAndReturn(func(context.Context) (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader(Node2TestLog)), nil
+	})
+
+	reg.AfterNodeCreation(second)
+	reg.WaitForLogsToBeConsumed()
+
+	if got := listener.getRestarts(); len(got) != 1 || got[0] != Node1TestId {
+		t.Errorf("expected one restart notification for %v, got %v", Node1TestId, got)
+	}
+	want := append(append([]Block{}, NodeBlockTestData[Node1TestId]...), NodeBlockTestData[Node2TestId]...)
+	blockEqual(t, Node1TestId, listener.getBlocks(Node1TestId), want)
+}
+
+func TestNodeLogDispatcher_NodeSuspensionNotifiesRestartListeners(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().RegisterListener(gomock.Any())
+	net.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{})
+
+	node := driver.NewMockNode(ctrl)
+	node.EXPECT().GetLabel().AnyTimes().Return(string(Node1TestId))
+
+	reg, err := NewNodeLogDispatcher(net, t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create log dispatcher: %v", err)
+	}
+	listener := newRestartRecordingListener()
+	reg.RegisterLogListener(listener)
+
+	reg.BeforeNodeRemoval(node)
+
+	if got := listener.getRestarts(); len(got) != 1 || got[0] != Node1TestId {
+		t.Errorf("expected restart notification on suspension, got %v", got)
+	}
+}
+
+type restartRecordingListener struct {
+	mu       sync.Mutex
+	blocks   map[Node][]Block
+	restarts []Node
+}
+
+func newRestartRecordingListener() *restartRecordingListener {
+	return &restartRecordingListener{blocks: map[Node][]Block{}}
+}
+
+func (l *restartRecordingListener) OnBlock(node Node, b Block) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if b.Height > 0 {
+		l.blocks[node] = append(l.blocks[node], b)
+	}
+}
+
+func (l *restartRecordingListener) OnNodeRestart(node Node) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.restarts = append(l.restarts, node)
+}
+
+func (l *restartRecordingListener) getBlocks(node Node) []Block {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]Block{}, l.blocks[node]...)
+}
+
+func (l *restartRecordingListener) getRestarts() []Node {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]Node{}, l.restarts...)
+}


### PR DESCRIPTION
With the changes of #271 nodes can now be killed without terminating the docker container, this messed up logging.