### PR TITLE
Fix rpc null return

### DIFF
--- a/driver/rpc/rpc.go
+++ b/driver/rpc/rpc.go
@@ -189,11 +189,14 @@ func (r Impl) GetNetworkRules(block string) (opera.Rules, error) {
 		block = "latest"
 	}
 
-	var rules opera.Rules
+	var rules *opera.Rules
 	if err := r.Call(&rules, "eth_getRules", block); err != nil {
 		return opera.Rules{}, fmt.Errorf("failed to get network rules: %w", err)
 	}
-	return rules, nil
+	if rules == nil {
+		return opera.Rules{}, fmt.Errorf("no network rules available for block %q", block)
+	}
+	return *rules, nil
 }
 
 func (r Impl) transactionReceipt(txHash common.Hash) (*types.Receipt, error) {

--- a/driver/rpc/rpc_test.go
+++ b/driver/rpc/rpc_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"go.uber.org/mock/gomock"
@@ -109,6 +110,72 @@ func TestRpcClientImpl_WaitTransactionReceipt_Error(t *testing.T) {
 		Times(1)
 
 	if _, err := client.WaitTransactionReceipt(context.Background(), common.Hash{}); !errors.Is(err, injectedError) {
+		t.Fatalf("expected error %v, got %v", injectedError, err)
+	}
+}
+
+func TestRpcClientImpl_GetNetworkRules_Success(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	mock := NewMockrpcClient(ctrl)
+	client := Impl{rpcClient: mock}
+
+	injectedRules := opera.Rules{Name: "test-rules"}
+
+	mock.EXPECT().
+		Call(gomock.Any(), "eth_getRules", "latest").
+		DoAndReturn(func(result interface{}, method string, args ...interface{}) error {
+			resultPtr, ok := result.(**opera.Rules)
+			if !ok {
+				t.Fatalf("result type is not **opera.Rules")
+			}
+			*resultPtr = &injectedRules
+			return nil
+		})
+
+	rules, err := client.GetNetworkRules("")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got, want := rules.Name, injectedRules.Name; got != want {
+		t.Errorf("got rules name %q, want %q", got, want)
+	}
+}
+
+func TestRpcClientImpl_GetNetworkRules_NullResult(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	mock := NewMockrpcClient(ctrl)
+	client := Impl{rpcClient: mock}
+
+	mock.EXPECT().
+		Call(gomock.Any(), "eth_getRules", "latest").
+		Return(nil)
+
+	if _, err := client.GetNetworkRules("latest"); err == nil {
+		t.Fatal("expected error for null rules result, got nil")
+	}
+}
+
+func TestRpcClientImpl_GetNetworkRules_Error(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	mock := NewMockrpcClient(ctrl)
+	client := Impl{rpcClient: mock}
+
+	injectedError := errors.New("injected error")
+
+	mock.EXPECT().
+		Call(gomock.Any(), "eth_getRules", "latest").
+		Return(injectedError)
+
+	if _, err := client.GetNetworkRules("latest"); !errors.Is(err, injectedError) {
 		t.Fatalf("expected error %v, got %v", injectedError, err)
 	}
 }

--- a/driver/rpc/rpc_test.go
+++ b/driver/rpc/rpc_test.go
@@ -114,7 +114,7 @@ func TestRpcClientImpl_WaitTransactionReceipt_Error(t *testing.T) {
 	}
 }
 
-func TestRpcClientImpl_GetNetworkRules_Success(t *testing.T) {
+func TestGetNetworkRules_ReturnsRules_WhenRulesAreAvailable(t *testing.T) {
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
@@ -144,7 +144,7 @@ func TestRpcClientImpl_GetNetworkRules_Success(t *testing.T) {
 	}
 }
 
-func TestRpcClientImpl_GetNetworkRules_NullResult(t *testing.T) {
+func TestGetNetworkRules_ReturnsError_WhenResultIsNull(t *testing.T) {
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
Sonic's eth_getRules can legitimately return null without an error — notably during the epoch-transition window where the current epoch state is already advanced but its history-table entry isn't written yet. Norma's GetNetworkRules silently decoded that null into a zero-value opera.Rules, which the networkRules checker then fed into opera.UpdateRules, panicking on a nil *big.Int in Rules.Copy. The fix decodes into a *opera.Rules and returns an error when it stays nil, so the checker's 30-second convergence retry loop absorbs the transient window instead of crashing the run.

Fixes [#877](https://github.com/0xsoniclabs/sonic-admin/issues/877#event-29125435684).