### PR TITLE
Let an application submit through a single node

### DIFF
--- a/SCENARIO_SPECIFICATION.md
+++ b/SCENARIO_SPECIFICATION.md
@@ -270,6 +270,27 @@ the registry is written, and registering the ones that happen to exist would
 prioritize a part of their traffic and quietly leave the rest behind. Asking for
 them reports that rather than doing it.
 
+**Where the transactions enter the network.** By default an application's
+transactions are submitted through whichever node's RPC interface takes them
+first, which is what a load measuring the network as a whole wants. The optional
+`rpcNode` parameter names one node label instead, and then every transaction of
+that application enters the network there and nowhere else.
+
+```yaml
+- runApp: fast
+  type: priority
+  rpcNode: validator-0     # optional; any node label, default is any node
+  rate:
+    constant: 20
+```
+
+The label is the one the node runs under: the identifier of its `startNode` step
+for a single instance, and `<identifier>-<index>` when that step started several.
+An application asking for a label no running node carries fails to start. If the
+node is stopped later, that application's transactions are dropped and reported
+as failed submissions rather than sent elsewhere, which is visible in the
+monitoring data as rejected transactions.
+
 **Rate shapes** — exactly one of the following must be set on `rate`:
 
 ```yaml

--- a/SCENARIO_SPECIFICATION.md
+++ b/SCENARIO_SPECIFICATION.md
@@ -286,6 +286,9 @@ that application enters the network there and nowhere else.
 
 The label is the one the node runs under: the identifier of its `startNode` step
 for a single instance, and `<identifier>-<index>` when that step started several.
+A node started as `type: rpc` is the usual target, so that the load enters the
+network through a node that proposes nothing of its own.
+
 An application asking for a label no running node carries fails to start. If the
 node is stopped later, that application's transactions are dropped and reported
 as failed submissions rather than sent elsewhere, which is visible in the

--- a/driver/executor/run.go
+++ b/driver/executor/run.go
@@ -843,11 +843,12 @@ func execRunApp(
 	}
 
 	app, err := net.CreateApplication(ctx, &driver.ApplicationConfig{
-		Name:  step.Identifier,
-		Type:  step.AppType,
-		Load:  step.AppLoad,
-		Rate:  step.Rate,
-		Users: users,
+		Name:    step.Identifier,
+		Type:    step.AppType,
+		Load:    step.AppLoad,
+		RpcNode: step.AppRpcNode,
+		Rate:    step.Rate,
+		Users:   users,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create application %s: %w", step.Identifier, err)

--- a/driver/network.go
+++ b/driver/network.go
@@ -93,10 +93,16 @@ type Network interface {
 	// any potential other resources.
 	Shutdown() error
 
-	// SendTransaction sends a transaction to the network. The source identifies
-	// which load generator produced it, for diagnostics and for attributing it
-	// to an application in the monitoring data.
+	// SendTransaction sends a transaction to the network, through the RPC
+	// interface of whichever node takes it first. The source identifies which
+	// load generator produced it, for diagnostics and for attributing it to an
+	// application in the monitoring data.
 	SendTransaction(tx *types.Transaction, source TransactionSource)
+
+	// SendTransactionTo sends a transaction to the network through the RPC
+	// interface of the node with the given label, and nowhere else. It is what an
+	// application pinned to a node needs; see ApplicationConfig.RpcNode.
+	SendTransactionTo(label string, tx *types.Transaction, source TransactionSource)
 
 	// RegisterTransactionObserver registers an observer to be notified about
 	// every transaction submitted through SendTransaction.
@@ -209,6 +215,13 @@ type ApplicationConfig struct {
 	// instead of defining their own, such as the priority lanes. It is empty for
 	// every other type.
 	Load string
+
+	// RpcNode is the label of the node whose RPC interface receives every
+	// transaction of this application. Empty, the default, submits through any
+	// node of the network, which is what a load that measures the network as a
+	// whole wants; naming one node is for asking what the network does with
+	// traffic that enters it in a single place.
+	RpcNode string
 
 	// Rate defines the Tx/s config the source should produce while active.
 	Rate *parser.Rate

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -359,6 +359,10 @@ func (n *LocalNetwork) SendTransaction(tx *types.Transaction, source driver.Tran
 	n.rpcWorkerPool.SendTransaction(tx, source)
 }
 
+func (n *LocalNetwork) SendTransactionTo(label string, tx *types.Transaction, source driver.TransactionSource) {
+	n.rpcWorkerPool.SendTransactionTo(label, tx, source)
+}
+
 func (n *LocalNetwork) RegisterTransactionObserver(observer driver.TransactionObserver) {
 	n.rpcWorkerPool.RegisterObserver(observer)
 }
@@ -504,6 +508,26 @@ func (n *LocalNetwork) ensureAppContext() error {
 	return nil
 }
 
+// checkRpcNode reports whether an application may be pinned to the given node
+// label. An empty label pins nothing. A label no node of the network carries is
+// refused here rather than at the first transaction, where it would be a warning
+// per transaction of a load that produces nothing.
+func (n *LocalNetwork) checkRpcNode(label string) error {
+	if label == "" {
+		return nil
+	}
+	labels := make([]string, 0, len(n.nodes))
+	for _, node := range n.GetActiveNodes() {
+		if node.GetLabel() == label {
+			return nil
+		}
+		labels = append(labels, node.GetLabel())
+	}
+	return fmt.Errorf(
+		"no node labelled %q to send the transactions of the application to, running are %v",
+		label, labels)
+}
+
 func (n *LocalNetwork) CreateApplication(ctx context.Context, config *driver.ApplicationConfig) (driver.Application, error) {
 	if err := n.ensureAppContext(); err != nil {
 		return nil, fmt.Errorf("failed to initialize app context: %w", err)
@@ -514,6 +538,10 @@ func (n *LocalNetwork) CreateApplication(ctx context.Context, config *driver.App
 		return nil, fmt.Errorf("failed to connect to RPC to initialize the application; %v", err)
 	}
 	defer rpcClient.Close()
+
+	if err := n.checkRpcNode(config.RpcNode); err != nil {
+		return nil, err
+	}
 
 	appId := n.nextAppId.Add(1)
 	application, err := app.NewApplication(config.Type, config.Load, n.appContext, 0, appId)
@@ -526,7 +554,8 @@ func (n *LocalNetwork) CreateApplication(ctx context.Context, config *driver.App
 		return nil, fmt.Errorf("failed to parse shaper; %v", err)
 	}
 
-	appController, err := controller.NewAppController(config.Name, application, sh, config.Users, n.appContext, n)
+	appController, err := controller.NewAppController(
+		config.Name, config.RpcNode, application, sh, config.Users, n.appContext, n)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/network/rpc/rpc_pool.go
+++ b/driver/network/rpc/rpc_pool.go
@@ -18,6 +18,7 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -32,6 +33,7 @@ import (
 type RpcWorkerPool struct {
 	txs       chan transactionWithSource
 	workers   map[driver.Node]*workerGroup
+	queues    *nodeQueues
 	ctx       context.Context
 	cancel    context.CancelFunc
 	observers *observers
@@ -43,6 +45,7 @@ func NewRpcWorkerPool(ctx context.Context) *RpcWorkerPool {
 	return &RpcWorkerPool{
 		txs:       make(chan transactionWithSource, 100),
 		workers:   make(map[driver.Node]*workerGroup, 10),
+		queues:    newNodeQueues(),
 		ctx:       ctx,
 		cancel:    cancel,
 		observers: &observers{},
@@ -51,6 +54,80 @@ func NewRpcWorkerPool(ctx context.Context) *RpcWorkerPool {
 
 func (p *RpcWorkerPool) SendTransaction(tx *types.Transaction, source driver.TransactionSource) {
 	p.txs <- transactionWithSource{tx: tx, source: source}
+}
+
+// SendTransactionTo submits the transaction through the node of the given label.
+// A transaction for a label no node of the network answers to is dropped and
+// reported to the observers as a failed submission, which is what it is: nothing
+// took it, and a scenario pinning an application to a node it then stops should
+// see that in its data rather than lose the transactions silently.
+func (p *RpcWorkerPool) SendTransactionTo(
+	label string,
+	tx *types.Transaction,
+	source driver.TransactionSource,
+) {
+	queue, served := p.queues.of(label)
+	if !served {
+		err := fmt.Errorf("no node labelled %q is serving transactions", label)
+		p.observers.notify(source, tx, time.Now(), err)
+		slog.Warn("failed to send tx", "node", label, "source", source, "error", err)
+		return
+	}
+	queue <- transactionWithSource{tx: tx, source: source}
+}
+
+// nodeQueues holds the transaction queue of every node label an application has
+// been pinned to, and knows which of those labels a node is currently serving. A
+// queue outlives the node it belongs to, so a node that leaves the network and
+// comes back keeps the transactions of its applications.
+type nodeQueues struct {
+	mu     sync.Mutex
+	queues map[string]chan transactionWithSource
+	served map[string]int
+}
+
+func newNodeQueues() *nodeQueues {
+	return &nodeQueues{
+		queues: map[string]chan transactionWithSource{},
+		served: map[string]int{},
+	}
+}
+
+// queue returns the queue of the given label, creating it if it does not exist.
+func (q *nodeQueues) queue(label string) chan transactionWithSource {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.queueOf(label)
+}
+
+// of returns the queue of the given label and whether a node is serving it.
+func (q *nodeQueues) of(label string) (chan transactionWithSource, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.queueOf(label), q.served[label] > 0
+}
+
+func (q *nodeQueues) queueOf(label string) chan transactionWithSource {
+	queue, exists := q.queues[label]
+	if !exists {
+		queue = make(chan transactionWithSource, 100)
+		q.queues[label] = queue
+	}
+	return queue
+}
+
+func (q *nodeQueues) startServing(label string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.served[label]++
+}
+
+func (q *nodeQueues) stopServing(label string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.served[label] > 0 {
+		q.served[label]--
+	}
 }
 
 // RegisterObserver adds an observer to be notified about every transaction this
@@ -98,14 +175,17 @@ func (p *RpcWorkerPool) AfterNodeCreation(newNode driver.Node) {
 		return
 	}
 
+	label := newNode.GetLabel()
 	wg := workerGroup{}
 	p.workers[newNode] = &wg
 	for i := 0; i < 150; i++ {
-		wg.add(newNode.GetLabel(), *rpcUrl, p.txs, p.observers)
+		wg.add(label, *rpcUrl, p.txs, p.queues.queue(label), p.observers)
 	}
+	p.queues.startServing(label)
 }
 
 func (p *RpcWorkerPool) BeforeNodeRemoval(node driver.Node) {
+	p.queues.stopServing(node.GetLabel())
 	p.workers[node].close()
 }
 
@@ -133,8 +213,14 @@ func (p *RpcWorkerPool) Close() error {
 // When the group is closed, it should not be re-used and should be forgotten.
 type workerGroup []*worker
 
-func (wg *workerGroup) add(nodeName string, rpcUrl driver.URL, txs chan transactionWithSource, observers *observers) {
-	w := newWorker(nodeName, rpcUrl, txs, observers)
+func (wg *workerGroup) add(
+	nodeName string,
+	rpcUrl driver.URL,
+	txs chan transactionWithSource,
+	own chan transactionWithSource,
+	observers *observers,
+) {
+	w := newWorker(nodeName, rpcUrl, txs, own, observers)
 	*wg = append(*wg, w)
 }
 
@@ -158,16 +244,25 @@ func (wg *workerGroup) close() {
 // it starts dispatching asynchronously. This process can be interrupted by
 // closing the worker before it starts dispatching.
 type worker struct {
-	nodeName  string
-	rpcUrl    driver.URL
-	done      chan bool
-	txs       chan transactionWithSource
+	nodeName string
+	rpcUrl   driver.URL
+	done     chan bool
+	txs      chan transactionWithSource
+	// own holds the transactions of the applications pinned to this worker's
+	// node, which no other node's workers take.
+	own       chan transactionWithSource
 	ctx       context.Context
 	cancel    context.CancelFunc
 	observers *observers
 }
 
-func newWorker(nodeName string, rpcUrl driver.URL, txs chan transactionWithSource, observers *observers) *worker {
+func newWorker(
+	nodeName string,
+	rpcUrl driver.URL,
+	txs chan transactionWithSource,
+	own chan transactionWithSource,
+	observers *observers,
+) *worker {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	w := &worker{
@@ -175,6 +270,7 @@ func newWorker(nodeName string, rpcUrl driver.URL, txs chan transactionWithSourc
 		rpcUrl:    rpcUrl,
 		done:      make(chan bool),
 		txs:       txs,
+		own:       own,
 		ctx:       ctx,
 		cancel:    cancel,
 		observers: observers,
@@ -213,16 +309,31 @@ func (p *worker) runRpcSenderLoop() error {
 	}
 
 	defer rpcClient.Close()
+	send := func(tx transactionWithSource) {
+		err := rpcClient.SendTransaction(context.Background(), tx.tx)
+		// The submission is reported before any logging, keeping the measured
+		// moment as close to the actual submission as possible.
+		p.observers.notify(tx.source, tx.tx, time.Now(), err)
+		if err != nil {
+			slog.Warn("failed to send tx", "node", p.nodeName, "source", tx.source, "error", err)
+		}
+	}
 	for {
+		// The transactions pinned to this node come first: they have nowhere else
+		// to go, while the ones of the shared queue are taken by every node.
 		select {
+		case tx := <-p.own:
+			send(tx)
+			continue
+		case <-p.ctx.Done():
+			return nil
+		default:
+		}
+		select {
+		case tx := <-p.own:
+			send(tx)
 		case tx := <-p.txs:
-			err := rpcClient.SendTransaction(context.Background(), tx.tx)
-			// The submission is reported before any logging, keeping the
-			// measured moment as close to the actual submission as possible.
-			p.observers.notify(tx.source, tx.tx, time.Now(), err)
-			if err != nil {
-				slog.Warn("failed to send tx", "node", p.nodeName, "source", tx.source, "error", err)
-			}
+			send(tx)
 		case <-p.ctx.Done():
 			return nil
 		}

--- a/driver/network/rpc/rpc_pool_test.go
+++ b/driver/network/rpc/rpc_pool_test.go
@@ -31,7 +31,7 @@ func TestRetryRpcReturnGracefully(t *testing.T) {
 
 	start := time.Now()
 	txs := make(chan transactionWithSource)
-	w := newWorker("test", "wrong", txs, &observers{})
+	w := newWorker("test", "wrong", txs, make(chan transactionWithSource), &observers{})
 
 	time.Sleep(6 * time.Second)
 	w.close()
@@ -80,9 +80,66 @@ func TestClosePool(t *testing.T) {
 	}
 }
 
+func TestPool_PinnedTransactionsGoToTheirNodeAlone(t *testing.T) {
+	pool := NewRpcWorkerPool(t.Context())
+	pool.queues.startServing("A")
+
+	var tx types.Transaction
+	pool.SendTransactionTo("A", &tx, driver.TransactionSource{App: "pinned"})
+
+	select {
+	case got := <-pool.queues.queue("A"):
+		if got.source.App != "pinned" {
+			t.Errorf("queue of A holds the transactions of %q", got.source.App)
+		}
+	default:
+		t.Error("the transaction did not reach the queue of node A")
+	}
+	select {
+	case got := <-pool.txs:
+		t.Errorf("a pinned transaction reached the shared queue: %v", got.source)
+	default:
+	}
+}
+
+func TestPool_ReportsPinnedTransactionsNoNodeServes(t *testing.T) {
+	pool := NewRpcWorkerPool(t.Context())
+	observer := &recordingObserver{}
+	pool.RegisterObserver(observer)
+
+	var tx types.Transaction
+	pool.SendTransactionTo("gone", &tx, driver.TransactionSource{App: "pinned"})
+
+	if got := len(observer.errs); got != 1 {
+		t.Fatalf("got %d submissions reported, wanted the dropped one", got)
+	}
+	if observer.errs[0] == nil {
+		t.Error("the dropped transaction was reported as submitted")
+	}
+	select {
+	case got := <-pool.queues.queue("gone"):
+		t.Errorf("the transaction was queued for a node that does not exist: %v", got.source)
+	default:
+	}
+}
+
+// recordingObserver keeps the error of every submission reported to it.
+type recordingObserver struct {
+	mu   sync.Mutex
+	errs []error
+}
+
+func (o *recordingObserver) OnTransactionSubmitted(
+	_ driver.TransactionSource, _ *types.Transaction, _ time.Time, err error,
+) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.errs = append(o.errs, err)
+}
+
 func TestCloseWorkerStartStop(t *testing.T) {
 	txs := make(chan transactionWithSource)
-	w := newWorker("test", "wrong", txs, &observers{})
+	w := newWorker("test", "wrong", txs, make(chan transactionWithSource), &observers{})
 	w.close()
 }
 
@@ -90,7 +147,7 @@ func TestCloseWorkerGroupStartStop(t *testing.T) {
 	txs := make(chan transactionWithSource)
 	wg := workerGroup{}
 	for i := 0; i < 150; i++ {
-		wg.add("test", "wrong", txs, &observers{})
+		wg.add("test", "wrong", txs, make(chan transactionWithSource), &observers{})
 	}
 	wg.close()
 }

--- a/driver/network_mock.go
+++ b/driver/network_mock.go
@@ -220,6 +220,18 @@ func (mr *MockNetworkMockRecorder) SendTransaction(tx, source any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTransaction", reflect.TypeOf((*MockNetwork)(nil).SendTransaction), tx, source)
 }
 
+// SendTransactionTo mocks base method.
+func (m *MockNetwork) SendTransactionTo(label string, tx *types.Transaction, source TransactionSource) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SendTransactionTo", label, tx, source)
+}
+
+// SendTransactionTo indicates an expected call of SendTransactionTo.
+func (mr *MockNetworkMockRecorder) SendTransactionTo(label, tx, source any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTransactionTo", reflect.TypeOf((*MockNetwork)(nil).SendTransactionTo), label, tx, source)
+}
+
 // Shutdown mocks base method.
 func (m *MockNetwork) Shutdown() error {
 	m.ctrl.T.Helper()

--- a/driver/parser/scenario.go
+++ b/driver/parser/scenario.go
@@ -328,10 +328,11 @@ type Step struct {
 	ExtraArguments string
 
 	// App parameters
-	AppType string
-	AppLoad string // the traffic an app type carries when it does not define its own
-	Users   *int
-	Rate    *Rate
+	AppType    string
+	AppLoad    string // the traffic an app type carries when it does not define its own
+	AppRpcNode string // the only node this app's transactions are sent to, if any
+	Users      *int
+	Rate       *Rate
 
 	// Update rules parameters
 	Rules genesis.NetworkRulesPatch
@@ -591,6 +592,7 @@ var paramDescriptions = map[string]string{
 	"failing":        "When true, the step is expected to fail; a passing result is treated as an error.",
 	"extraArguments": "Extra command line arguments for sonicd.",
 	"load":           "Traffic an application type carries when it does not define its own, such as the load of a priority lane.",
+	"rpcNode":        "Label of the only node the transactions of the application are submitted to. Omitted, they are submitted through any node of the network.",
 	"users":          "Number of concurrent user accounts the application should simulate.",
 	"rate":           "Transaction rate configuration for the application.",
 }
@@ -599,7 +601,7 @@ var paramDescriptions = map[string]string{
 var allowedParams = map[StepFunction][]string{
 	FuncStartNode:    {"type", "imageName", "dataVolume", "stake", "instances", "failing", "extraArguments"},
 	FuncStopNode:     {},
-	FuncRunApp:       {"type", "load", "users", "rate"},
+	FuncRunApp:       {"type", "load", "rpcNode", "users", "rate"},
 	FuncStopApp:      {},
 	FuncUpdateRules:  {},
 	FuncDelegate:     {},
@@ -639,6 +641,12 @@ func (s *Step) parseParam(key string, val *yaml.Node) error {
 			return fmt.Errorf("invalid load value: %w", err)
 		}
 		s.AppLoad = v
+	case "rpcNode":
+		var v string
+		if err := val.Decode(&v); err != nil {
+			return fmt.Errorf("invalid rpcNode value: %w", err)
+		}
+		s.AppRpcNode = v
 	case "imageName":
 		var v string
 		if err := val.Decode(&v); err != nil {

--- a/driver/parser/scenario_test.go
+++ b/driver/parser/scenario_test.go
@@ -1245,6 +1245,34 @@ Scenario:
 	require.Equal(t, "uniswap", step.AppLoad)
 }
 
+func TestParseBytes_ApplicationRpcNodeIsParsed(t *testing.T) {
+	scenario, err := ParseBytes([]byte(`
+Name: Test
+Description: A test scenario.
+Scenario:
+  - runApp: fast
+    type: counter
+    rpcNode: validator-0
+    rate:
+      constant: 5
+`))
+	require.NoError(t, err)
+	require.NoError(t, scenario.Check())
+	require.Equal(t, "validator-0", scenario.Steps[0].AppRpcNode)
+}
+
+func TestParseBytes_OnlyAnApplicationCanNameAnRpcNode(t *testing.T) {
+	_, err := ParseBytes([]byte(`
+Name: Test
+Description: A test scenario.
+Scenario:
+  - startNode: validator
+    type: validator
+    rpcNode: validator-0
+`))
+	require.ErrorContains(t, err, `parameter "rpcNode" is not valid`)
+}
+
 func TestScenario_ApplicationLoadIsValidated(t *testing.T) {
 	tests := map[string]struct {
 		appType string

--- a/load/controller/controller.go
+++ b/load/controller/controller.go
@@ -36,6 +36,7 @@ import (
 // The RPC Client is used to send the transactions into the network.
 type AppController struct {
 	name        string
+	rpcNode     string
 	shaper      shaper.Shaper
 	application app.Application
 	network     driver.Network
@@ -48,9 +49,11 @@ type AppController struct {
 // one the scenario gave the application; it travels with every transaction so
 // that monitoring can attribute it to this application rather than to the type
 // of load it generates - two applications of different types can generate the
-// same transactions.
+// same transactions. The rpcNode, when not empty, is the label of the only node
+// this application's transactions are submitted through.
 func NewAppController(
 	name string,
+	rpcNode string,
 	application app.Application,
 	shaper shaper.Shaper,
 	numUsers int,
@@ -76,6 +79,7 @@ func NewAppController(
 
 	return &AppController{
 		name:        name,
+		rpcNode:     rpcNode,
 		shaper:      shaper,
 		application: application,
 		network:     network,
@@ -95,7 +99,7 @@ func (ac *AppController) Run(ctx context.Context) error {
 		done.Add(1)
 		go func() {
 			defer done.Done()
-			runGeneratorLoop(user, source, ac.trigger, ac.network)
+			runGeneratorLoop(user, source, ac.rpcNode, ac.trigger, ac.network)
 		}()
 	}
 

--- a/load/controller/controller_test.go
+++ b/load/controller/controller_test.go
@@ -89,7 +89,7 @@ func TestLoadGeneration_CanRealizeConstantTrafficShape(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create app context: %v", err)
 			}
-			controller, err := controller.NewAppController("test-app", application, shaper, 100, appContext, net)
+			controller, err := controller.NewAppController("test-app", "", application, shaper, 100, appContext, net)
 			if err != nil {
 				t.Fatalf("failed to create app controller: %v", err)
 			}

--- a/load/controller/generator.go
+++ b/load/controller/generator.go
@@ -23,9 +23,13 @@ import (
 	"github.com/0xsoniclabs/norma/load/app"
 )
 
+// runGeneratorLoop generates and submits the transactions of one user. An empty
+// rpcNode submits through any node of the network; a label submits through that
+// node alone.
 func runGeneratorLoop(
 	user app.User,
 	source driver.TransactionSource,
+	rpcNode string,
 	trigger <-chan struct{},
 	network driver.Network,
 ) {
@@ -33,8 +37,12 @@ func runGeneratorLoop(
 		tx, err := user.GenerateTx()
 		if err != nil {
 			slog.Error("failed to generate tx", "error", err, "source", source)
-		} else {
+			continue
+		}
+		if rpcNode == "" {
 			network.SendTransaction(tx, source)
+		} else {
+			network.SendTransactionTo(rpcNode, tx, source)
 		}
 	}
 }

--- a/load/controller/mocked_test.go
+++ b/load/controller/mocked_test.go
@@ -57,7 +57,7 @@ func TestMockedTrafficGenerating(t *testing.T) {
 	// use constant shaper
 	constantShaper := shaper.NewConstantShaper(100) // 100 txs/sec
 
-	appController, err := NewAppController("test-app", mockedApp, constantShaper, numUsers, appContext, mockedNetwork)
+	appController, err := NewAppController("test-app", "", mockedApp, constantShaper, numUsers, appContext, mockedNetwork)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/load/controller/rpc_test.go
+++ b/load/controller/rpc_test.go
@@ -65,7 +65,7 @@ func TestTrafficGenerating(t *testing.T) {
 	constantShaper := shaper.NewConstantShaper(30.0) // 30 txs/sec
 
 	numGenerators := 5 // 5 parallel workers
-	app, err := controller.NewAppController("test-app", application, constantShaper, numGenerators, appContext, net)
+	app, err := controller.NewAppController("test-app", "", application, constantShaper, numGenerators, appContext, net)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scenarios/release_testing/features/priority_lanes/lane_through_an_rpc_node.yml
+++ b/scenarios/release_testing/features/priority_lanes/lane_through_an_rpc_node.yml
@@ -1,0 +1,64 @@
+Name: Release Features Priority Lanes Through An Rpc Node
+
+Description: >-
+  Two identical counter loads on a throttled network, one prioritized and
+  submitting every transaction through a node that is not a validator while the
+  other uses any node there is. It is the longest way into a block a prioritized
+  transaction can take - the node it enters through emits no events at all, so it
+  has to reach a validator by gossip first - and the lane is expected to keep its
+  advantage over the ordinary load anyway. Note that the node the lane submits to
+  has to run for as long as the lane does: were it stopped, those transactions
+  would be dropped and reported as failed submissions rather than sent elsewhere.
+
+InitialNetworkRules:
+  Economy:
+    Gas:
+      MaxEventGas: 1500000
+  Epochs:
+    MaxEpochGas: 1000000000000
+    MaxEpochDuration: 1h
+  Upgrades:
+    Sonic: true
+    Allegro: true
+    Brio: true
+    TransactionPriorities: true
+
+Scenario:
+  - startNode: validator
+    type: validator
+    instances: 3
+
+  # The load of the lane enters the network here, through a node that holds no
+  # stake and proposes nothing.
+  - startNode: rpc
+    type: rpc
+
+  - runApp: ordinary
+    type: counter
+    users: 100
+    rate:
+      constant: 300
+
+  - runApp: fast
+    type: priority
+    load: counter
+    rpcNode: rpc
+    users: 100
+    rate:
+      constant: 10
+
+  - waitFor: 120s
+
+  - checks:
+      - blocksProduced
+      - networkRules:
+          rules:
+            Upgrades:
+              TransactionPriorities: true
+      - prioritizedTransactionsFirst:
+          minMixedBlocks: 10
+
+  - stopApp: fast
+  - stopApp: ordinary
+
+  - waitFor: 30s


### PR DESCRIPTION
Every transaction went to whichever RPC worker picked it up first, so a load could not be made to enter the network in one place. That matters for the priority lanes: how many validators hold a prioritized transaction when it is admitted changes what the feature has to do to keep its advantage.

### The field

An application can now name the node its transactions are submitted through, and omitting it keeps today's behaviour — any node:

```yaml
- runApp: fast
  type: priority
  rpcNode: validator-0
```

The label is the one the node runs under: the identifier of its `startNode` step for a single instance, `<identifier>-<index>` when that step started several.

### How it routes

The worker pool keeps a queue per node label beside the shared one. A node's workers serve their own queue before the shared one, because the transactions pinned to them have nowhere else to go, while the shared ones are taken by every node.

Two failure modes are deliberate rather than silent. An application naming a label no running node carries fails to start, instead of warning once per transaction of a load that produces nothing. If its node is stopped later, its transactions are reported to the observers as failed submissions rather than sent elsewhere — so they appear in the monitoring data as rejected.

### The scenario

`lane_through_an_rpc_node.yml` starts three validators and one node that is not a validator, then runs two identical counter loads: the prioritized one submits through that non-validator node alone, the ordinary one through any node there is.

That is the longest way into a block a prioritized transaction can take — the node it enters through emits no events of its own, so the transaction has to reach a validator by gossip before it can be carried anywhere. The lane is expected to keep its advantage over the ordinary load regardless, and the ordering is asserted with `prioritizedTransactionsFirst`.

Stacked on #282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
