### PR TITLE
Add priority lanes, a check that they work, and scenarios

### DIFF
--- a/SCENARIO_SPECIFICATION.md
+++ b/SCENARIO_SPECIFICATION.md
@@ -237,10 +237,38 @@ Starts a load-generating application. The value is the application’s
 ```
 
 **Supported application types** (case-insensitive): `counter`, `erc20`,
-`store`, `uniswap`, `smartaccount`, `subsidies`, `transient`,
+`store`, `uniswap`, `smartaccount`, `subsidies`, `priority`, `transient`,
 `selfdestructoldcontract`, `selfdestructnewcontract`, `ecdsa`,
 `largecontract`, `allofbundle`, `oneofbundle`, `subsidizedbundle`,
 `failingbundle`, `duplicatedbundle`, `bls12add`, `mix`.
+
+A priority lane is a property of a load rather than a load of its own, so
+`priority` does not generate traffic itself: the optional `load` parameter names
+the type that does, and the accounts signing it are registered in the on-chain
+priority registry.
+
+```yaml
+- runApp: fast
+  type: priority
+  load: uniswap            # optional; any type above, defaults to counter
+  rate:
+    constant: 20
+```
+
+Running that next to a plain `uniswap` application isolates the effect of the
+feature, since the two loads differ in nothing else. `load` applies to `priority`
+only; on any other type it is an error, as is nesting one lane in another.
+
+`priority` requires the `TransactionPriorities` upgrade to be active and fails
+to start otherwise; see
+[scenarios/examples/priority_lanes.yml](scenarios/examples/priority_lanes.yml)
+for a scenario making the effect of the lanes visible.
+
+The loads whose users create the accounts they sign with while they run - the
+bundle types and `mix` - cannot be prioritized: their accounts are not known when
+the registry is written, and registering the ones that happen to exist would
+prioritize a part of their traffic and quietly leave the rest behind. Asking for
+them reports that rather than doing it.
 
 **Rate shapes** — exactly one of the following must be set on `rate`:
 
@@ -359,6 +387,7 @@ Upgrades:
   SingleProposerBlockFormation: <bool>
   GasSubsidies: <bool>
   TransactionBundles: <bool>
+  TransactionPriorities: <bool>
 ```
 
 Type notes:
@@ -380,31 +409,33 @@ The canonical Go type is
 Checks appear as items inside a `checks:` step. Each entry is either a bare
 function name or a mapping.
 
-| Function           | Purpose                                                          | Parameters                                    |
-| ------------------ | ---------------------------------------------------------------- | --------------------------------------------- |
-| `blockGasRate`     | Assert block gas rate ≤ ceiling over an observation window.      | `ceiling`, `tolerance`, `duration`, `failing` |
-| `blockHashes`      | Assert all nodes agree on block hashes.                          | `failing`                                     |
-| `blockHeights`     | Assert all nodes are within tolerance of the same height.        | `tolerance`, `duration`, `failing`            |
-| `blocksHalted`     | Assert block production has halted over an observation window.   | `tolerance`, `duration`, `failing`            |
-| `blocksProduced`   | Assert the network produces blocks over an observation window.   | `tolerance`, `duration`, `failing`            |
-| `eventThrottled`   | Assert the listed validators emit events far slower than others. | `throttledNodes`, `failing`                   |
-| `networkRules`     | Assert the active rules on all nodes match the given patch.      | `rules`, `duration`, `failing`                |
-| `validatorsActive` | Assert every running validator is in the epoch's validator set.  | `failing`                                     |
+| Function                       | Purpose                                                          | Parameters                                    |
+| ------------------------------ | ---------------------------------------------------------------- | --------------------------------------------- |
+| `blockGasRate`                 | Assert block gas rate ≤ ceiling over an observation window.      | `ceiling`, `tolerance`, `duration`, `failing` |
+| `blockHashes`                  | Assert all nodes agree on block hashes.                          | `failing`                                     |
+| `blockHeights`                 | Assert all nodes are within tolerance of the same height.        | `tolerance`, `duration`, `failing`            |
+| `blocksHalted`                 | Assert block production has halted over an observation window.   | `tolerance`, `duration`, `failing`            |
+| `blocksProduced`               | Assert the network produces blocks over an observation window.   | `tolerance`, `duration`, `failing`            |
+| `eventThrottled`               | Assert the listed validators emit events far slower than others. | `throttledNodes`, `failing`                   |
+| `networkRules`                 | Assert the active rules on all nodes match the given patch.      | `rules`, `duration`, `failing`                |
+| `prioritizedTransactionsFirst` | Assert blocks open with registered senders' transactions.        | `minMixedBlocks`, `minRunCoverage`, `failing` |
+| `validatorsActive`             | Assert every running validator is in the epoch's validator set.  | `failing`                                     |
 
 ### 5.1 Windows of time
 
 Every check fixes the span it judges **when it starts**, and never reads data
 recorded before that instant. There are four shapes.
 
-| Check            | Window kind            | Anchored at                  | Judges                                 |
-| ---------------- | ---------------------- | ---------------------------- | -------------------------------------- |
-| `blocksProduced` | Forward observation    | now, at entry                | Height samples taken while waiting     |
-| `blocksHalted`   | Forward observation    | now, at entry                | Height samples taken while waiting     |
-| `blockGasRate`   | Forward observation    | chain head, at entry         | Blocks produced while waiting          |
-| `blockHeights`   | Convergence budget     | now + budget, at entry       | Live heights, re-read until they agree |
-| `networkRules`   | Convergence budget     | now + budget, at entry       | Live rules, re-read until they agree   |
-| `blockHashes`    | Fixed block range      | lowest head of healthy nodes | Blocks 0…that head, settled everywhere |
-| `eventThrottled` | Two measured snapshots | each DAG head query          | Event delta ÷ the interval measured    |
+| Check                          | Window kind            | Anchored at                  | Judges                                 |
+| ------------------------------ | ---------------------- | ---------------------------- | -------------------------------------- |
+| `blocksProduced`               | Forward observation    | now, at entry                | Height samples taken while waiting     |
+| `blocksHalted`                 | Forward observation    | now, at entry                | Height samples taken while waiting     |
+| `blockGasRate`                 | Forward observation    | chain head, at entry         | Blocks produced while waiting          |
+| `prioritizedTransactionsFirst` | Forward observation    | chain head, at entry         | Blocks produced while waiting          |
+| `blockHeights`                 | Convergence budget     | now + budget, at entry       | Live heights, re-read until they agree |
+| `networkRules`                 | Convergence budget     | now + budget, at entry       | Live rules, re-read until they agree   |
+| `blockHashes`                  | Fixed block range      | lowest head of healthy nodes | Blocks 0…that head, settled everywhere |
+| `eventThrottled`               | Two measured snapshots | each DAG head query          | Event delta ÷ the interval measured    |
 
 **Forward observation.** The check notes the current instant, waits for its
 window, and then looks only at what the monitor collected while it waited.
@@ -471,6 +502,16 @@ Two things to keep in mind:
   in blocks**. `duration`, when given, always wins over `tolerance`.
 - `duration` is an observation window for the three observing checks, but a
   convergence budget for `blockHeights` and `networkRules`.
+
+`prioritizedTransactionsFirst` notes the head when it starts and then waits for
+blocks, judging only those the network produces from that point on. It stops once
+`minMixedBlocks` of them (**10**) carried transactions of both classes, and
+requires their opening run of prioritized transactions to cover a median
+`minRunCoverage` (**0.5**) of the transactions the per-entity gas quota admits.
+Its `duration` (**2m**) is how long it waits for those blocks; too few, and the
+check fails for lack of evidence rather than passing. Lower the coverage for a
+lane congested enough that transactions are regularly demoted for reasons a block
+does not show, such as a nonce gap.
 
 Both floors are enforced when the scenario is loaded, not minutes into the run:
 on a check that reads the parameter as a window, a `duration` below 2s is

--- a/driver/checking/priority_ordering.go
+++ b/driver/checking/priority_ordering.go
@@ -1,0 +1,469 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package checking
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"slices"
+	"time"
+
+	"github.com/0xsoniclabs/norma/driver"
+	"github.com/0xsoniclabs/norma/driver/monitoring"
+	"github.com/0xsoniclabs/norma/driver/rpc"
+	priority_registry "github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// The check observes the network forward in time: it notes the head of the chain
+// when it starts and judges only blocks produced after that, so it reports on the
+// load the scenario has running rather than on anything an earlier step left
+// behind. It stops once it has seen enough blocks carrying both prioritized and
+// ordinary transactions, or when one of the two bounds below is reached.
+const (
+	// maxBlocksObserved bounds the blocks read, so that a fast chain cannot turn
+	// one check into thousands of requests.
+	maxBlocksObserved = 500
+
+	// defaultPriorityTimeout is how long the check waits for the blocks it needs. It has
+	// to outlast a lane that meets ordinary traffic only occasionally, and it has
+	// to end a run in which the two never meet.
+	defaultPriorityTimeout = 2 * time.Minute
+
+	// priorityPollInterval is how long the check waits before asking again for
+	// the head of the chain.
+	priorityPollInterval = 500 * time.Millisecond
+)
+
+// defaultMinMixedBlocks is how many blocks must carry transactions of both
+// classes for the observation to mean anything. Without a floor the check would
+// pass on a network where nothing was prioritized at all.
+const defaultMinMixedBlocks = 10
+
+// defaultMinRunCoverage is the share of the prioritized transactions a block
+// could hoist that its opening run must cover, as a median over the observed
+// blocks. Hoisting puts all of them in that run, so the value is near one; an
+// order that ignores priorities leaves runs of the length chance produces, which
+// is a small fraction of a block carrying hundreds of transactions. Scenarios
+// that congest the lane can lower it, see the minRunCoverage parameter.
+const defaultMinRunCoverage = 0.5
+
+func init() {
+	RegisterNetworkCheck("prioritizedTransactionsFirst",
+		func(net driver.Network, _ *monitoring.Monitor) Checker {
+			return newPriorityOrderingChecker(net)
+		})
+}
+
+// priorityOrderingChecker verifies that block formation hoists the transactions
+// of registered senders: a block carrying both classes opens with a run of
+// prioritized transactions, and that run stays within the gas the registry
+// grants one entity per block.
+//
+// The ordering is a pure function of the block's transactions, the registry and
+// the account nonces, so unlike a comparison of latencies it does not depend on
+// rates, timing or the machine the network runs on.
+//
+// What a block does not show is which of its transactions were hoisted: a
+// prioritized transaction the quota or a nonce gap demoted is appended among the
+// ordinary ones and is indistinguishable from one. The check therefore measures
+// the opening run against the transactions the quota could admit rather than
+// against all of them, judges the median block, and asserts the quota only where
+// no demotion is visible.
+type priorityOrderingChecker struct {
+	source         prioritySource
+	minMixedBlocks int
+	minRunCoverage float64
+	timeout        time.Duration
+}
+
+func newPriorityOrderingChecker(net driver.Network) *priorityOrderingChecker {
+	return &priorityOrderingChecker{
+		source:         &networkPrioritySource{net: net},
+		minMixedBlocks: defaultMinMixedBlocks,
+		minRunCoverage: defaultMinRunCoverage,
+		timeout:        defaultPriorityTimeout,
+	}
+}
+
+// prioritySource provides what the check reads: the chain's blocks in order, the
+// priority of a sender and the gas one entity may have hoisted per block.
+type prioritySource interface {
+	LatestBlock(ctx context.Context) (int, error)
+	Block(ctx context.Context, height int) ([]blockTransaction, error)
+	Prioritized(ctx context.Context, sender common.Address) (priorityClass, error)
+	GasQuota(ctx context.Context) (uint64, error)
+}
+
+// priorityClass is what the registry says about a sender: whether its
+// transactions are prioritized and which entity's per-block gas budget they draw
+// from. The entity is compared and reported, never interpreted.
+type priorityClass struct {
+	Prioritized bool
+	Entity      string
+}
+
+// blockTransaction is one transaction of a block, in the order the block carries
+// it.
+type blockTransaction struct {
+	From common.Address
+	Gas  uint64 // the gas reserved, which is what the quota counts
+	// Internal marks a transaction the client itself inserted, such as sealing an
+	// epoch. Those are placed around the transactions of users rather than
+	// ordered among them.
+	Internal bool
+}
+
+func (c *priorityOrderingChecker) Configure(config CheckerConfig) Checker {
+	if config == nil {
+		return c
+	}
+	relaxed := *c
+	if v, exists := config["minMixedBlocks"]; exists {
+		relaxed.minMixedBlocks = v.(int)
+	}
+	if v, exists := config["minRunCoverage"]; exists {
+		relaxed.minRunCoverage = v.(float64)
+	}
+	if v, exists := config["duration"]; exists {
+		relaxed.timeout = time.Duration(v.(int64))
+	}
+	return &relaxed
+}
+
+func (c *priorityOrderingChecker) Check(ctx context.Context) error {
+	quota, err := c.source.GasQuota(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to read the priority configuration: %w", err)
+	}
+	start, err := c.source.LatestBlock(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to read the head of the chain: %w", err)
+	}
+
+	classes := map[common.Address]priorityClass{}
+	classOf := func(sender common.Address) (priorityClass, error) {
+		if known, found := classes[sender]; found {
+			return known, nil
+		}
+		known, err := c.source.Prioritized(ctx, sender)
+		if err != nil {
+			return priorityClass{}, err
+		}
+		classes[sender] = known
+		return known, nil
+	}
+
+	seen := observation{}
+	deadline := time.Now().Add(c.timeout)
+	next := start + 1
+	waited := false
+
+	for seen.mixed < c.minMixedBlocks && seen.blocks < maxBlocksObserved {
+		head, err := c.source.LatestBlock(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to read the head of the chain: %w", err)
+		}
+		if head < next {
+			// The block is not there yet: wait for the network to produce it, as
+			// long as the budget lasts.
+			if time.Now().After(deadline) {
+				waited = true
+				break
+			}
+			if err := sleep(ctx, priorityPollInterval); err != nil {
+				return err
+			}
+			continue
+		}
+
+		for ; next <= head && seen.mixed < c.minMixedBlocks && seen.blocks < maxBlocksObserved; next++ {
+			txs, err := c.source.Block(ctx, next)
+			if err != nil {
+				return fmt.Errorf("failed to read block %d: %w", next, err)
+			}
+
+			classified := make([]classifiedTransaction, 0, len(txs))
+			for _, tx := range txs {
+				if tx.Internal {
+					continue
+				}
+				known, err := classOf(tx.From)
+				if err != nil {
+					return fmt.Errorf("failed to read the priority of %v: %w", tx.From, err)
+				}
+				classified = append(classified, classifiedTransaction{class: known, gas: tx.Gas})
+			}
+			seen.add(next, measureOrder(classified, quota), quota)
+		}
+	}
+
+	slog.Info("checked the order of prioritized transactions",
+		"observedBlocks", seen.blocks,
+		"firstBlock", start+1,
+		"mixedBlocks", seen.mixed,
+		"medianRunCoverage", medianOf(seen.coverages),
+		"minRunCoverage", c.minRunCoverage,
+		"blocksOverQuota", len(seen.overQuota),
+		"blocksWithDemotedTransactions", seen.demoted,
+		"gasQuota", quota)
+
+	var issues []error
+	if seen.mixed < c.minMixedBlocks {
+		reason := fmt.Sprintf("in the %d blocks produced since the check started", seen.blocks)
+		if waited {
+			reason = fmt.Sprintf("in the %d blocks the network produced in %s", seen.blocks, c.timeout)
+		}
+		issues = append(issues, fmt.Errorf(
+			"only %d blocks carried both prioritized and ordinary transactions %s, "+
+				"%d are required: the ordering of an absent load cannot be observed, "+
+				"so this check would pass on a network without priorities",
+			seen.mixed, reason, c.minMixedBlocks))
+	}
+	if len(seen.overQuota) > 0 {
+		issues = append(issues, fmt.Errorf(
+			"prioritized transactions were hoisted beyond the gas one entity may "+
+				"have per block: %v", seen.overQuota))
+	}
+	if median := medianOf(seen.coverages); seen.mixed >= c.minMixedBlocks && median < c.minRunCoverage {
+		issues = append(issues, fmt.Errorf(
+			"blocks carrying both do not open with their prioritized transactions: "+
+				"the opening run covers a median %.2f of the transactions the gas "+
+				"quota could admit, %.2f is required - the block order does not look "+
+				"prioritized at all",
+			median, c.minRunCoverage))
+	}
+	return errors.Join(issues...)
+}
+
+// observation accumulates what the blocks read so far say about the order.
+type observation struct {
+	blocks    int       // blocks read
+	mixed     int       // of those, the ones carrying both classes
+	demoted   int       // of those, the ones that also left prioritized ones behind
+	coverages []float64 // the coverage of each mixed block
+	overQuota []string  // the blocks whose hoisted run exceeded the quota
+}
+
+func (o *observation) add(height int, order blockOrder, quota uint64) {
+	o.blocks++
+	if !order.mixed || order.admissible == 0 {
+		// One class only, or a lane the quota cannot admit anything of: the block
+		// says nothing about the order of the two.
+		return
+	}
+	o.mixed++
+	o.coverages = append(o.coverages, order.coverage())
+
+	if order.run < order.prioritized {
+		// Prioritized transactions follow ordinary ones, so this block demoted some
+		// of them and where its hoisted prefix ended is not observable. Anything the
+		// opening run carries beyond the quota may be that remainder rather than an
+		// overrun.
+		o.demoted++
+		return
+	}
+	for entity, gas := range order.runGas {
+		if gas > quota {
+			o.overQuota = append(o.overQuota, fmt.Sprintf(
+				"block %d hoisted %d gas of %d allowed for entity %s",
+				height, gas, quota, entity))
+		}
+	}
+}
+
+// classifiedTransaction is a transaction of a block paired with what the registry
+// says about its sender.
+type classifiedTransaction struct {
+	class priorityClass
+	gas   uint64
+}
+
+// blockOrder is what one block says about the order of prioritized
+// transactions.
+type blockOrder struct {
+	mixed       bool              // carries transactions of both classes
+	prioritized int               // prioritized transactions anywhere in the block
+	admissible  int               // as many of them as the gas quota can admit
+	run         int               // prioritized transactions opening the block
+	runGas      map[string]uint64 // the gas of that run, per entity
+}
+
+// coverage is the share of the prioritized transactions a block could hoist that
+// its opening run carries. It saturates at one: a run longer than the quota
+// admits contains transactions the client demoted, which are not evidence of a
+// better order than the quota allows.
+func (o blockOrder) coverage() float64 {
+	return min(float64(o.run)/float64(o.admissible), 1)
+}
+
+// measureOrder reads the given block. admissible replaces the plain count of
+// prioritized transactions as the yardstick for the opening run: the client
+// hoists them per entity only while that entity's gas quota lasts and demotes
+// the rest, so a lane offering more gas than its quota necessarily leaves
+// prioritized transactions among the ordinary ones. Counting those as a
+// misordering would fail the check exactly when the quota does its job.
+//
+// It is computed by admitting the prioritized transactions in block order while
+// their entity has budget left, which is an upper bound: the per-sender nonce
+// contiguity the client also requires can only admit fewer.
+func measureOrder(txs []classifiedTransaction, quota uint64) blockOrder {
+	order := blockOrder{runGas: map[string]uint64{}}
+
+	budget := map[string]uint64{}
+	remaining := func(entity string) uint64 {
+		if left, known := budget[entity]; known {
+			return left
+		}
+		return quota
+	}
+	for _, tx := range txs {
+		if !tx.class.Prioritized {
+			continue
+		}
+		order.prioritized++
+		if left := remaining(tx.class.Entity); tx.gas <= left {
+			budget[tx.class.Entity] = left - tx.gas
+			order.admissible++
+		}
+	}
+	order.mixed = order.prioritized > 0 && order.prioritized < len(txs)
+
+	for _, tx := range txs {
+		if !tx.class.Prioritized {
+			break
+		}
+		order.runGas[tx.class.Entity] += tx.gas
+		order.run++
+	}
+	return order
+}
+
+// medianOf returns the median of the given values, or zero if there are none.
+func medianOf(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := slices.Clone(values)
+	slices.Sort(sorted)
+	return sorted[len(sorted)/2]
+}
+
+// networkPrioritySource reads the blocks and the registry of a live network.
+type networkPrioritySource struct {
+	net      driver.Network
+	client   rpc.Client
+	registry *priority_registry.Registry
+}
+
+func (s *networkPrioritySource) connect() error {
+	if s.client != nil {
+		return nil
+	}
+	client, err := s.net.DialRandomRpc()
+	if err != nil {
+		return fmt.Errorf("failed to connect to the network: %w", err)
+	}
+	registry, err := priority_registry.NewRegistry(priority_registry.GetAddress(), client)
+	if err != nil {
+		client.Close()
+		return fmt.Errorf("failed to bind to the priority registry: %w", err)
+	}
+	s.client, s.registry = client, registry
+	return nil
+}
+
+func (s *networkPrioritySource) LatestBlock(ctx context.Context) (int, error) {
+	if err := s.connect(); err != nil {
+		return 0, err
+	}
+	height, err := s.client.BlockNumber(ctx)
+	return int(height), err
+}
+
+func (s *networkPrioritySource) Block(_ context.Context, height int) ([]blockTransaction, error) {
+	if err := s.connect(); err != nil {
+		return nil, err
+	}
+	var block *struct {
+		Transactions []struct {
+			From common.Address `json:"from"`
+			Gas  hexutil.Uint64 `json:"gas"`
+			V    *hexutil.Big   `json:"v"`
+			R    *hexutil.Big   `json:"r"`
+		} `json:"transactions"`
+	}
+	if err := s.client.Call(
+		&block, "eth_getBlockByNumber", hexutil.EncodeUint64(uint64(height)), true,
+	); err != nil {
+		return nil, err
+	}
+	if block == nil {
+		return nil, fmt.Errorf("block %d not found", height)
+	}
+
+	txs := make([]blockTransaction, 0, len(block.Transactions))
+	for _, tx := range block.Transactions {
+		txs = append(txs, blockTransaction{
+			From: tx.From,
+			Gas:  uint64(tx.Gas),
+			// The client signs its own transactions with an empty signature.
+			Internal: isZero(tx.V) && isZero(tx.R),
+		})
+	}
+	return txs, nil
+}
+
+func (s *networkPrioritySource) Prioritized(_ context.Context, sender common.Address) (priorityClass, error) {
+	if err := s.connect(); err != nil {
+		return priorityClass{}, err
+	}
+	priority, err := s.registry.SenderPriority(nil, sender)
+	if err != nil {
+		return priorityClass{}, err
+	}
+	if priority.Level == 0 {
+		return priorityClass{}, nil
+	}
+	// The gas quota is granted per entity, so senders of the same entity - one
+	// Norma application - share it.
+	return priorityClass{Prioritized: true, Entity: priority.Id.String()}, nil
+}
+
+func (s *networkPrioritySource) GasQuota(_ context.Context) (uint64, error) {
+	if err := s.connect(); err != nil {
+		return 0, err
+	}
+	config, err := s.registry.GetPriorityConfig(nil)
+	if err != nil {
+		return 0, err
+	}
+	if !config.MaxGasPerEntityPerBlock.IsUint64() {
+		return 0, fmt.Errorf(
+			"the registry grants %v gas per entity per block, which does not fit a 64 bit value",
+			config.MaxGasPerEntityPerBlock)
+	}
+	return config.MaxGasPerEntityPerBlock.Uint64(), nil
+}
+
+func isZero(value *hexutil.Big) bool {
+	return value == nil || (*big.Int)(value).Sign() == 0
+}

--- a/driver/checking/priority_ordering_test.go
+++ b/driver/checking/priority_ordering_test.go
@@ -1,0 +1,320 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package checking
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+const txGas = 30_000
+
+func TestPriorityOrdering_HoistedBlocksPass(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		source := blocksOf(20, hoisted(10, 10))
+		require.NoError(t, checkerFor(source).Check(t.Context()))
+	})
+}
+
+func TestPriorityOrdering_ScrambledBlocksFail(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// The order a network without priorities produces: the two classes are mixed
+		// through the block, so the opening run covers a small share of them.
+		source := blocksOf(20, alternating(10, 10))
+		err := checkerFor(source).Check(t.Context())
+		require.ErrorContains(t, err, "does not look prioritized")
+	})
+}
+
+func TestPriorityOrdering_ABlockOpeningWithOrdinaryTransactionsFails(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		block := append(ordinary(10), prioritized(10)...)
+		err := checkerFor(blocksOf(20, block)).Check(t.Context())
+		require.ErrorContains(t, err, "does not look prioritized")
+	})
+}
+
+func TestPriorityOrdering_RequiresEnoughBlocksCarryingBoth(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Blocks of one class say nothing about the order of the other, so a run
+		// where the prioritized load never met ordinary traffic must not pass.
+		err := checkerFor(blocksOf(20, prioritized(10))).Check(t.Context())
+		require.ErrorContains(t, err, "carried both")
+		require.ErrorContains(t, err, "would pass on a network without priorities")
+	})
+}
+
+func TestPriorityOrdering_JudgesOnlyBlocksProducedAfterItStarted(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// A chain of well ordered blocks that stops producing when the check starts.
+		// The check observes forward in time, so it has nothing to judge and must
+		// say so rather than pass on the blocks of an earlier step.
+		source := blocksOf(0, nil)
+		source.existing, source.past = 50, hoisted(10, 10)
+
+		err := checkerFor(source).Check(t.Context())
+		require.ErrorContains(t, err, "carried both")
+	})
+}
+
+func TestPriorityOrdering_WaitsForTheBlocksItNeeds(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// The blocks arrive one every two seconds, well beyond the interval the
+		// check polls at, and it collects them rather than giving up.
+		source := blocksOf(20, hoisted(10, 10))
+		source.blockTime = 2 * time.Second
+		require.NoError(t, checkerFor(source).Check(t.Context()))
+	})
+}
+
+func TestPriorityOrdering_GivesUpAfterItsBudget(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// A network so slow that the check cannot see its evidence: it ends after
+		// its budget rather than holding the scenario.
+		source := blocksOf(20, hoisted(10, 10))
+		source.blockTime = time.Minute
+
+		checker := checkerFor(source).Configure(CheckerConfig{"duration": int64(10 * time.Second)})
+		start := time.Now()
+		require.ErrorContains(t, checker.Check(t.Context()), "in 10s")
+		require.WithinDuration(t, start.Add(10*time.Second), time.Now(), time.Second)
+	})
+}
+
+func TestPriorityOrdering_HoistingBeyondTheQuotaFails(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// 10 transactions of 30k gas against a quota of 200k: the client may hoist
+		// six of them, so a block whose opening run carries all ten is over budget.
+		source := blocksOf(20, hoisted(10, 10))
+		source.quota = 200_000
+		err := checkerFor(source).Check(t.Context())
+		require.ErrorContains(t, err, "beyond the gas one entity may have per block")
+	})
+}
+
+func TestPriorityOrdering_TheQuotaIsCountedPerEntity(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Two entities hoisting 60k each exceed a quota of 100k together but not
+		// individually, which is how the client grants it.
+		block := append(prioritizedOf(1, 2, 30_000), prioritizedOf(2, 2, 30_000)...)
+		source := blocksOf(20, append(block, ordinary(10)...))
+		source.quota = 100_000
+		require.NoError(t, checkerFor(source).Check(t.Context()))
+
+		// The same gas spent by one entity is over its budget.
+		source = blocksOf(20, append(prioritizedOf(1, 4, 30_000), ordinary(10)...))
+		source.quota = 100_000
+		require.ErrorContains(t, checkerFor(source).Check(t.Context()),
+			"beyond the gas one entity may have per block")
+	})
+}
+
+func TestPriorityOrdering_TransactionsTheQuotaDemotesAreNotAMisordering(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// A lane offering more gas than its quota: the client hoists what fits and
+		// leaves the rest among the ordinary transactions. Judged against all
+		// prioritized transactions of the block the order would look broken, while it
+		// is exactly what the quota prescribes.
+		block := append(prioritizedOf(1, 2, 50_000_000), ordinary(10)...)
+		block = append(block, prioritizedOf(1, 8, 50_000_000)...)
+
+		source := blocksOf(20, block)
+		source.quota = 100_000_000
+		require.NoError(t, checkerFor(source).Check(t.Context()))
+	})
+}
+
+func TestPriorityOrdering_TheQuotaIsNotAssertedWhereTransactionsWereDemoted(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// A block that demoted prioritized transactions does not show where its
+		// hoisted prefix ended, so the gas of the opening run beyond the quota cannot
+		// be told from the demoted remainder and must not be reported as an overrun.
+		block := append(prioritizedOf(1, 3, 50_000_000), ordinary(10)...)
+		block = append(block, prioritizedOf(1, 5, 50_000_000)...)
+
+		source := blocksOf(20, block)
+		source.quota = 100_000_000
+		require.NoError(t, checkerFor(source).Check(t.Context()))
+	})
+}
+
+func TestPriorityOrdering_TheRequiredCoverageCanBeRelaxed(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Three of the ten transactions the quota admits open the block.
+		block := append(prioritized(3), ordinary(10)...)
+		block = append(block, prioritized(7)...)
+
+		base := checkerFor(blocksOf(20, block))
+		require.ErrorContains(t, base.Check(t.Context()), "does not look prioritized")
+
+		relaxed := checkerFor(blocksOf(20, block)).Configure(CheckerConfig{"minRunCoverage": 0.25})
+		require.NoError(t, relaxed.Check(t.Context()))
+	})
+}
+
+func TestPriorityOrdering_PartialHoistingIsAccepted(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Transactions a nonce gap or the quota left behind stay among the ordinary
+		// ones; the check judges the median block rather than demanding every
+		// prioritized transaction be hoisted.
+		block := append(prioritized(7), ordinary(10)...)
+		block = append(block, prioritized(3)...)
+		require.NoError(t, checkerFor(blocksOf(20, block)).Check(t.Context()))
+	})
+}
+
+func TestPriorityOrdering_InternalTransactionsDoNotCount(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// The client inserts its own transactions around the ordered ones, so an
+		// epoch seal at the front of a block is not an ordinary transaction that
+		// overtook the lane.
+		block := append([]blockTransaction{{From: common.Address{0xff}, Gas: txGas, Internal: true}}, hoisted(10, 10)...)
+		require.NoError(t, checkerFor(blocksOf(20, block)).Check(t.Context()))
+	})
+}
+
+func TestPriorityOrdering_ConfigureOverridesTheRequiredEvidence(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		base := checkerFor(blocksOf(4, hoisted(10, 10)))
+		require.ErrorContains(t, base.Check(t.Context()), "carried both",
+			"four blocks are below the default requirement")
+
+		relaxed := checkerFor(blocksOf(4, hoisted(10, 10))).
+			Configure(CheckerConfig{"minMixedBlocks": 4})
+		require.NoError(t, relaxed.Check(t.Context()))
+	})
+}
+
+func TestPriorityOrdering_ReportsAFailingSource(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		source := blocksOf(20, hoisted(10, 10))
+		source.err = errors.New("no reachable node")
+		require.ErrorContains(t, checkerFor(source).Check(t.Context()), "no reachable node")
+	})
+}
+
+func checkerFor(source *fakePrioritySource) Checker {
+	return &priorityOrderingChecker{
+		source:         source,
+		minMixedBlocks: defaultMinMixedBlocks,
+		minRunCoverage: defaultMinRunCoverage,
+		timeout:        defaultPriorityTimeout,
+	}
+}
+
+// prioritized and ordinary build transactions of senders the fake source
+// classifies by their address: the first byte carries the priority, the second
+// the entity the sender belongs to.
+func prioritized(count int) []blockTransaction {
+	return prioritizedOf(1, count, txGas)
+}
+
+func prioritizedOf(entity byte, count int, gas uint64) []blockTransaction {
+	return transactionsOf(count, common.Address{0x01, entity}, gas)
+}
+
+func ordinary(count int) []blockTransaction {
+	return transactionsOf(count, common.Address{0x02}, txGas)
+}
+
+func transactionsOf(count int, sender common.Address, gas uint64) []blockTransaction {
+	txs := make([]blockTransaction, 0, count)
+	for range count {
+		txs = append(txs, blockTransaction{From: sender, Gas: gas})
+	}
+	return txs
+}
+
+// hoisted is a block as the client forms it: the prioritized transactions first.
+func hoisted(prio, plain int) []blockTransaction {
+	return append(prioritized(prio), ordinary(plain)...)
+}
+
+// alternating is a block whose classes are interleaved, as an order that ignores
+// priorities produces.
+func alternating(prio, plain int) []blockTransaction {
+	var txs []blockTransaction
+	for i := 0; i < prio || i < plain; i++ {
+		if i < prio {
+			txs = append(txs, prioritized(1)...)
+		}
+		if i < plain {
+			txs = append(txs, ordinary(1)...)
+		}
+	}
+	return txs
+}
+
+// blocksOf is a network that produces the given number of blocks, all of the
+// given content, while the check observes it, and then stops.
+func blocksOf(count int, block []blockTransaction) *fakePrioritySource {
+	return &fakePrioritySource{produced: count, block: block, quota: 100_000_000}
+}
+
+// fakePrioritySource is a chain of existing blocks that produces produced more,
+// one per blockTime, from the moment its head is first read.
+type fakePrioritySource struct {
+	existing  int                // blocks on the chain before the check starts
+	produced  int                // blocks produced after that
+	blockTime time.Duration      // how long each of those takes
+	past      []blockTransaction // what the existing blocks carry
+	block     []blockTransaction // what the produced blocks carry
+	quota     uint64
+	err       error
+
+	firstRead time.Time
+}
+
+func (s *fakePrioritySource) LatestBlock(context.Context) (int, error) {
+	if s.err != nil {
+		return 0, s.err
+	}
+	if s.firstRead.IsZero() {
+		s.firstRead = time.Now()
+		return s.existing, nil
+	}
+	produced := s.produced
+	if s.blockTime > 0 {
+		produced = min(produced, int(time.Since(s.firstRead)/s.blockTime))
+	}
+	return s.existing + produced, nil
+}
+
+func (s *fakePrioritySource) Block(_ context.Context, height int) ([]blockTransaction, error) {
+	if height <= s.existing {
+		return s.past, s.err
+	}
+	return s.block, s.err
+}
+
+func (s *fakePrioritySource) Prioritized(_ context.Context, sender common.Address) (priorityClass, error) {
+	if sender[0] != 0x01 {
+		return priorityClass{}, s.err
+	}
+	return priorityClass{Prioritized: true, Entity: fmt.Sprintf("%d", sender[1])}, s.err
+}
+
+func (s *fakePrioritySource) GasQuota(context.Context) (uint64, error) {
+	return s.quota, s.err
+}

--- a/driver/executor/run.go
+++ b/driver/executor/run.go
@@ -845,6 +845,7 @@ func execRunApp(
 	app, err := net.CreateApplication(ctx, &driver.ApplicationConfig{
 		Name:  step.Identifier,
 		Type:  step.AppType,
+		Load:  step.AppLoad,
 		Rate:  step.Rate,
 		Users: users,
 	})

--- a/driver/executor/run.go
+++ b/driver/executor/run.go
@@ -945,6 +945,7 @@ var checkFunctionToCheckerName = map[parser.StepFunction]string{
 	parser.FuncCheckBlocksProduced:   "blocksRolling",
 	parser.FuncCheckEventThrottled:   "eventThrottled",
 	parser.FuncCheckNetworkRules:     "networkRules",
+	parser.FuncCheckPrioritized:      "prioritizedTransactionsFirst",
 	parser.FuncCheckValidatorsActive: "validatorsActive",
 }
 
@@ -986,6 +987,12 @@ func execCheck(ctx context.Context, checkerName string, spec *parser.CheckSpec, 
 	}
 	if len(spec.ThrottledNodes) > 0 {
 		config["throttledNodes"] = spec.ThrottledNodes
+	}
+	if spec.MinMixedBlocks != nil {
+		config["minMixedBlocks"] = *spec.MinMixedBlocks
+	}
+	if spec.MinRunCoverage != nil {
+		config["minRunCoverage"] = *spec.MinRunCoverage
 	}
 
 	if len(config) > 0 {

--- a/driver/executor/run_test.go
+++ b/driver/executor/run_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/0xsoniclabs/norma/genesis"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -1524,5 +1525,18 @@ func undelegateStep(node, delegator string, stake *uint64) parser.Step {
 		UndelegateTargets: []parser.UndelegateTarget{
 			{Node: node, Delegator: delegator, Stake: stake},
 		},
+	}
+}
+
+func TestCheckFunctionToCheckerName_CoversEveryCheckAndNamesARegisteredChecker(t *testing.T) {
+	// A check the parser accepts but this table does not know fails at the end of
+	// a scenario that has already run, which is the most expensive moment to find
+	// out about a missing entry.
+	checkers := checking.InitNetworkChecks(nil, nil)
+	for _, function := range parser.AllCheckFunctions() {
+		name, mapped := checkFunctionToCheckerName[function]
+		require.Truef(t, mapped, "check %q has no entry in checkFunctionToCheckerName", function)
+		require.Containsf(t, checkers, name,
+			"check %q maps to %q, which no checker registered", function, name)
 	}
 }

--- a/driver/network.go
+++ b/driver/network.go
@@ -205,6 +205,11 @@ type ApplicationConfig struct {
 	// Type defines the on-chain app which should generate the traffic.
 	Type string
 
+	// Load names the traffic of application types that carry another type's
+	// instead of defining their own, such as the priority lanes. It is empty for
+	// every other type.
+	Load string
+
 	// Rate defines the Tx/s config the source should produce while active.
 	Rate *parser.Rate
 

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -516,7 +516,7 @@ func (n *LocalNetwork) CreateApplication(ctx context.Context, config *driver.App
 	defer rpcClient.Close()
 
 	appId := n.nextAppId.Add(1)
-	application, err := app.NewApplication(config.Type, n.appContext, 0, appId)
+	application, err := app.NewApplication(config.Type, config.Load, n.appContext, 0, appId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize on-chain app; %v", err)
 	}

--- a/driver/parser/check.go
+++ b/driver/parser/check.go
@@ -40,7 +40,6 @@ func (s *Scenario) Check() error {
 	if err := genesis.ValidateNetworkRulesPatch(s.InitialRules); err != nil {
 		errs = append(errs, fmt.Errorf("invalid initial network rules: %w", err))
 	}
-
 	// Validate each step.
 	for i, step := range s.Steps {
 		if err := step.Check(); err != nil {
@@ -174,6 +173,19 @@ func (s *Step) checkRunApp() error {
 		errs = append(errs, fmt.Errorf("run app requires a type"))
 	} else if !app.IsSupportedApplicationType(appType) {
 		errs = append(errs, fmt.Errorf("unknown application type: %v", appType))
+	}
+
+	if s.AppLoad != "" {
+		switch {
+		case !app.AcceptsLoadParameter(appType):
+			errs = append(errs, fmt.Errorf(
+				"application type %v generates its own load, so it takes no load", appType))
+		case !app.IsSupportedApplicationType(s.AppLoad):
+			errs = append(errs, fmt.Errorf("unknown load: %v", s.AppLoad))
+		case app.AcceptsLoadParameter(s.AppLoad):
+			errs = append(errs, fmt.Errorf(
+				"load %v carries a load of its own, which cannot be nested", s.AppLoad))
+		}
 	}
 
 	if s.Rate == nil {

--- a/driver/parser/scenario.go
+++ b/driver/parser/scenario.go
@@ -294,6 +294,7 @@ type Step struct {
 
 	// App parameters
 	AppType string
+	AppLoad string // the traffic an app type carries when it does not define its own
 	Users   *int
 	Rate    *Rate
 
@@ -554,6 +555,7 @@ var paramDescriptions = map[string]string{
 	"instances":      "Number of node instances to start.",
 	"failing":        "When true, the step is expected to fail; a passing result is treated as an error.",
 	"extraArguments": "Extra command line arguments for sonicd.",
+	"load":           "Traffic an application type carries when it does not define its own, such as the load of a priority lane.",
 	"users":          "Number of concurrent user accounts the application should simulate.",
 	"rate":           "Transaction rate configuration for the application.",
 }
@@ -562,7 +564,7 @@ var paramDescriptions = map[string]string{
 var allowedParams = map[StepFunction][]string{
 	FuncStartNode:    {"type", "imageName", "dataVolume", "stake", "instances", "failing", "extraArguments"},
 	FuncStopNode:     {},
-	FuncRunApp:       {"type", "users", "rate"},
+	FuncRunApp:       {"type", "load", "users", "rate"},
 	FuncStopApp:      {},
 	FuncUpdateRules:  {},
 	FuncDelegate:     {},
@@ -596,6 +598,12 @@ func (s *Step) parseParam(key string, val *yaml.Node) error {
 		default:
 			s.NodeType = v
 		}
+	case "load":
+		var v string
+		if err := val.Decode(&v); err != nil {
+			return fmt.Errorf("invalid load value: %w", err)
+		}
+		s.AppLoad = v
 	case "imageName":
 		var v string
 		if err := val.Decode(&v); err != nil {

--- a/driver/parser/scenario.go
+++ b/driver/parser/scenario.go
@@ -57,6 +57,7 @@ const (
 	FuncCheckBlocksProduced   StepFunction = "blocksProduced"
 	FuncCheckEventThrottled   StepFunction = "eventThrottled"
 	FuncCheckNetworkRules     StepFunction = "networkRules"
+	FuncCheckPrioritized      StepFunction = "prioritizedTransactionsFirst"
 	FuncCheckValidatorsActive StepFunction = "validatorsActive"
 )
 
@@ -87,7 +88,13 @@ var allCheckFunctions = [...]StepFunction{
 	FuncCheckBlocksProduced,
 	FuncCheckEventThrottled,
 	FuncCheckNetworkRules,
+	FuncCheckPrioritized,
 	FuncCheckValidatorsActive,
+}
+
+// AllCheckFunctions returns every check function valid inside a checks: step.
+func AllCheckFunctions() []StepFunction {
+	return allCheckFunctions[:]
 }
 
 // toStepFunction returns the StepFunction for a given string, or an error if not recognized.
@@ -119,6 +126,8 @@ type CheckSpec struct {
 	Failing        bool
 	Rules          genesis.NetworkRulesPatch
 	ThrottledNodes []string
+	MinMixedBlocks *int
+	MinRunCoverage *float64
 }
 
 // UnmarshalYAML implements custom YAML unmarshalling for CheckSpec.
@@ -247,6 +256,32 @@ func (c *CheckSpec) parseParam(keyNode, valNode *yaml.Node) error {
 			)
 		}
 		c.Rules = patch
+	case "minMixedBlocks":
+		var v int
+		if err := valNode.Decode(&v); err != nil {
+			return fmt.Errorf(
+				"line %d: invalid minMixedBlocks: %w", keyNode.Line, err,
+			)
+		}
+		if v < 1 {
+			return fmt.Errorf(
+				"line %d: minMixedBlocks must be >= 1, got %d", keyNode.Line, v,
+			)
+		}
+		c.MinMixedBlocks = &v
+	case "minRunCoverage":
+		var v float64
+		if err := valNode.Decode(&v); err != nil {
+			return fmt.Errorf(
+				"line %d: invalid minRunCoverage: %w", keyNode.Line, err,
+			)
+		}
+		if v <= 0 || v > 1 {
+			return fmt.Errorf(
+				"line %d: minRunCoverage must be in (0,1], got %v", keyNode.Line, v,
+			)
+		}
+		c.MinRunCoverage = &v
 	case "throttledNodes":
 		var v []string
 		if err := valNode.Decode(&v); err != nil {
@@ -714,6 +749,7 @@ var checkFunctionDescriptions = map[StepFunction]string{
 	FuncCheckBlocksProduced: "Assert that all nodes have produced blocks within tolerance.",
 	FuncCheckEventThrottled: "Assert that validators listed in throttledNodes emit events at a significantly lower rate than the rest.",
 	FuncCheckNetworkRules:   "Assert that the active network rules on all nodes match the expected rules patch.",
+	FuncCheckPrioritized:    "Assert that blocks carrying transactions of both registered and unregistered senders open with the registered ones, within the gas the priority registry grants one entity per block.",
 
 	FuncCheckValidatorsActive: "Assert that every running validator node is in the current epoch's validator set.",
 }
@@ -727,6 +763,7 @@ var checkFunctionParams = map[StepFunction][]string{
 	FuncCheckBlocksProduced: {"tolerance", "duration", "failing"},
 	FuncCheckEventThrottled: {"throttledNodes", "failing"},
 	FuncCheckNetworkRules:   {"rules", "duration", "failing"},
+	FuncCheckPrioritized:    {"minMixedBlocks", "minRunCoverage", "duration", "failing"},
 
 	FuncCheckValidatorsActive: {"failing"},
 }
@@ -737,8 +774,10 @@ var checkParamDescriptions = map[string]string{
 	"failing":        "When true, the check is expected to fail; a passing result is treated as an error.",
 	"rules":          "Expected network rules patch (NetworkRulesPatch field structure).",
 	"tolerance":      "For a height check, the allowed deviation (int, in blocks) between nodes. For a production, halt or gas rate check, the length of the observation window expressed in monitoring samples (one per second); duration overrides it.",
+	"minMixedBlocks": "Number of blocks that must carry transactions of both registered and unregistered senders for the priority ordering check to be conclusive.",
+	"minRunCoverage": "Share (0,1] of the prioritized transactions the gas quota admits that must open a block, as a median. Lower it for a congested lane, where transactions demoted for reasons a block does not show are common.",
 	"throttledNodes": "List of node labels expected to be throttled.",
-	"duration":       "Duration (e.g. \"30s\"). For a production, halt or gas rate check, how long to actively observe the network; only data collected while waiting is judged, and the window must be at least 2s. For a height or rules check, how long the nodes are given to converge, with 0 meaning a single attempt.",
+	"duration":       "Duration (e.g. \"30s\"). For a production, halt or gas rate check, how long to actively observe the network; only data collected while waiting is judged, and the window must be at least 2s. For a height or rules check, how long the nodes are given to converge, with 0 meaning a single attempt. For the priority ordering check, how long to wait for the blocks it needs.",
 }
 
 // PrintHelp writes a formatted summary of all available scenario step

--- a/driver/parser/scenario_test.go
+++ b/driver/parser/scenario_test.go
@@ -1201,3 +1201,81 @@ Scenario:
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unknown check function")
 }
+
+func TestCheck_TransactionPrioritiesAreAcceptedInARulesUpdate(t *testing.T) {
+	input := `
+Name: Priority Lanes
+Description: Enables priority lanes while the network is running.
+Scenario:
+  - startNode: validator
+    type: validator
+  - updateRules:
+      Upgrades:
+        TransactionPriorities: true
+`
+	scenario, err := ParseBytes([]byte(input))
+	require.NoError(t, err)
+	require.NoError(t, scenario.Check())
+
+	step := scenario.Steps[1]
+	require.Equal(t, FuncUpdateRules, step.Function)
+	require.NotNil(t, step.Rules.Upgrades)
+	require.NotNil(t, step.Rules.Upgrades.TransactionPriorities)
+	require.True(t, *step.Rules.Upgrades.TransactionPriorities)
+}
+
+func TestParseBytes_ApplicationLoadIsParsed(t *testing.T) {
+	// A priority lane is a property of a load rather than a load of its own, so
+	// the load it carries is a parameter of the application.
+	scenario, err := ParseBytes([]byte(`
+Name: Test
+Description: A test scenario.
+Scenario:
+  - runApp: fast
+    type: priority
+    load: uniswap
+    rate:
+      constant: 5
+`))
+	require.NoError(t, err)
+	require.NoError(t, scenario.Check())
+
+	step := scenario.Steps[0]
+	require.Equal(t, "priority", step.AppType)
+	require.Equal(t, "uniswap", step.AppLoad)
+}
+
+func TestScenario_ApplicationLoadIsValidated(t *testing.T) {
+	tests := map[string]struct {
+		appType string
+		load    string
+		issue   string
+	}{
+		"a load the type cannot carry": {
+			appType: "counter", load: "uniswap", issue: "generates its own load",
+		},
+		"a load that does not exist": {
+			appType: "priority", load: "nonesuch", issue: "unknown load",
+		},
+		"a lane inside a lane": {
+			appType: "priority", load: "priority", issue: "cannot be nested",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			rate := float32(5)
+			scenario := &Scenario{
+				Name:        "Test",
+				Description: "A test scenario.",
+				Steps: []Step{{
+					Function:   FuncRunApp,
+					Identifier: "load",
+					AppType:    test.appType,
+					AppLoad:    test.load,
+					Rate:       &Rate{Constant: &rate},
+				}},
+			}
+			require.ErrorContains(t, scenario.Check(), test.issue)
+		})
+	}
+}

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"time"
 
+	priority_registry "github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
 	gas_subsidies_registry "github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
 	"github.com/0xsoniclabs/sonic/integration/makefakegenesis"
 	"github.com/0xsoniclabs/sonic/opera"
@@ -68,6 +69,12 @@ func GenerateJsonGenesis(jsonFile string, validatorStakes []uint64, rules *opera
 			Name:    "SubsidiesRegistry",
 			Address: gas_subsidies_registry.GetAddress(),
 			Code:    gas_subsidies_registry.GetCode(),
+			Nonce:   1,
+		},
+		{
+			Name:    "PriorityRegistry",
+			Address: priority_registry.GetAddress(),
+			Code:    priority_registry.GetCode(),
 			Nonce:   1,
 		},
 	}

--- a/load/app/app.go
+++ b/load/app/app.go
@@ -39,3 +39,20 @@ type User interface {
 	GenerateTx() (*types.Transaction, error)
 	GetSentTransactions() uint64
 }
+
+// PrioritizableUser is a User that discloses the accounts it signs its
+// transactions with.
+//
+// Sonic keys the priority of a transaction on its sender, so a load can only be
+// placed in a priority lane if the accounts signing it are known before it
+// starts - see PriorityApplication. Users that create senders while they run, or
+// that delegate to other users, deliberately do not implement this: registering
+// the accounts they happen to hold at setup time would prioritize a part of
+// their traffic and silently leave the rest behind.
+type PrioritizableUser interface {
+	User
+
+	// SigningAccounts returns the accounts this user signs its transactions
+	// with, all of which it will use for the whole run.
+	SigningAccounts() []*Account
+}

--- a/load/app/app_mock.go
+++ b/load/app/app_mock.go
@@ -123,3 +123,70 @@ func (mr *MockUserMockRecorder) GetSentTransactions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSentTransactions", reflect.TypeOf((*MockUser)(nil).GetSentTransactions))
 }
+
+// MockPrioritizableUser is a mock of PrioritizableUser interface.
+type MockPrioritizableUser struct {
+	ctrl     *gomock.Controller
+	recorder *MockPrioritizableUserMockRecorder
+	isgomock struct{}
+}
+
+// MockPrioritizableUserMockRecorder is the mock recorder for MockPrioritizableUser.
+type MockPrioritizableUserMockRecorder struct {
+	mock *MockPrioritizableUser
+}
+
+// NewMockPrioritizableUser creates a new mock instance.
+func NewMockPrioritizableUser(ctrl *gomock.Controller) *MockPrioritizableUser {
+	mock := &MockPrioritizableUser{ctrl: ctrl}
+	mock.recorder = &MockPrioritizableUserMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockPrioritizableUser) EXPECT() *MockPrioritizableUserMockRecorder {
+	return m.recorder
+}
+
+// GenerateTx mocks base method.
+func (m *MockPrioritizableUser) GenerateTx() (*types.Transaction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GenerateTx")
+	ret0, _ := ret[0].(*types.Transaction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GenerateTx indicates an expected call of GenerateTx.
+func (mr *MockPrioritizableUserMockRecorder) GenerateTx() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateTx", reflect.TypeOf((*MockPrioritizableUser)(nil).GenerateTx))
+}
+
+// GetSentTransactions mocks base method.
+func (m *MockPrioritizableUser) GetSentTransactions() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSentTransactions")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// GetSentTransactions indicates an expected call of GetSentTransactions.
+func (mr *MockPrioritizableUserMockRecorder) GetSentTransactions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSentTransactions", reflect.TypeOf((*MockPrioritizableUser)(nil).GetSentTransactions))
+}
+
+// SigningAccounts mocks base method.
+func (m *MockPrioritizableUser) SigningAccounts() []*Account {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SigningAccounts")
+	ret0, _ := ret[0].([]*Account)
+	return ret0
+}
+
+// SigningAccounts indicates an expected call of SigningAccounts.
+func (mr *MockPrioritizableUserMockRecorder) SigningAccounts() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SigningAccounts", reflect.TypeOf((*MockPrioritizableUser)(nil).SigningAccounts))
+}

--- a/load/app/app_test.go
+++ b/load/app/app_test.go
@@ -135,7 +135,7 @@ func TestGenerators(t *testing.T) {
 					continue
 				}
 				t.Run(name, func(t *testing.T) {
-					application, err := app.NewApplication(name, appCtx, 0, 0)
+					application, err := app.NewApplication(name, "", appCtx, 0, 0)
 					require.NoError(t, err, "failed to create application")
 					testGenerator(t, application, appCtx)
 				})
@@ -240,4 +240,59 @@ func testGenerator(t *testing.T, app app.Application, ctxt app.AppContext) {
 			return nil
 		})
 	require.NoError(t, err, "transactions were not processed in time")
+}
+
+func TestGenerators_Priorities(t *testing.T) {
+	rules := driver.NetworkRules{
+		Upgrades: &genesis.UpgradesPatch{
+			Sonic:   new(true),
+			Allegro: new(true),
+			Brio:    new(true),
+		},
+	}
+	net, err := local.NewLocalLegacyNetwork(t.Context(), &driver.NetworkConfig{
+		Validators:   driver.DefaultValidators(t.Name()),
+		NetworkRules: rules,
+	})
+	require.NoError(t, err, "failed to create new local network")
+	t.Cleanup(func() {
+		require.NoError(t, net.Shutdown(), "failed to shutdown network")
+	})
+
+	primaryAccount, err := app.NewAccount(0, PrivateKey, FakeNetworkID)
+	require.NoError(t, err, "failed to create primary account")
+
+	appCtx, err := app.NewContext(context.Background(), net, primaryAccount, rules)
+	require.NoError(t, err, "failed to create application context")
+
+	// While the network does not apply priorities, the application would
+	// generate traffic indistinguishable from the counter application, which it
+	// is expected to report instead of doing.
+	_, err = app.NewPriorityApplication(appCtx, 0, 0)
+	require.ErrorContains(t, err, "transaction priorities are disabled")
+
+	// Enabling the feature at runtime covers a scenario switching it on while
+	// the network is up; the rule takes effect with the next epoch seal.
+	require.NoError(t, net.ApplyNetworkRules(t.Context(), driver.NetworkRules{
+		Upgrades: &genesis.UpgradesPatch{TransactionPriorities: new(true)},
+	}), "failed to enable transaction priorities")
+	require.NoError(t, net.AdvanceEpoch(t.Context(), 2), "failed to advance epoch")
+
+	priorityApp, err := app.NewPriorityApplication(appCtx, 0, 0)
+	require.NoError(t, err, "failed to create priority application")
+	testGenerator(t, priorityApp, appCtx)
+
+	// A lane is a property of a load, not a load of its own: any generator whose
+	// users disclose the accounts they sign with can travel in one. The erc20
+	// load stands in for the ones that are not the counter load.
+	prioritizedErc20, err := app.NewApplication("priority", "erc20", appCtx, 0, 1)
+	require.NoError(t, err, "failed to create a prioritized erc20 application")
+	testGenerator(t, prioritizedErc20, appCtx)
+
+	// A load that creates the accounts it signs with while it runs cannot be
+	// registered up front, and says so instead of prioritizing a part of itself.
+	bundles, err := app.NewApplication("priority", "allofbundle", appCtx, 0, 2)
+	require.NoError(t, err, "failed to create a prioritized bundle application")
+	_, err = bundles.CreateUsers(appCtx, 1)
+	require.ErrorContains(t, err, "cannot be prioritized")
 }

--- a/load/app/bls12_add_app.go
+++ b/load/app/bls12_add_app.go
@@ -130,6 +130,12 @@ func (g *Bls12AddUser) GenerateTx() (*types.Transaction, error) {
 	return tx, err
 }
 
+// SigningAccounts implements PrioritizableUser: every transaction of this
+// user is signed by the single account it was created for.
+func (g *Bls12AddUser) SigningAccounts() []*Account {
+	return []*Account{g.sender}
+}
+
 // GetSentTransactions returns the number of transactions this user has sent.
 func (g *Bls12AddUser) GetSentTransactions() uint64 {
 	return g.sentTxs.Load()

--- a/load/app/bundle_app_test.go
+++ b/load/app/bundle_app_test.go
@@ -50,7 +50,7 @@ func TestGenerators_Bundles(t *testing.T) {
 		"DuplicatedBundle",
 	} {
 		t.Run(name, func(t *testing.T) {
-			application, err := app.NewApplication(name, appCtx, 0, uint32(appId))
+			application, err := app.NewApplication(name, "", appCtx, 0, uint32(appId))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -62,7 +62,7 @@ func TestGenerators_Bundles(t *testing.T) {
 		"FailingBundle",
 	} {
 		t.Run(name, func(t *testing.T) {
-			application, err := app.NewApplication(name, appCtx, 0, uint32(appId))
+			application, err := app.NewApplication(name, "", appCtx, 0, uint32(appId))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/load/app/counter_app.go
+++ b/load/app/counter_app.go
@@ -136,6 +136,12 @@ func (g *CounterUser) GenerateTx() (*types.Transaction, error) {
 	return tx, err
 }
 
+// SigningAccounts implements PrioritizableUser: every transaction of this
+// user is signed by the single account it was created for.
+func (g *CounterUser) SigningAccounts() []*Account {
+	return []*Account{g.sender}
+}
+
 func (g *CounterUser) GetSentTransactions() uint64 {
 	return g.sentTxs.Load()
 }

--- a/load/app/ecdsa_counter_app.go
+++ b/load/app/ecdsa_counter_app.go
@@ -158,6 +158,12 @@ func (g *EcdsaUser) GenerateTx() (*types.Transaction, error) {
 	return tx, err
 }
 
+// SigningAccounts implements PrioritizableUser: every transaction of this
+// user is signed by the single account it was created for.
+func (g *EcdsaUser) SigningAccounts() []*Account {
+	return []*Account{g.sender}
+}
+
 func (g *EcdsaUser) GetSentTransactions() uint64 {
 	return g.sentTxs.Load()
 }

--- a/load/app/erc20_app.go
+++ b/load/app/erc20_app.go
@@ -185,6 +185,12 @@ func (g *ERC20User) GenerateTx() (*types.Transaction, error) {
 	return tx, err
 }
 
+// SigningAccounts implements PrioritizableUser: every transaction of this
+// user is signed by the single account it was created for.
+func (g *ERC20User) SigningAccounts() []*Account {
+	return []*Account{g.sender}
+}
+
 func (g *ERC20User) GetSentTransactions() uint64 {
 	return atomic.LoadUint64(&g.sentTxs)
 }

--- a/load/app/factory.go
+++ b/load/app/factory.go
@@ -23,18 +23,44 @@ import (
 
 type appFactoryFunc func(context AppContext, feederId, appId uint32) (Application, error)
 
-func NewApplication(appType string, context AppContext, feederId, appId uint32) (Application, error) {
-	if factory := getFactory(appType); factory != nil {
+// NewApplication creates an application of the given type.
+//
+// The load parameter names the traffic of application types that do not define
+// their own but carry another type's - the priority lanes, which are a property
+// of a load rather than a load themselves. It must be empty for every other
+// type; see AcceptsLoadParameter.
+func NewApplication(appType, load string, context AppContext, feederId, appId uint32) (Application, error) {
+	if load != "" {
+		if !AcceptsLoadParameter(appType) {
+			return nil, fmt.Errorf(
+				"application type '%s' generates its own load, so it takes no load parameter", appType)
+		}
+		if !IsSupportedApplicationType(load) {
+			return nil, fmt.Errorf("unknown load '%s' for application type '%s'", load, appType)
+		}
+		// A lane inside a lane would register the same accounts twice and mean
+		// nothing beyond the single lane it already is.
+		if AcceptsLoadParameter(load) {
+			return nil, fmt.Errorf("load '%s' carries a load of its own, which cannot be nested", load)
+		}
+	}
+	if factory := getFactory(appType, load); factory != nil {
 		return factory(context, feederId, appId)
 	}
 	return nil, fmt.Errorf("unknown application type '%s'", appType)
 }
 
 func IsSupportedApplicationType(appType string) bool {
-	return getFactory(appType) != nil
+	return getFactory(appType, "") != nil
 }
 
-func getFactory(appType string) appFactoryFunc {
+// AcceptsLoadParameter reports whether the given application type carries the
+// load of another one, which the load parameter of NewApplication selects.
+func AcceptsLoadParameter(appType string) bool {
+	return strings.ToLower(appType) == "priority"
+}
+
+func getFactory(appType, load string) appFactoryFunc {
 	switch strings.ToLower(appType) {
 	case "erc20":
 		return NewERC20Application
@@ -48,6 +74,13 @@ func getFactory(appType string) appFactoryFunc {
 		return NewSmartAccountApplication
 	case "subsidies":
 		return NewSubsidiesApplication
+	case "priority":
+		// An empty load is the counter one, which is the cheapest traffic to
+		// compare a lane against.
+		if load == "" {
+			load = "counter"
+		}
+		return NewPrioritizedApplication(load)
 	case "transient":
 		return NewTransientApplication
 	case "selfdestructoldcontract":

--- a/load/app/large_contract_app.go
+++ b/load/app/large_contract_app.go
@@ -136,6 +136,12 @@ func (g *LargeContractUser) GenerateTx() (*types.Transaction, error) {
 	return tx, err
 }
 
+// SigningAccounts implements PrioritizableUser: every transaction of this
+// user is signed by the single account it was created for.
+func (g *LargeContractUser) SigningAccounts() []*Account {
+	return []*Account{g.sender}
+}
+
 func (g *LargeContractUser) GetSentTransactions() uint64 {
 	return g.sentTxs.Load()
 }

--- a/load/app/mix_app.go
+++ b/load/app/mix_app.go
@@ -75,7 +75,7 @@ func NewMixApplication(appContext AppContext, feederId, appId uint32) (Applicati
 		mixSubAppsCount := uint32(len(mixAppTypes))
 		subAppId := mixAppIdOffset + appId*mixSubAppsCount + uint32(i)
 
-		application, err := NewApplication(entry.appType, appContext, feederId, subAppId)
+		application, err := NewApplication(entry.appType, "", appContext, feederId, subAppId)
 		if err != nil {
 			return nil, fmt.Errorf("mix: failed to initialise sub-app %q: %w", entry.appType, err)
 		}

--- a/load/app/priority_app.go
+++ b/load/app/priority_app.go
@@ -1,0 +1,215 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/0xsoniclabs/norma/driver/rpc"
+	priority_registry "github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// The lane this application's users are registered in. A single level is enough
+// to separate prioritized from ordinary traffic; the weight only orders
+// transactions of the same level against each other and is therefore left at
+// the same value for all users.
+const (
+	priorityLevel  = 1
+	priorityWeight = 0
+)
+
+// priorityRegistryUpdateGasLimit covers a registry update, which writes one slot -
+// the level, weight and entity of a sender share a single word. The limit is
+// fixed to keep the setup from paying for a gas estimation per user.
+const priorityRegistryUpdateGasLimit = 100_000
+
+// The per-entity rate limits this application configures in the registry.
+// They are deliberately generous: a load generator should be limited by the
+// network, not by a lane budget it happens to share with itself. Lower them to
+// observe the rate limiting itself.
+var (
+	priorityMaxGasPerEntityPerBlock          = big.NewInt(100_000_000)
+	priorityMaxPiggybackTxsPerEntityPerEvent = big.NewInt(1_000)
+)
+
+// PriorityApplication generates the traffic of another application in a priority
+// lane: the load is that application's - the same transactions, gas limits and
+// gas prices - and the only difference is that the accounts signing it are
+// registered in the on-chain priority registry. Running it next to the very same
+// application without the registration therefore isolates the effect of the
+// priority lanes feature: the two differ in nothing else.
+//
+// Any load whose users disclose the accounts they sign with can be prioritized,
+// see PrioritizableUser. Which one it carries is chosen by the `load` parameter
+// of the scenario's application, e.g. `type: priority` with `load: uniswap` for
+// uniswap traffic in a lane.
+//
+// All users of one application share one entity id, which is what the client
+// rate-limits per block, so an application maps to what a production registry
+// would consider one customer.
+//
+// Traffic is only prioritized while the network runs with the
+// TransactionPriorities upgrade enabled; without it the registry is never
+// queried and this application would be the load it wraps in disguise. It
+// therefore refuses to start on a network that has the upgrade disabled rather
+// than generating load that proves nothing.
+type PriorityApplication struct {
+	Application
+	load     string
+	registry *priority_registry.Registry
+	entity   *big.Int
+}
+
+// NewPriorityApplication creates a priority lane carrying the counter load,
+// which is the load whose transactions are the cheapest to distinguish from one
+// another. See NewPrioritizedApplication for any other load.
+func NewPriorityApplication(ctxt AppContext, feederId, appId uint32) (Application, error) {
+	return NewPrioritizedApplication("counter")(ctxt, feederId, appId)
+}
+
+// NewPrioritizedApplication returns a factory creating the load of the given
+// application type in a priority lane. The load is set up as it would be on its
+// own; only its users are additionally registered in the priority registry.
+func NewPrioritizedApplication(load string) appFactoryFunc {
+	return func(ctxt AppContext, feederId, appId uint32) (Application, error) {
+		enabled, err := transactionPrioritiesEnabled(ctxt.GetClient())
+		if err != nil {
+			return nil, fmt.Errorf("failed to read the network's transaction priority state; %w", err)
+		}
+		if !enabled {
+			return nil, fmt.Errorf(
+				"transaction priorities are disabled on this network, so this " +
+					"application's traffic would not be prioritized; enable the " +
+					"TransactionPriorities upgrade in the scenario's network rules")
+		}
+
+		traffic, err := NewApplication(load, "", ctxt, feederId, appId)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create the %s load to prioritize; %w", load, err)
+		}
+
+		registry, err := priority_registry.NewRegistry(priority_registry.GetAddress(), ctxt.GetClient())
+		if err != nil {
+			return nil, fmt.Errorf("failed to bind to priority registry contract; %w", err)
+		}
+
+		// The limits are global, so applications sharing a network overwrite each
+		// other here - with the same values, since they are constants.
+		if _, err := ctxt.Run(func(opts *bind.TransactOpts) (*types.Transaction, error) {
+			return registry.SetConfig(opts, priorityMaxGasPerEntityPerBlock, priorityMaxPiggybackTxsPerEntityPerEvent)
+		}); err != nil {
+			return nil, fmt.Errorf("failed to configure priority registry limits; %w", err)
+		}
+
+		return &PriorityApplication{
+			Application: traffic,
+			load:        load,
+			registry:    registry,
+			entity:      new(big.Int).SetUint64(uint64(appId)),
+		}, nil
+	}
+}
+
+// CreateUsers creates the users generating the load and registers the accounts
+// they sign with as members of this application's priority lane.
+func (a *PriorityApplication) CreateUsers(ctxt AppContext, numUsers int) ([]User, error) {
+	users, err := a.Application.CreateUsers(ctxt, numUsers)
+	if err != nil {
+		return nil, err
+	}
+
+	accounts, err := a.signingAccounts(users)
+	if err != nil {
+		return nil, err
+	}
+	if err := a.prioritize(ctxt, accounts); err != nil {
+		return nil, fmt.Errorf("failed to register users in priority registry; %w", err)
+	}
+	return users, nil
+}
+
+// signingAccounts collects the accounts of the given users that are to be
+// registered in the lane, and reports a load that cannot disclose them.
+func (a *PriorityApplication) signingAccounts(users []User) ([]*Account, error) {
+	accounts := make([]*Account, 0, len(users))
+	for _, user := range users {
+		prioritizable, ok := user.(PrioritizableUser)
+		if !ok {
+			return nil, fmt.Errorf(
+				"the %s load cannot be prioritized: its users (%T) do not disclose "+
+					"the accounts they sign with, so they cannot be registered in the "+
+					"priority registry", a.load, user)
+		}
+		accounts = append(accounts, prioritizable.SigningAccounts()...)
+	}
+	return accounts, nil
+}
+
+// transactionPrioritiesEnabled reports whether the network currently applies
+// transaction priorities.
+func transactionPrioritiesEnabled(client rpc.Client) (bool, error) {
+	rules, err := client.GetNetworkRules("latest")
+	if err != nil {
+		return false, fmt.Errorf("failed to get network rules; %w", err)
+	}
+	return rules.Upgrades.TransactionPriorities, nil
+}
+
+// prioritize has every account register itself in the priority registry. The
+// registrations are submitted before any receipt is awaited, and each one comes
+// from a different account, so a validator can emit all of them at once - it
+// carries at most one transaction per sender per event. Registering them from a
+// single account would instead cost one event per user, which on a congested
+// network is a considerable part of a scenario.
+func (a *PriorityApplication) prioritize(ctxt AppContext, accounts []*Account) error {
+	gasPrice, err := ctxt.GetClient().SuggestGasPrice(context.Background())
+	if err != nil {
+		return fmt.Errorf("failed to get gas price suggestion; %w", err)
+	}
+
+	txs := make([]*types.Transaction, 0, len(accounts))
+	for _, account := range accounts {
+		opts, err := bind.NewKeyedTransactorWithChainID(account.privateKey, account.chainID)
+		if err != nil {
+			return fmt.Errorf("failed to create transactor; %w", err)
+		}
+		opts.GasLimit = priorityRegistryUpdateGasLimit
+		opts.GasPrice = new(big.Int).Mul(gasPrice, big.NewInt(2))
+		opts.Nonce = new(big.Int).SetUint64(account.getNextNonce())
+
+		tx, err := a.registry.SetSenderPriority(opts, account.address, priorityLevel, priorityWeight, a.entity)
+		if err != nil {
+			return fmt.Errorf("failed to submit priority of %v; %w", account.address, err)
+		}
+		txs = append(txs, tx)
+	}
+
+	for _, tx := range txs {
+		receipt, err := ctxt.GetReceipt(tx.Hash())
+		if err != nil {
+			return fmt.Errorf("failed to get receipt; %w", err)
+		}
+		if receipt.Status != types.ReceiptStatusSuccessful {
+			return fmt.Errorf("priority registration reverted")
+		}
+	}
+	return nil
+}

--- a/load/app/priority_app_test.go
+++ b/load/app/priority_app_test.go
@@ -1,0 +1,91 @@
+// Copyright 2024 Fantom Foundation
+// This file is part of Norma System Testing Infrastructure for Sonic.
+//
+// Norma is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Norma is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Norma. If not, see <http://www.gnu.org/licenses/>.
+
+package app
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestLoadParameter_OnlyPriorityLanesCarryAnotherLoad(t *testing.T) {
+	// A lane is not a kind of load, it is a property of one, so it is the only
+	// type asking which load it should carry.
+	require.True(t, AcceptsLoadParameter("priority"))
+	require.True(t, AcceptsLoadParameter("PRIORITY"), "types are case-insensitive")
+	for _, appType := range []string{"counter", "uniswap", "largecontract", "mix", ""} {
+		require.False(t, AcceptsLoadParameter(appType),
+			"the %s load is its own, so it takes no load parameter", appType)
+	}
+}
+
+func TestNewApplication_RejectsALoadTheTypeCannotCarry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctxt := NewMockAppContext(ctrl)
+
+	// Nothing is created, so the context is never used; the parameters alone
+	// decide these.
+	_, err := NewApplication("counter", "uniswap", ctxt, 0, 0)
+	require.ErrorContains(t, err, "generates its own load")
+
+	_, err = NewApplication("priority", "nonesuch", ctxt, 0, 0)
+	require.ErrorContains(t, err, "unknown load")
+
+	_, err = NewApplication("priority", "priority", ctxt, 0, 0)
+	require.ErrorContains(t, err, "cannot be nested")
+}
+
+func TestPriorityApplication_RegistersTheAccountsOfEveryUser(t *testing.T) {
+	first, second := newTestAccount(t, 1), newTestAccount(t, 2)
+	users := []User{
+		&CounterUser{sender: first},
+		&CounterUser{sender: second},
+	}
+
+	// The registration itself talks to the chain, so this test stops at the
+	// accounts the application collected to register.
+	app := &PriorityApplication{load: "counter"}
+	collected, err := app.signingAccounts(users)
+	require.NoError(t, err)
+	require.Equal(t, []*Account{first, second}, collected)
+}
+
+func TestPriorityApplication_RefusesALoadThatDoesNotDiscloseItsAccounts(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	// A user that signs with accounts it creates while running - a bundle or a
+	// composed load - cannot be registered up front, and prioritizing a part of
+	// its traffic would quietly measure something else than it claims to.
+	opaque := NewMockUser(ctrl)
+	app := &PriorityApplication{load: "mix"}
+
+	_, err := app.signingAccounts([]User{opaque})
+	require.ErrorContains(t, err, "cannot be prioritized")
+	require.ErrorContains(t, err, "mix", "the error should name the load that was asked for")
+}
+
+func newTestAccount(t *testing.T, id int) *Account {
+	t.Helper()
+	const fakeNetworkID = 0xfa3
+	factory, err := NewAccountFactory(big.NewInt(fakeNetworkID), 0, uint32(id))
+	require.NoError(t, err)
+	account, err := factory.CreateAccount(nil)
+	require.NoError(t, err)
+	return account
+}

--- a/load/app/self_destruct_new_contract_app.go
+++ b/load/app/self_destruct_new_contract_app.go
@@ -124,6 +124,12 @@ func (g *SelfDestructNewContractUser) GenerateTx() (*types.Transaction, error) {
 	return tx, err
 }
 
+// SigningAccounts implements PrioritizableUser: every transaction of this
+// user is signed by the single account it was created for.
+func (g *SelfDestructNewContractUser) SigningAccounts() []*Account {
+	return []*Account{g.sender}
+}
+
 func (g *SelfDestructNewContractUser) GetSentTransactions() uint64 {
 	return g.sentTxs.Load()
 }

--- a/load/app/self_destruct_old_contract_app.go
+++ b/load/app/self_destruct_old_contract_app.go
@@ -126,6 +126,12 @@ func (g *SelfDestructOldContractUser) GenerateTx() (*types.Transaction, error) {
 	return tx, err
 }
 
+// SigningAccounts implements PrioritizableUser: every transaction of this
+// user is signed by the single account it was created for.
+func (g *SelfDestructOldContractUser) SigningAccounts() []*Account {
+	return []*Account{g.sender}
+}
+
 func (g *SelfDestructOldContractUser) GetSentTransactions() uint64 {
 	return g.sentTxs.Load()
 }

--- a/load/app/smartaccount_app.go
+++ b/load/app/smartaccount_app.go
@@ -210,6 +210,12 @@ func (g *SmartAccountUser) GenerateTx() (*types.Transaction, error) {
 	return tx, err
 }
 
+// SigningAccounts implements PrioritizableUser: every transaction of this
+// user is signed by the single account it was created for.
+func (g *SmartAccountUser) SigningAccounts() []*Account {
+	return []*Account{g.sender}
+}
+
 func (g *SmartAccountUser) GetSentTransactions() uint64 {
 	return atomic.LoadUint64(&g.sentTxs)
 }

--- a/load/app/store_app.go
+++ b/load/app/store_app.go
@@ -143,6 +143,12 @@ func (g *StoreUser) GenerateTx() (*types.Transaction, error) {
 	return tx, err
 }
 
+// SigningAccounts implements PrioritizableUser: every transaction of this
+// user is signed by the single account it was created for.
+func (g *StoreUser) SigningAccounts() []*Account {
+	return []*Account{g.sender}
+}
+
 func (g *StoreUser) GetSentTransactions() uint64 {
 	return g.sentTxs.Load()
 }

--- a/load/app/subsidies_app.go
+++ b/load/app/subsidies_app.go
@@ -163,6 +163,12 @@ func (u *SubsidiesUser) GenerateTx() (*types.Transaction, error) {
 	return tx, nil
 }
 
+// SigningAccounts implements PrioritizableUser: every transaction of this
+// user is signed by the single account it was created for.
+func (u *SubsidiesUser) SigningAccounts() []*Account {
+	return []*Account{u.Sender}
+}
+
 func (u *SubsidiesUser) GetSentTransactions() uint64 {
 	return u.sentTxs.Load()
 }

--- a/load/app/transient_app.go
+++ b/load/app/transient_app.go
@@ -129,6 +129,12 @@ func (g *TransientUser) GenerateTx() (*types.Transaction, error) {
 	return tx, err
 }
 
+// SigningAccounts implements PrioritizableUser: every transaction of this
+// user is signed by the single account it was created for.
+func (g *TransientUser) SigningAccounts() []*Account {
+	return []*Account{g.sender}
+}
+
 func (g *TransientUser) GetSentTransactions() uint64 {
 	return g.sentTxs.Load()
 }

--- a/load/app/uniswap_app.go
+++ b/load/app/uniswap_app.go
@@ -288,6 +288,12 @@ func (g *UniswapUser) GenerateTx() (*types.Transaction, error) {
 	return tx, err
 }
 
+// SigningAccounts implements PrioritizableUser: every transaction of this
+// user is signed by the single account it was created for.
+func (g *UniswapUser) SigningAccounts() []*Account {
+	return []*Account{g.sender}
+}
+
 func (g *UniswapUser) GetSentTransactions() uint64 {
 	return atomic.LoadUint64(&g.sentTxs)
 }

--- a/scenarios/examples/priority_lanes.yml
+++ b/scenarios/examples/priority_lanes.yml
@@ -1,21 +1,13 @@
 Name: Priority Lanes Pilot
 
 Description: >-
-  Shows the effect of prioritized transactions. The loads `ordinary` and `fast`
-  submit the very same transactions at the very same rate and differ in nothing
-  but the registration of their senders in the priority registry. They start
-  alone and are then joined by `congestion`, which offers far more than the
-  network commits and thereby builds the queue the lanes are about. The report's
-  "sent vs received transactions per application" plot is where the difference
-  shows: the distance between what an application submitted and what the chain
-  committed keeps growing for `ordinary` from the moment the queue exists, while
-  `fast` is served at the rate it submits throughout and its backlog stays the
-  couple of blocks it takes to commit a transaction. Once the loads stop, that
-  backlog is gone within seconds, whereas the one of `ordinary` outlives the
-  scenario. Expect `fast` to commit around twice the transactions of `ordinary`.
-  Prioritized transactions are also emitted by validators before their own turn
-  to originate them, which is why `fast` keeps up even before the congestion
-  starts.
+  Shows the effect of prioritized transactions: two identical counter loads, one
+  with its senders registered in the priority registry, joined later by a third
+  that congests the network. Expect the lane to be served at the rate it submits
+  while the ordinary load builds a backlog that outlives the scenario, and to
+  commit clearly more transactions than it. Note that the lane keeps up even
+  before the congestion starts, because validators emit prioritized transactions
+  before their own turn to originate them.
 
 # Congestion is what makes the lanes distinguishable at all: while every
 # transaction reaches the next block anyway, being scheduled first buys nothing.

--- a/scenarios/examples/priority_lanes.yml
+++ b/scenarios/examples/priority_lanes.yml
@@ -1,0 +1,93 @@
+Name: Priority Lanes Pilot
+
+Description: >-
+  Shows the effect of prioritized transactions. The loads `ordinary` and `fast`
+  submit the very same transactions at the very same rate and differ in nothing
+  but the registration of their senders in the priority registry. They start
+  alone and are then joined by `congestion`, which offers far more than the
+  network commits and thereby builds the queue the lanes are about. The report's
+  "sent vs received transactions per application" plot is where the difference
+  shows: the distance between what an application submitted and what the chain
+  committed keeps growing for `ordinary` from the moment the queue exists, while
+  `fast` is served at the rate it submits throughout and its backlog stays the
+  couple of blocks it takes to commit a transaction. Once the loads stop, that
+  backlog is gone within seconds, whereas the one of `ordinary` outlives the
+  scenario. Expect `fast` to commit around twice the transactions of `ordinary`.
+  Prioritized transactions are also emitted by validators before their own turn
+  to originate them, which is why `fast` keeps up even before the congestion
+  starts.
+
+# Congestion is what makes the lanes distinguishable at all: while every
+# transaction reaches the next block anyway, being scheduled first buys nothing.
+# The network is throttled to commit a fraction of its usual throughput - by
+# capping the gas an event carries and by slowing the rate events are emitted at
+# - so that the queue this scenario needs is built by a load a single machine
+# comfortably generates. The cap still leaves ample room for the largest
+# transactions Norma itself sends: funding a batch of accounts and the system
+# transactions behind steps such as advanceEpoch.
+InitialNetworkRules:
+  Emitter:
+    Interval: 2s
+  Economy:
+    Gas:
+      MaxEventGas: 2500000
+  Upgrades:
+    Sonic: true
+    Allegro: true
+    Brio: true
+    TransactionPriorities: true
+
+Scenario:
+  # Two validators, so that transactions also arrive at a validator that is not
+  # the current proposer. That is the path where a prioritized transaction is
+  # emitted eagerly instead of waiting for its sender's turn.
+  - startNode: validator
+    type: validator
+    instances: 3
+
+  # The two loads to compare. They are started while the network is still idle,
+  # both to establish how they look without a queue and to keep the setup of
+  # their accounts out of the congested phase.
+  - runApp: ordinary
+    type: counter
+    users: 100
+    rate:
+      constant: 15
+
+  # The lane carries the same load as `ordinary` above. Any other load generator
+  # can be put in a lane the same way, by naming it here.
+  - runApp: fast
+    type: priority
+    load: counter
+    users: 100
+    rate:
+      constant: 15
+
+  - waitFor: 30s
+
+  # Background load, well beyond what the throttled network commits, so its
+  # queue keeps growing for as long as it runs.
+  - runApp: congestion
+    type: counter
+    users: 100
+    rate:
+      constant: 200
+
+  - waitFor: 90s
+
+  - checks:
+      - blocksProduced
+      # A run with the feature inactive would compare two identical loads and
+      # conclude nothing, so make that impossible to overlook.
+      - networkRules:
+          rules:
+            Upgrades:
+              TransactionPriorities: true
+
+  - stopApp: congestion
+  - stopApp: fast
+  - stopApp: ordinary
+
+  # Time for the backlog of the prioritized load to drain, which is where the
+  # two lanes differ most visibly.
+  - waitFor: 30s

--- a/scenarios/load_generators/priority.yml
+++ b/scenarios/load_generators/priority.yml
@@ -1,0 +1,24 @@
+Name: Priority Load Test
+Description: >-
+  Runs the priority load generator against a single validator to verify that transactions of registered senders are processed correctly.
+
+InitialNetworkRules:
+  Upgrades:
+    Sonic: true
+    Allegro: true
+    Brio: true
+    TransactionPriorities: true
+
+Scenario:
+  - startNode: validator
+    type: validator
+
+  - runApp: priority
+    type: priority
+    users: 10
+    rate:
+      constant: 10
+
+  - waitFor: 30s
+
+  - stopApp: priority

--- a/scenarios/release_testing/features/priority_lanes/lane_ahead_of_ordinary_load.yml
+++ b/scenarios/release_testing/features/priority_lanes/lane_ahead_of_ordinary_load.yml
@@ -1,11 +1,10 @@
 Name: Release Features Priority Lanes Ahead Of Ordinary Load
 
 Description: >-
-  Two identical counter loads on a network throttled far below what they offer, one
-  with its senders registered in the priority registry, sized so that none of the
-  lane's limits binds. Measured: the lane commits everything it submits at a median
-  0.5s to emission and 7.4s to inclusion, while the ordinary load reaches 129.1s and
-  keeps growing.
+  Two identical counter loads on a network throttled far below what they offer,
+  one with its senders registered in the priority registry, sized so that none of
+  the lane's limits binds. Expect the lane to commit everything it submits within
+  seconds while the ordinary load falls ever further behind.
 
 InitialNetworkRules:
   Economy:

--- a/scenarios/release_testing/features/priority_lanes/lane_ahead_of_ordinary_load.yml
+++ b/scenarios/release_testing/features/priority_lanes/lane_ahead_of_ordinary_load.yml
@@ -1,0 +1,59 @@
+Name: Release Features Priority Lanes Ahead Of Ordinary Load
+
+Description: >-
+  Two identical counter loads on a network throttled far below what they offer, one
+  with its senders registered in the priority registry, sized so that none of the
+  lane's limits binds. Measured: the lane commits everything it submits at a median
+  0.5s to emission and 7.4s to inclusion, while the ordinary load reaches 129.1s and
+  keeps growing.
+
+InitialNetworkRules:
+  Economy:
+    Gas:
+      MaxEventGas: 1500000
+  Epochs:
+    MaxEpochGas: 1000000000000
+    MaxEpochDuration: 1h
+  Upgrades:
+    Sonic: true
+    Allegro: true
+    Brio: true
+    TransactionPriorities: true
+
+Scenario:
+  # Three, so that transactions also reach a validator that is not the proposer,
+  # which is the path a prioritized transaction is admitted eagerly on.
+  - startNode: validator
+    type: validator
+    instances: 3
+
+  - runApp: ordinary
+    type: counter
+    users: 100
+    rate:
+      constant: 300
+
+  # 6 transactions per event, where eager admission allows some 25.
+  - runApp: fast
+    type: priority
+    load: counter
+    users: 100
+    rate:
+      constant: 10
+
+  - waitFor: 120s
+
+  - checks:
+      - blocksProduced
+      # A run with the feature off would compare two identical loads.
+      - networkRules:
+          rules:
+            Upgrades:
+              TransactionPriorities: true
+      - prioritizedTransactionsFirst:
+          minMixedBlocks: 10
+
+  - stopApp: fast
+  - stopApp: ordinary
+
+  - waitFor: 30s

--- a/scenarios/release_testing/features/priority_lanes/lane_under_heavy_gas_load.yml
+++ b/scenarios/release_testing/features/priority_lanes/lane_under_heavy_gas_load.yml
@@ -1,17 +1,15 @@
 Name: Release Features Priority Lanes Under Heavy Gas Load
 
 Description: >-
-  A lane under load measured in gas: storage writes of 6.5 MGas each, prioritized
-  against the same load unprioritized, both offering more than the network commits.
-  A handful of them exhausts the two limits stated in gas - half an event's budget
-  for eager admission, 50 MGas here, and MaxGasPerEntityPerBlock, 100 MGas - while
-  the count of transactions stays far below the one stated in transactions.
-  Measured: the lane is pinned at 99.6 MGas of the average block against its 100
-  MGas quota, the ordinary load keeps 44 MGas, and the median time to inclusion is
-  the same for both, 24.7s against 23.5s, with only the tail differing, 105.9s
-  against 140.3s. A priority decides who goes first within the quota; it does not
-  raise it. The quota also counts gas reserved rather than used, so the 10 percent
-  these transactions over-reserve is quota paid for and not spent.
+  A lane under load measured in gas: storage writes prioritized against the same
+  load unprioritized, both offering more than the network commits, so that a
+  handful of transactions exhausts the limits stated in gas while the one stated
+  in transactions stays out of reach. Expect the lane to be pinned at its
+  per-entity gas quota, taking clearly more gas of every block than the ordinary
+  load but no better time to inclusion - a priority decides who goes first within
+  the quota, it does not raise it. Note that the quota counts gas reserved rather
+  than used, so whatever these transactions over-reserve is quota paid for and
+  not spent.
 
 InitialNetworkRules:
   Economy:

--- a/scenarios/release_testing/features/priority_lanes/lane_under_heavy_gas_load.yml
+++ b/scenarios/release_testing/features/priority_lanes/lane_under_heavy_gas_load.yml
@@ -1,0 +1,65 @@
+Name: Release Features Priority Lanes Under Heavy Gas Load
+
+Description: >-
+  A lane under load measured in gas: storage writes of 6.5 MGas each, prioritized
+  against the same load unprioritized, both offering more than the network commits.
+  A handful of them exhausts the two limits stated in gas - half an event's budget
+  for eager admission, 50 MGas here, and MaxGasPerEntityPerBlock, 100 MGas - while
+  the count of transactions stays far below the one stated in transactions.
+  Measured: the lane is pinned at 99.6 MGas of the average block against its 100
+  MGas quota, the ordinary load keeps 44 MGas, and the median time to inclusion is
+  the same for both, 24.7s against 23.5s, with only the tail differing, 105.9s
+  against 140.3s. A priority decides who goes first within the quota; it does not
+  raise it. The quota also counts gas reserved rather than used, so the 10 percent
+  these transactions over-reserve is quota paid for and not spent.
+
+InitialNetworkRules:
+  Economy:
+    Gas:
+      MaxEventGas: 100000000
+    ShortGasPower:
+      AllocPerSec: 150000000
+    LongGasPower:
+      AllocPerSec: 150000000
+  Epochs:
+    MaxEpochGas: 1000000000000
+    MaxEpochDuration: 1h
+  Upgrades:
+    Sonic: true
+    Allegro: true
+    Brio: true
+    TransactionPriorities: true
+
+Scenario:
+  - startNode: validator
+    type: validator
+    instances: 3
+
+  - runApp: fast
+    type: priority
+    load: store
+    users: 50
+    rate:
+      constant: 20
+
+  - runApp: ordinary
+    type: store
+    users: 50
+    rate:
+      constant: 20
+
+  - waitFor: 120s
+
+  - checks:
+      - blocksProduced
+      - networkRules:
+          rules:
+            Upgrades:
+              TransactionPriorities: true
+      - prioritizedTransactionsFirst:
+          minMixedBlocks: 10
+
+  - stopApp: fast
+  - stopApp: ordinary
+
+  - waitFor: 30s

--- a/scenarios/release_testing/features/priority_lanes/lane_under_transaction_count_load.yml
+++ b/scenarios/release_testing/features/priority_lanes/lane_under_transaction_count_load.yml
@@ -2,13 +2,13 @@ Name: Release Features Priority Lanes Under Transaction Count Load
 
 Description: >-
   A lane under load measured in transactions, the counterpart of the heavy gas
-  scenario next to it: 600 prioritized against 400 ordinary counter transactions per
-  second, both beyond what the network commits, with no gas limit near binding.
-  Measured: the lane takes 1179 transactions of the average block against 589, at a
-  median 43.7s against 86.3s - the same two-to-one split the heavy gas scenario
-  produces. MaxPiggybackTxsPerEntityPerEvent, 1000 per entity per event, is out of
-  reach: one event would have to carry more than a thousand of this entity's
-  transactions, and the whole network commits some 420 per second here.
+  scenario next to it: prioritized against ordinary counter load, both beyond
+  what the network commits, with no gas limit near binding. Expect the lane to
+  take clearly more of every block than the ordinary load and to be included
+  markedly faster, about the same split the heavy gas scenario produces. Note
+  that the limit on prioritized transactions per entity per event stays out of
+  reach: one event would have to carry more than a thousand of them, far beyond
+  what the whole network commits in a second.
 
 InitialNetworkRules:
   Economy:

--- a/scenarios/release_testing/features/priority_lanes/lane_under_transaction_count_load.yml
+++ b/scenarios/release_testing/features/priority_lanes/lane_under_transaction_count_load.yml
@@ -1,0 +1,67 @@
+Name: Release Features Priority Lanes Under Transaction Count Load
+
+Description: >-
+  A lane under load measured in transactions, the counterpart of the heavy gas
+  scenario next to it: 600 prioritized against 400 ordinary counter transactions per
+  second, both beyond what the network commits, with no gas limit near binding.
+  Measured: the lane takes 1179 transactions of the average block against 589, at a
+  median 43.7s against 86.3s - the same two-to-one split the heavy gas scenario
+  produces. MaxPiggybackTxsPerEntityPerEvent, 1000 per entity per event, is out of
+  reach: one event would have to carry more than a thousand of this entity's
+  transactions, and the whole network commits some 420 per second here.
+
+InitialNetworkRules:
+  Economy:
+    Gas:
+      MaxEventGas: 100000000
+    ShortGasPower:
+      AllocPerSec: 60000000
+    LongGasPower:
+      AllocPerSec: 60000000
+  Epochs:
+    MaxEpochGas: 1000000000000
+    MaxEpochDuration: 1h
+  Upgrades:
+    Sonic: true
+    Allegro: true
+    Brio: true
+    TransactionPriorities: true
+
+Scenario:
+  - startNode: validator
+    type: validator
+    instances: 3
+
+  # Started before the ordinary load: registering its users costs one ordinary
+  # transaction each, which a pool already full would not carry in time.
+  - runApp: fast
+    type: priority
+    load: counter
+    users: 200
+    rate:
+      constant: 600
+
+  # The rates together stay near what the network commits. Several times beyond it
+  # leaves a six-figure pool that every validator re-sorts per event, which costs
+  # more than the lane gains - measured, it puts the lane behind ordinary traffic.
+  - runApp: ordinary
+    type: counter
+    users: 200
+    rate:
+      constant: 400
+
+  - waitFor: 120s
+
+  - checks:
+      - blocksProduced
+      - networkRules:
+          rules:
+            Upgrades:
+              TransactionPriorities: true
+      - prioritizedTransactionsFirst:
+          minMixedBlocks: 10
+
+  - stopApp: fast
+  - stopApp: ordinary
+
+  - waitFor: 30s


### PR DESCRIPTION
Sonic's transaction priorities feature hoists the transactions of registered senders ahead of the rest at block formation, up to a gas quota per registered entity. Norma had no way to place load in such a lane.

### The lane

A lane is not a load of its own — the point is comparing the same traffic with and without a priority. The new `priority` application type therefore takes the load it carries as a parameter:

```yaml
- runApp: fast
  type: priority
  load: uniswap
```

It registers the accounts its users sign with as one entity and generates that load unchanged.

Loads whose senders are not known before the run refuse to be prioritized. Registering what such a load happens to hold at setup time would prioritize part of its traffic and silently leave the rest behind, which is worse than refusing.

### The check

`prioritizedTransactionsFirst` reads block order rather than latency. Latency is not deterministic here: it depends on the offered rate, the pool depth and the machine, and the advantage disappears once a lane saturates its quota — while the ordering stays correct throughout.

The check notes the head of the chain when it starts, waits for the blocks produced from there, and fails if:

- too few of them carry transactions of both classes — no evidence, rather than a pass on a network where nothing was prioritized;
- the run of prioritized transactions a block opens with covers less than a median share of the transactions the quota can admit (0.5 by default, lower it with `minRunCoverage` for a congested lane);
- the gas of that run exceeds the quota of one entity — asserted only where the block demoted nothing, since a demoted transaction sits among the ordinary ones and cannot be told from one.

The yardstick is what the quota admits, not every prioritized transaction in the block. A lane offering more gas than its quota necessarily leaves some behind, so the stricter yardstick would fail exactly when the quota does its job.

### The scenarios

| Scenario | Intent |
| --- | --- |
| `examples/priority_lanes.yml` | Show the effect at all: a lane, the identical unprioritized load, and congestion. |
| `release_testing/.../lane_ahead_of_ordinary_load.yml` | A lane below all of its limits. |
| `release_testing/.../lane_under_transaction_count_load.yml` | A lane under load measured in transactions. |
| `release_testing/.../lane_under_heavy_gas_load.yml` | A lane under load measured in gas, pinned at its quota. |
| `load_generators/priority.yml` | Smoke test for the new application type. |

Each release test asserts the ordering with the new check.

Stacked on #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
