### PR TITLE
Fix the SA5011 findings staticcheck reports on main

### DIFF
--- a/driver/checking/simulated_network_test.go
+++ b/driver/checking/simulated_network_test.go
@@ -123,9 +123,8 @@ func TestSimulation_UnreachableNodeStopsBeingSampled(t *testing.T) {
 
 		latest := net.GetBlockStatus("A").GetLatest()
 		if latest == nil {
-			t.Fatalf("expected samples from before the node was stopped")
-		}
-		if at := latest.Position.Time(); !at.Before(stoppedAt) {
+			t.Fatal("expected samples from before the node was stopped")
+		} else if at := latest.Position.Time(); !at.Before(stoppedAt) {
 			t.Errorf("last sample taken at %v, want before %v", at, stoppedAt)
 		}
 	})

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -755,18 +755,21 @@ func TestLocalNetwork_MountDataDir_Can_Be_Reused(t *testing.T) {
 		t.Fatalf("failed to create node: %v", err)
 	}
 
-	getModificationTime := func() (*time.Time, []string, error) {
-		var carmenModTime *time.Time
+	getModificationTime := func() (time.Time, []string, error) {
+		var carmenModTime time.Time
+		var found bool
 		var visitedDirs []string
 		localDirBinding := fmt.Sprintf("%s/%s", temp, dataVolume)
 		err := filepath.Walk(localDirBinding, func(path string, info os.FileInfo, err error) error {
 			visitedDirs = append(visitedDirs, path)
 			if strings.HasSuffix(path, "transactions.rlp") {
-				carmenModTime = new(time.Time)
-				*carmenModTime = info.ModTime()
+				carmenModTime, found = info.ModTime(), true
 			}
 			return nil
 		})
+		if err == nil && !found {
+			err = fmt.Errorf("directory contains no database files, visited %v", visitedDirs)
+		}
 		return carmenModTime, visitedDirs, err
 	}
 
@@ -774,9 +777,6 @@ func TestLocalNetwork_MountDataDir_Can_Be_Reused(t *testing.T) {
 	prevModTime, prevVisitedDirs, err := getModificationTime()
 	if err != nil {
 		t.Fatalf("failed to get modification time: %v", err)
-	}
-	if prevModTime == nil {
-		t.Fatalf("directory does not contain database files: %v", prevVisitedDirs)
 	}
 
 	if !slices.ContainsFunc(
@@ -812,7 +812,7 @@ func TestLocalNetwork_MountDataDir_Can_Be_Reused(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get modification time: %v", err)
 	}
-	if got, want := *currModTime, *prevModTime; got.Equal(want) {
+	if got, want := currModTime, prevModTime; got.Equal(want) {
 		t.Errorf("got modification time %v, wanted modification time %v", got, want)
 	}
 	if !slices.ContainsFunc(


### PR DESCRIPTION
`staticcheck` reports four `SA5011` findings on `main` — two in `driver/checking/simulated_network_test.go`, two in `driver/network/local/local_test.go`. Both are a `t.Fatalf` guarding a pointer, followed by a dereference: the analyser does not treat `Fatalf` as the end of the test, so it sees a path where the nil pointer reaches the dereference.

They surface unpredictably. Whether a given PR's lint job reports them depends on whether the golangci-lint action's cache happens to serve those two packages a previous result or re-analyses them, so PRs that touch nothing nearby fail while others pass.

The fix makes the dereference dominated by the check that guards it, so no analyser has to reason about `Fatalf` at all. In the local network test the helper now reports a missing database file as an error instead of returning a nil time, which also closes a real gap: the second call's result was dereferenced with no check whatsoever, so a run without database files panicked instead of failing with a message.

Based on `main`, so it can go in ahead of the branches waiting on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
