### PR TITLE
Multi user staking: Add tests on top of proposed changes

### DIFF
--- a/driver/executor/run_test.go
+++ b/driver/executor/run_test.go
@@ -18,8 +18,10 @@ package executor
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"fmt"
 	"math/big"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -28,6 +30,8 @@ import (
 	"github.com/0xsoniclabs/norma/driver/checking"
 	"github.com/0xsoniclabs/norma/driver/parser"
 	"github.com/0xsoniclabs/norma/genesis"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"go.uber.org/mock/gomock"
 )
 
@@ -1391,4 +1395,134 @@ func validatorNode(ctrl *gomock.Controller, id int) driver.Node {
 	node := driver.NewMockNode(ctrl)
 	node.EXPECT().GetValidatorId().Return(&id).AnyTimes()
 	return node
+}
+
+// A single account may stake on the same validator repeatedly: topping up an
+// existing stake, reducing it in several steps, draining it and staking again
+// from zero. All of it must go through one delegator account, and the tracked
+// stake must follow the running total.
+func TestDelegation_SingleAccountRepeatedlyDelegatesAndUndelegates(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	registry := NewMockvalidatorRegistry(ctrl)
+
+	const validatorId = 2
+	var calls []string
+	var funded []common.Address
+	var signers []*ecdsa.PrivateKey
+
+	registry.EXPECT().
+		fundDelegator(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, address common.Address, amount uint64) error {
+			calls = append(calls, fmt.Sprintf("fund %d", amount))
+			funded = append(funded, address)
+			return nil
+		}).AnyTimes()
+	registry.EXPECT().
+		delegate(gomock.Any(), validatorId, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ int, stake uint64, key *ecdsa.PrivateKey) error {
+			calls = append(calls, fmt.Sprintf("delegate %d", stake))
+			signers = append(signers, key)
+			return nil
+		}).AnyTimes()
+	registry.EXPECT().
+		undelegateAs(gomock.Any(), validatorId, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ int, stake uint64, key *ecdsa.PrivateKey) error {
+			calls = append(calls, fmt.Sprintf("undelegate %d", stake))
+			signers = append(signers, key)
+			return nil
+		}).AnyTimes()
+
+	state := newDelegationTestState(t, map[string]driver.Node{
+		"heavy": validatorNode(ctrl, validatorId),
+	})
+
+	// The sequence of scenarios/examples/repeated_delegation.yml.
+	partial := func(stake uint64) *uint64 { return &stake }
+	steps := []struct {
+		name      string
+		step      parser.Step
+		wantStake uint64
+	}{
+		{"initial stake", delegateStep("heavy", "cycler", 1_000_000), 1_000_000},
+		{"top up", delegateStep("heavy", "cycler", 500_000), 1_500_000},
+		{"first partial", undelegateStep("heavy", "cycler", partial(400_000)), 1_100_000},
+		{"second partial", undelegateStep("heavy", "cycler", partial(100_000)), 1_000_000},
+		{"drain", undelegateStep("heavy", "cycler", nil), 0},
+		{"stake again from zero", delegateStep("heavy", "cycler", 750_000), 750_000},
+		{"drain again", undelegateStep("heavy", "cycler", nil), 0},
+	}
+
+	for _, test := range steps {
+		var err error
+		if test.step.Function == parser.FuncDelegate {
+			err = execDelegate(t.Context(), &test.step, registry, state)
+		} else {
+			err = execUndelegate(t.Context(), &test.step, registry, state)
+		}
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", test.name, err)
+		}
+		got := state.expectedStakes[stakeKey{"cycler", validatorId}]
+		if got != test.wantStake {
+			t.Errorf("%s: expected a tracked stake of %d S, got %d S", test.name, test.wantStake, got)
+		}
+	}
+
+	// A full undelegation passes 0 down, letting the chain report the amount.
+	want := []string{
+		"fund " + fmt.Sprint(1_000_000+delegatorGasBudget), "delegate 1000000",
+		"fund " + fmt.Sprint(500_000+delegatorGasBudget), "delegate 500000",
+		"undelegate 400000",
+		"undelegate 100000",
+		"undelegate 0",
+		"fund " + fmt.Sprint(750_000+delegatorGasBudget), "delegate 750000",
+		"undelegate 0",
+	}
+	if !slices.Equal(calls, want) {
+		t.Errorf("unexpected call sequence:\n got %v\nwant %v", calls, want)
+	}
+
+	// Every operation belongs to the same account: one tracked delegator,
+	// one funded address, one signing key.
+	if len(state.delegators) != 1 {
+		t.Errorf("expected a single delegator account, got %d", len(state.delegators))
+	}
+	address := state.delegators["cycler"].address
+	for _, got := range funded {
+		if got != address {
+			t.Errorf("expected all funding to go to %s, got %s", address.Hex(), got.Hex())
+		}
+	}
+	for _, key := range signers {
+		if crypto.PubkeyToAddress(key.PublicKey) != address {
+			t.Errorf("expected all operations to be signed by %s, got %s",
+				address.Hex(), crypto.PubkeyToAddress(key.PublicKey).Hex())
+		}
+	}
+
+	// After the last drain the chain must agree that nothing is staked.
+	registry.EXPECT().getDelegatorStake(address, validatorId).Return(uint64(0), nil)
+	if err := execVerifyStakes(
+		&parser.Step{Function: parser.FuncVerifyStakes}, registry, state,
+	); err != nil {
+		t.Errorf("unexpected verification error: %v", err)
+	}
+}
+
+func delegateStep(node, delegator string, stake uint64) parser.Step {
+	return parser.Step{
+		Function: parser.FuncDelegate,
+		DelegateTargets: []parser.DelegateTarget{
+			{Node: node, Delegator: delegator, Stake: stake},
+		},
+	}
+}
+
+func undelegateStep(node, delegator string, stake *uint64) parser.Step {
+	return parser.Step{
+		Function: parser.FuncUndelegate,
+		UndelegateTargets: []parser.UndelegateTarget{
+			{Node: node, Delegator: delegator, Stake: stake},
+		},
+	}
 }

--- a/driver/executor/run_test.go
+++ b/driver/executor/run_test.go
@@ -1046,3 +1046,349 @@ func TestRun_VerifyStakes_ChecksFullyUndelegatedPairIsZero(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+// The tests below cover scenarios that are set up wrongly: they target nodes
+// that do not exist, are not validators, or hold no stake for the delegator
+// performing the operation. Each of them must fail with a message that names
+// the offending step, and must not leave the executor's stake bookkeeping in
+// a state that a later verifyStakes would silently accept.
+
+func TestDelegate_UnknownNodeIsReported(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	registry := NewMockvalidatorRegistry(ctrl)
+	// No delegation call is expected for a node that does not exist.
+
+	state := newDelegationTestState(t, nil)
+	step := &parser.Step{
+		Function: parser.FuncDelegate,
+		DelegateTargets: []parser.DelegateTarget{
+			{Node: "ghost", Delegator: "alice", Stake: 1_000},
+		},
+	}
+
+	err := execDelegate(t.Context(), step, registry, state)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found in active nodes") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(state.expectedStakes) != 0 {
+		t.Errorf("expected no tracked stake, got %v", state.expectedStakes)
+	}
+}
+
+func TestUndelegate_UnknownNodeIsReported(t *testing.T) {
+	tests := map[string]parser.UndelegateTarget{
+		"self undelegation":      {Node: "ghost"},
+		"delegator undelegation": {Node: "ghost", Delegator: "alice"},
+	}
+	for name, target := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			registry := NewMockvalidatorRegistry(ctrl)
+			// Neither undelegation path may be entered.
+
+			state := newDelegationTestState(t, nil)
+			step := &parser.Step{
+				Function:          parser.FuncUndelegate,
+				UndelegateTargets: []parser.UndelegateTarget{target},
+			}
+
+			err := execUndelegate(t.Context(), step, registry, state)
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !strings.Contains(err.Error(), "not found in active nodes") {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDelegation_NonValidatorNodeIsReported(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	registry := NewMockvalidatorRegistry(ctrl)
+	observer := driver.NewMockNode(ctrl)
+	observer.EXPECT().GetValidatorId().Return(nil).AnyTimes()
+
+	state := newDelegationTestState(t, map[string]driver.Node{"watcher": observer})
+
+	err := execDelegate(t.Context(), &parser.Step{
+		Function: parser.FuncDelegate,
+		DelegateTargets: []parser.DelegateTarget{
+			{Node: "watcher", Delegator: "alice", Stake: 1_000},
+		},
+	}, registry, state)
+	if err == nil || !strings.Contains(err.Error(), "is not a validator") {
+		t.Errorf("expected a non-validator error for delegate, got: %v", err)
+	}
+
+	err = execUndelegate(t.Context(), &parser.Step{
+		Function: parser.FuncUndelegate,
+		UndelegateTargets: []parser.UndelegateTarget{
+			{Node: "watcher"},
+		},
+	}, registry, state)
+	if err == nil || !strings.Contains(err.Error(), "is not a validator") {
+		t.Errorf("expected a non-validator error for undelegate, got: %v", err)
+	}
+}
+
+// A base name matching several numbered instances is ambiguous: picking the
+// first one would stake on an arbitrary validator.
+func TestDelegation_AmbiguousNodeNameIsReported(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	registry := NewMockvalidatorRegistry(ctrl)
+
+	first, second := 2, 3
+	nodeA := driver.NewMockNode(ctrl)
+	nodeA.EXPECT().GetValidatorId().Return(&first).AnyTimes()
+	nodeB := driver.NewMockNode(ctrl)
+	nodeB.EXPECT().GetValidatorId().Return(&second).AnyTimes()
+
+	state := newDelegationTestState(t, map[string]driver.Node{
+		"heavy-0": nodeA,
+		"heavy-1": nodeB,
+	})
+
+	err := execDelegate(t.Context(), &parser.Step{
+		Function: parser.FuncDelegate,
+		DelegateTargets: []parser.DelegateTarget{
+			{Node: "heavy", Delegator: "alice", Stake: 1_000},
+		},
+	}, registry, state)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "multiple instances") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// Funding precedes delegation; when the treasury transfer fails the delegation
+// must not be attempted, because the account cannot pay for it.
+func TestDelegate_FundingFailureSkipsTheDelegation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	registry := NewMockvalidatorRegistry(ctrl)
+
+	registry.EXPECT().
+		fundDelegator(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(fmt.Errorf("insufficient funds for gas * price + value"))
+	// delegate must not be called.
+
+	state := newDelegationTestState(t, map[string]driver.Node{
+		"heavy": validatorNode(ctrl, 2),
+	})
+	step := &parser.Step{
+		Function: parser.FuncDelegate,
+		DelegateTargets: []parser.DelegateTarget{
+			{Node: "heavy", Delegator: "alice", Stake: 1_000},
+		},
+	}
+
+	err := execDelegate(t.Context(), step, registry, state)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to fund delegator") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(state.expectedStakes) != 0 {
+		t.Errorf("expected no tracked stake, got %v", state.expectedStakes)
+	}
+}
+
+// A rejected delegation must not be recorded as expected stake, otherwise the
+// next verifyStakes would report a mismatch instead of the real failure.
+func TestDelegate_FailedDelegationIsNotTracked(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	registry := NewMockvalidatorRegistry(ctrl)
+
+	registry.EXPECT().fundDelegator(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	registry.EXPECT().
+		delegate(gomock.Any(), 2, uint64(1_000), gomock.Any()).
+		Return(fmt.Errorf("delegate transaction reverted"))
+
+	state := newDelegationTestState(t, map[string]driver.Node{
+		"heavy": validatorNode(ctrl, 2),
+	})
+	step := &parser.Step{
+		Function: parser.FuncDelegate,
+		DelegateTargets: []parser.DelegateTarget{
+			{Node: "heavy", Delegator: "alice", Stake: 1_000},
+		},
+	}
+
+	if err := execDelegate(t.Context(), step, registry, state); err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if len(state.expectedStakes) != 0 {
+		t.Errorf("expected no tracked stake, got %v", state.expectedStakes)
+	}
+}
+
+// Undelegating a known delegator from a validator it never staked on reaches
+// the chain, where the SFC query finds no stake. The executor must surface
+// that rejection rather than treat the step as a no-op.
+func TestUndelegate_DelegatorWithoutStakeOnValidatorIsReported(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	registry := NewMockvalidatorRegistry(ctrl)
+
+	registry.EXPECT().fundDelegator(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	registry.EXPECT().delegate(gomock.Any(), 2, uint64(1_000), gomock.Any()).Return(nil)
+	// The undelegation targets the other validator, where alice has nothing.
+	registry.EXPECT().
+		undelegateAs(gomock.Any(), 3, uint64(0), gomock.Any()).
+		Return(fmt.Errorf("delegator has no stake on validator 3"))
+
+	state := newDelegationTestState(t, map[string]driver.Node{
+		"heavy": validatorNode(ctrl, 2),
+		"light": validatorNode(ctrl, 3),
+	})
+
+	if err := execDelegate(t.Context(), &parser.Step{
+		Function: parser.FuncDelegate,
+		DelegateTargets: []parser.DelegateTarget{
+			{Node: "heavy", Delegator: "alice", Stake: 1_000},
+		},
+	}, registry, state); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	err := execUndelegate(t.Context(), &parser.Step{
+		Function: parser.FuncUndelegate,
+		UndelegateTargets: []parser.UndelegateTarget{
+			{Node: "light", Delegator: "alice"},
+		},
+	}, registry, state)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no stake on validator 3") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// The stake on the validator alice did delegate to stays untouched.
+	if got := state.expectedStakes[stakeKey{"alice", 2}]; got != 1_000 {
+		t.Errorf("expected the unrelated stake to remain 1000 S, got %d S", got)
+	}
+}
+
+// Self-undelegation from a validator without stake is rejected by the registry;
+// the error must name the node so the scenario step can be identified.
+func TestUndelegate_SelfUndelegationFailureIsReported(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	registry := NewMockvalidatorRegistry(ctrl)
+
+	registry.EXPECT().
+		unregisterValidator(gomock.Any(), 2, uint64(0)).
+		Return(fmt.Errorf("validator has no self-stake"))
+
+	state := newDelegationTestState(t, map[string]driver.Node{
+		"heavy": validatorNode(ctrl, 2),
+	})
+	step := &parser.Step{
+		Function: parser.FuncUndelegate,
+		UndelegateTargets: []parser.UndelegateTarget{
+			{Node: "heavy"},
+		},
+	}
+
+	err := execUndelegate(t.Context(), step, registry, state)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "heavy") {
+		t.Errorf("expected the node name in the error, got: %v", err)
+	}
+}
+
+// Undelegating more than was delegated is rejected on-chain. The local
+// bookkeeping must not underflow into a huge expected stake when it happens.
+func TestUndelegate_MoreThanDelegatedDoesNotUnderflowTheBookkeeping(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	registry := NewMockvalidatorRegistry(ctrl)
+
+	registry.EXPECT().fundDelegator(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	registry.EXPECT().delegate(gomock.Any(), 2, uint64(1_000), gomock.Any()).Return(nil)
+	registry.EXPECT().undelegateAs(gomock.Any(), 2, uint64(5_000), gomock.Any()).Return(nil)
+
+	state := newDelegationTestState(t, map[string]driver.Node{
+		"heavy": validatorNode(ctrl, 2),
+	})
+
+	if err := execDelegate(t.Context(), &parser.Step{
+		Function: parser.FuncDelegate,
+		DelegateTargets: []parser.DelegateTarget{
+			{Node: "heavy", Delegator: "alice", Stake: 1_000},
+		},
+	}, registry, state); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tooMuch := uint64(5_000)
+	if err := execUndelegate(t.Context(), &parser.Step{
+		Function: parser.FuncUndelegate,
+		UndelegateTargets: []parser.UndelegateTarget{
+			{Node: "heavy", Delegator: "alice", Stake: &tooMuch},
+		},
+	}, registry, state); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := state.expectedStakes[stakeKey{"alice", 2}]; got != 0 {
+		t.Errorf("expected the tracked stake to be clamped to 0, got %d S", got)
+	}
+}
+
+func TestVerifyStakes_StakeQueryFailureIsReported(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	registry := NewMockvalidatorRegistry(ctrl)
+
+	registry.EXPECT().fundDelegator(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	registry.EXPECT().delegate(gomock.Any(), 2, uint64(1_000), gomock.Any()).Return(nil)
+	registry.EXPECT().
+		getDelegatorStake(gomock.Any(), 2).
+		Return(uint64(0), fmt.Errorf("connection reset"))
+
+	state := newDelegationTestState(t, map[string]driver.Node{
+		"heavy": validatorNode(ctrl, 2),
+	})
+	if err := execDelegate(t.Context(), &parser.Step{
+		Function: parser.FuncDelegate,
+		DelegateTargets: []parser.DelegateTarget{
+			{Node: "heavy", Delegator: "alice", Stake: 1_000},
+		},
+	}, registry, state); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	err := execVerifyStakes(&parser.Step{Function: parser.FuncVerifyStakes}, registry, state)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "query failed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// newDelegationTestState builds the minimal executor state the delegation steps
+// operate on.
+func newDelegationTestState(t *testing.T, nodes map[string]driver.Node) *runState {
+	t.Helper()
+	if nodes == nil {
+		nodes = map[string]driver.Node{}
+	}
+	return &runState{
+		nodes:          nodes,
+		delegators:     map[string]*delegatorAccount{},
+		expectedStakes: map[stakeKey]uint64{},
+	}
+}
+
+// validatorNode returns a node mock reporting the given validator id.
+func validatorNode(ctrl *gomock.Controller, id int) driver.Node {
+	node := driver.NewMockNode(ctrl)
+	node.EXPECT().GetValidatorId().Return(&id).AnyTimes()
+	return node
+}

--- a/driver/network/delegation_test.go
+++ b/driver/network/delegation_test.go
@@ -1,0 +1,381 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/0xsoniclabs/norma/driver/rpc"
+	"github.com/0xsoniclabs/sonic/gossip/contract/sfc100"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	gomock "go.uber.org/mock/gomock"
+)
+
+// insufficientFundsError is the rejection a Sonic node returns when an account
+// cannot cover value + gas * feeCap of the transaction it submits.
+const insufficientFundsError = "insufficient funds for gas * price + value"
+
+func TestDelegateToValidator_ZeroStakeIsRejectedWithoutTouchingTheChain(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	client := rpc.NewMockClient(ctrl)
+	// No client interaction is expected at all.
+
+	err := DelegateToValidator(t.Context(), client, 1, 0, testKey(t))
+	if err == nil {
+		t.Fatal("expected an error for a zero stake, got nil")
+	}
+	if !strings.Contains(err.Error(), "greater than zero") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDelegateToValidator_SubmitsStakeAsTransactionValue(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	client := rpc.NewMockClient(ctrl)
+
+	var submitted *types.Transaction
+	expectTransactionSubmission(client, &submitted, nil)
+	client.EXPECT().WaitTransactionReceipt(gomock.Any(), gomock.Any()).
+		Return(&types.Receipt{Status: types.ReceiptStatusSuccessful}, nil)
+
+	if err := DelegateToValidator(t.Context(), client, 3, 1_000, testKey(t)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := stakeToWei(1_000)
+	if got := submitted.Value(); got.Cmp(want) != 0 {
+		t.Errorf("expected a transaction value of %v wei, got %v", want, got)
+	}
+	if got := submitted.Gas(); got != delegationGasLimit {
+		t.Errorf("expected the fixed delegation gas limit %d, got %d", delegationGasLimit, got)
+	}
+	if got := decodeUint256Arg(t, "delegate", submitted.Data(), 0); got.Int64() != 3 {
+		t.Errorf("expected validator id 3 in the call data, got %v", got)
+	}
+}
+
+// A delegator account that cannot cover stake + gas is rejected by the node at
+// submission time; the rejection must not be mistaken for a successful
+// delegation. This is the only layer at which under-funding is observable:
+// the executor always funds the account before delegating, so a scenario
+// cannot express this case.
+func TestDelegateToValidator_InsufficientFundsIsReportedAsSubmissionFailure(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	client := rpc.NewMockClient(ctrl)
+
+	var submitted *types.Transaction
+	expectTransactionSubmission(client, &submitted, fmt.Errorf("%s", insufficientFundsError))
+	// The receipt must never be awaited for a transaction that was refused.
+
+	err := DelegateToValidator(t.Context(), client, 1, 1_000, testKey(t))
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), insufficientFundsError) {
+		t.Errorf("expected the node rejection to be propagated, got: %v", err)
+	}
+}
+
+func TestDelegateToValidator_RevertedTransactionIsReported(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	client := rpc.NewMockClient(ctrl)
+
+	var submitted *types.Transaction
+	expectTransactionSubmission(client, &submitted, nil)
+	client.EXPECT().WaitTransactionReceipt(gomock.Any(), gomock.Any()).
+		Return(&types.Receipt{Status: types.ReceiptStatusFailed}, nil)
+
+	err := DelegateToValidator(t.Context(), client, 1, 1_000, testKey(t))
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "reverted") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// Undelegating without an explicit amount from a validator the delegator never
+// staked on must fail before a transaction is submitted: the SFC contract would
+// revert on a zero-amount undelegation, and a silent no-op would let a scenario
+// believe stake was moved.
+func TestUndelegateFromValidator_WithoutStakeIsRejectedBeforeSubmission(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	client := rpc.NewMockClient(ctrl)
+
+	expectStakeQuery(t, client, big.NewInt(0))
+	// No transaction submission is expected.
+
+	err := UndelegateFromValidator(t.Context(), client, 7, 0, testKey(t))
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no stake on validator 7") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestUndelegateFromValidator_WithoutExplicitAmountUndelegatesTheQueriedStake(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	client := rpc.NewMockClient(ctrl)
+
+	onChain := stakeToWei(2_500)
+	expectStakeQuery(t, client, onChain)
+	var submitted *types.Transaction
+	expectTransactionSubmission(client, &submitted, nil)
+	client.EXPECT().WaitTransactionReceipt(gomock.Any(), gomock.Any()).
+		Return(&types.Receipt{Status: types.ReceiptStatusSuccessful}, nil)
+
+	if err := UndelegateFromValidator(t.Context(), client, 7, 0, testKey(t)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// undelegate(toValidatorID, wrID, amount)
+	if got := decodeUint256Arg(t, "undelegate", submitted.Data(), 2); got.Cmp(onChain) != 0 {
+		t.Errorf("expected the full on-chain stake %v to be undelegated, got %v", onChain, got)
+	}
+}
+
+func TestUndelegateFromValidator_StakeQueryFailureIsReported(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	client := rpc.NewMockClient(ctrl)
+
+	client.EXPECT().CallContract(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, fmt.Errorf("connection reset"))
+
+	err := UndelegateFromValidator(t.Context(), client, 7, 0, testKey(t))
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to query stake") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// An explicit amount is taken at face value: the on-chain stake is not queried,
+// so over-undelegating is only caught by the contract itself.
+func TestUndelegateFromValidator_ExplicitAmountSkipsTheStakeQuery(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	client := rpc.NewMockClient(ctrl)
+
+	var submitted *types.Transaction
+	expectTransactionSubmission(client, &submitted, nil)
+	client.EXPECT().WaitTransactionReceipt(gomock.Any(), gomock.Any()).
+		Return(&types.Receipt{Status: types.ReceiptStatusFailed}, nil)
+
+	err := UndelegateFromValidator(t.Context(), client, 7, 9_000, testKey(t))
+	if err == nil {
+		t.Fatal("expected an error for a reverted over-undelegation, got nil")
+	}
+	if got := decodeUint256Arg(t, "undelegate", submitted.Data(), 2); got.Cmp(stakeToWei(9_000)) != 0 {
+		t.Errorf("expected the requested amount to be submitted unchanged, got %v", got)
+	}
+}
+
+func TestGetDelegatorStake_ConvertsWeiToWholeS(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		wei  *big.Int
+		want uint64
+	}{
+		"no stake":     {big.NewInt(0), 0},
+		"whole amount": {stakeToWei(1_000), 1_000},
+		"rounded down": {new(big.Int).Add(stakeToWei(1_000), big.NewInt(9e17)), 1_000},
+		"below one S":  {big.NewInt(9e17), 0},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			client := rpc.NewMockClient(ctrl)
+			expectStakeQuery(t, client, test.wei)
+
+			got, err := GetDelegatorStake(client, common.Address{1}, 1)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != test.want {
+				t.Errorf("expected %d S, got %d S", test.want, got)
+			}
+		})
+	}
+}
+
+func TestFundAccount_TransfersTheRequestedAmount(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	client := rpc.NewMockClient(ctrl)
+
+	var submitted *types.Transaction
+	client.EXPECT().PendingNonceAt(gomock.Any(), gomock.Any()).Return(uint64(7), nil)
+	client.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ any, tx *types.Transaction) error {
+			submitted = tx
+			return nil
+		})
+	client.EXPECT().WaitTransactionReceipt(gomock.Any(), gomock.Any()).
+		Return(&types.Receipt{Status: types.ReceiptStatusSuccessful}, nil)
+
+	dest := common.Address{0xAB}
+	if err := FundAccount(t.Context(), client, testKey(t), dest, 42); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := submitted.To(); got == nil || *got != dest {
+		t.Errorf("expected a transfer to %s, got %v", dest.Hex(), got)
+	}
+	if got, want := submitted.Value(), stakeToWei(42); got.Cmp(want) != 0 {
+		t.Errorf("expected %v wei to be transferred, got %v", want, got)
+	}
+	if got := submitted.Nonce(); got != 7 {
+		t.Errorf("expected the pending nonce 7 to be used, got %d", got)
+	}
+	if got := submitted.Gas(); got != fundingGasLimit {
+		t.Errorf("expected the plain-transfer gas limit %d, got %d", fundingGasLimit, got)
+	}
+}
+
+// The treasury account funds every delegator; when it runs dry the failure has
+// to surface here rather than as an unexplained delegation error later on.
+func TestFundAccount_InsufficientTreasuryFundsIsReported(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	client := rpc.NewMockClient(ctrl)
+
+	client.EXPECT().PendingNonceAt(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
+	client.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).
+		Return(fmt.Errorf("%s", insufficientFundsError))
+
+	err := FundAccount(t.Context(), client, testKey(t), common.Address{1}, 1_000)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), insufficientFundsError) {
+		t.Errorf("expected the node rejection to be propagated, got: %v", err)
+	}
+}
+
+func TestFundAccount_NonceQueryFailureIsReported(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	client := rpc.NewMockClient(ctrl)
+
+	client.EXPECT().PendingNonceAt(gomock.Any(), gomock.Any()).
+		Return(uint64(0), fmt.Errorf("connection reset"))
+
+	err := FundAccount(t.Context(), client, testKey(t), common.Address{1}, 1_000)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to get pending nonce") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestFundAccount_RevertedTransferIsReported(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	client := rpc.NewMockClient(ctrl)
+
+	client.EXPECT().PendingNonceAt(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
+	client.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return(nil)
+	client.EXPECT().WaitTransactionReceipt(gomock.Any(), gomock.Any()).
+		Return(&types.Receipt{Status: types.ReceiptStatusFailed}, nil)
+
+	err := FundAccount(t.Context(), client, testKey(t), common.Address{1}, 1_000)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "reverted") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func testKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("failed to create a test key: %v", err)
+	}
+	return key
+}
+
+// expectTransactionSubmission sets up the calls the bind layer makes for a
+// contract transaction with a fixed gas limit: base fee lookup, nonce lookup
+// and the submission itself. The submitted transaction is captured in tx.
+func expectTransactionSubmission(
+	client *rpc.MockClient,
+	tx **types.Transaction,
+	sendErr error,
+) {
+	header := types.Header{BaseFee: big.NewInt(123)}
+	client.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).Return(&header, nil)
+	client.EXPECT().PendingNonceAt(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
+	client.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ any, submitted *types.Transaction) error {
+			*tx = submitted
+			return sendErr
+		})
+}
+
+// expectStakeQuery makes the next contract call return the given stake in wei.
+func expectStakeQuery(t *testing.T, client *rpc.MockClient, stake *big.Int) {
+	t.Helper()
+	uint256Type, err := abi.NewType("uint256", "", nil)
+	if err != nil {
+		t.Fatalf("failed to create uint256 type: %v", err)
+	}
+	packed, err := abi.Arguments{{Type: uint256Type}}.Pack(stake)
+	if err != nil {
+		t.Fatalf("failed to pack the stake: %v", err)
+	}
+	client.EXPECT().CallContract(gomock.Any(), gomock.Any(), gomock.Any()).Return(packed, nil)
+}
+
+// decodeUint256Arg returns the i-th argument of an encoded SFC call.
+func decodeUint256Arg(t *testing.T, method string, data []byte, i int) *big.Int {
+	t.Helper()
+	if len(data) < 4 {
+		t.Fatalf("call data of %s is too short: %d bytes", method, len(data))
+	}
+	sfcAbi, err := sfc100.ContractMetaData.GetAbi()
+	if err != nil {
+		t.Fatalf("failed to load the SFC ABI: %v", err)
+	}
+	args, err := sfcAbi.Methods[method].Inputs.Unpack(data[4:])
+	if err != nil {
+		t.Fatalf("failed to unpack the %s call data: %v", method, err)
+	}
+	value, ok := args[i].(*big.Int)
+	if !ok {
+		t.Fatalf("argument %d of %s is a %T, not a uint256", i, method, args[i])
+	}
+	return value
+}

--- a/scenarios/examples/repeated_delegation.yml
+++ b/scenarios/examples/repeated_delegation.yml
@@ -1,0 +1,75 @@
+# This scenario exercises repeated staking operations from a single account.
+# One delegator tops up its stake, reduces it in several partial steps, drains
+# it completely and stakes again from zero, always on the same validator.
+# Every change is followed by a verifyStakes step, so a stake that is
+# accumulated, reduced or reset wrongly is caught at the point it happens.
+
+Name: Repeated Delegation Test
+Description: >-
+  Delegate and undelegate repeatedly from a single external account on the
+  same validator, verifying the aggregated stake after every change.
+
+Scenario:
+  - startNode: heavy
+    type: validator
+
+  - waitFor: 5s
+
+  # Initial stake: 1_000_000.
+  - delegate:
+    - node: heavy
+      delegator: cycler
+      stake: 1_000_000
+
+  - advanceEpoch
+  - verifyStakes
+
+  # Top up the same (delegator, validator) pair: 1_000_000 + 500_000.
+  - delegate:
+    - node: heavy
+      delegator: cycler
+      stake: 500_000
+
+  - advanceEpoch
+  - verifyStakes
+
+  # Two partial undelegations in a row: 1_500_000 - 400_000 - 100_000.
+  - undelegate:
+    - node: heavy
+      delegator: cycler
+      stake: 400_000
+
+  - advanceEpoch
+  - verifyStakes
+
+  - undelegate:
+    - node: heavy
+      delegator: cycler
+      stake: 100_000
+
+  - advanceEpoch
+  - verifyStakes
+
+  # Drain the remaining 1_000_000 by omitting the amount.
+  - undelegate:
+    - node: heavy
+      delegator: cycler
+
+  - advanceEpoch
+  - verifyStakes
+
+  # Stake again from zero with the same account.
+  - delegate:
+    - node: heavy
+      delegator: cycler
+      stake: 750_000
+
+  - advanceEpoch
+  - verifyStakes
+
+  - undelegate:
+    - node: heavy
+      delegator: cycler
+
+  - advanceEpoch
+  - verifyStakes

--- a/scenarios/release_testing/validators/stake_across_validator_versions.yml
+++ b/scenarios/release_testing/validators/stake_across_validator_versions.yml
@@ -1,0 +1,92 @@
+Name: Release Validators Cross-Version Stake Rotation v2.1.6, v2.2.0 and Local
+
+Description: >-
+  Verifies a single external account can rotate 75% of the stake over
+  validators of different client versions by unstaking and staking
+  again, with on-chain stake matching expectation after every change.
+  Three validators self-stake 1M each and the account delegates 5M, so
+  the receiving validator holds 6M of 8M; the delegation walks over
+  v2.1.6, v2.2.0 and the candidate, ending on the candidate. The
+  released pins are feature peers, both implementing SFC delegation.
+
+  Deliberate deviation from RELEASE_TESTING.md §5a: a released peer
+  holds the quorum mid-scenario, so a fork by it stalls consensus
+  instead of being named by the hash check. Restoring the candidate's
+  two thirds would delete the test.
+
+Scenario:
+  - startNode: validator-local
+    type: validator
+    stake: 1000000
+
+  - startNode: validator-v216
+    type: validator
+    imageName: "sonic:v2.1.6"
+    stake: 1000000
+
+  - startNode: validator-v220
+    type: validator
+    imageName: "sonic:v2.2.0"
+    stake: 1000000
+
+  - runApp: normal
+    type: counter
+    users: 10
+    rate:
+      constant: 10
+
+  - waitFor: 20s
+
+  # The 75% starts on the candidate.
+  - delegate:
+      - node: validator-local
+        delegator: rotating-staker
+        stake: 5000000
+
+  - advanceEpoch
+  - verifyStakes
+
+  # Rotate it to v2.1.6. Both changes land at the same epoch seal, so
+  # the handoff is a single weight change rather than an interim state.
+  - undelegate:
+      - node: validator-local
+        delegator: rotating-staker
+
+  - delegate:
+      - node: validator-v216
+        delegator: rotating-staker
+        stake: 5000000
+
+  - advanceEpoch
+  - verifyStakes
+
+  # Rotate it on to v2.2.0.
+  - undelegate:
+      - node: validator-v216
+        delegator: rotating-staker
+
+  - delegate:
+      - node: validator-v220
+        delegator: rotating-staker
+        stake: 5000000
+
+  - advanceEpoch
+  - verifyStakes
+
+  - checks:
+      - blocksProduced:
+          tolerance: 10
+
+  # Close the cycle: back onto the candidate, which held and lost the
+  # 75% earlier, so it is staked again from zero.
+  - undelegate:
+      - node: validator-v220
+        delegator: rotating-staker
+
+  - delegate:
+      - node: validator-local
+        delegator: rotating-staker
+        stake: 5000000
+
+  - advanceEpoch
+  - verifyStakes


### PR DESCRIPTION
Add tests from some common patterns, mostly expectations on misconfigured scenarios. 

Add two new scenarios :
- example: one account does multiple delegate-undelegated pairs
- release testing: delegation is correctly interpreted by nodes using different versions, chain remains coherent. 