### PR TITLE
Pin sonic version in a norma run

### DIFF
--- a/RELEASE_TESTING.md
+++ b/RELEASE_TESTING.md
@@ -14,11 +14,11 @@ old version forking. What follows is a role-based procedure instead.
 
 `imageName` values are resolved by [driver/docker/images.go](driver/docker/images.go):
 
-| Reference                   | Resolution                                                   |
-| --------------------------- | ------------------------------------------------------------ |
-| omitted / `sonic:local`     | docker build from the [sonic](sonic) submodule               |
-| `sonic:vX.Y.Z`              | docker build from `github.com/0xsoniclabs/sonic.git#vX.Y.Z`  |
-| `sonic`                     | docker build from the remote repository's **default branch** |
+| Reference                   | Resolution                                                    |
+| --------------------------- | ------------------------------------------------------------- |
+| omitted / `sonic:local`     | docker build from the [sonic](sonic) submodule                |
+| `sonic:vX.Y.Z`              | docker build from the commit that `vX.Y.Z` names in `github.com/0xsoniclabs/sonic.git` |
+| `sonic`                     | docker build from the remote repository's **default branch**  |
 
 Consequences:
 
@@ -38,6 +38,15 @@ Consequences:
   so the submodule pointer is what decides which code the candidate actually
   is. `--sonic-path` can override this for local experiments, but the committed
   submodule revision is what CI and release runs build.
+- A reference is **resolved once per run**, and the nodes are started from the
+  image that resolution produced, which norma keeps under a `norma-pinned:<image
+  id>` reference of its own. The sources behind a reference move: a branch gets a
+  commit, a submodule gets checked out anew, and a docker tag can be re-pointed
+  by anything else on the host — which is also why the run does not leave its
+  image under one of those. A remote reference is therefore looked up with `git
+  ls-remote` and built from the commit it names right then, and every node of the
+  run gets that image — so a run tests one client per reference, and the log says
+  which commit and which image that was. `norma purge` drops the pins again.
 
 Norma's Go dependency on `github.com/0xsoniclabs/sonic` comes from the module
 proxy and has no `replace` directive pointing at `./sonic`. The submodule

--- a/driver/docker/client_version.go
+++ b/driver/docker/client_version.go
@@ -37,13 +37,11 @@ const SonicdBinaryPath = "/sonicd"
 // does not carry a version: "sonic:local" builds from a working copy and
 // "sonic:<commit hash>" from an arbitrary commit, either of which may be older
 // or newer than any release. Images that are not present yet are built or
-// pulled first, so this can be called before any node has started.
+// pulled first, so this can be called before any node has started. The version
+// is asked of the image the reference resolved to, and that image is the one
+// the run keeps using afterwards, see EnsureImage.
 func ClientVersions(ctx context.Context, imageRefs []string) ([]string, error) {
 	refs := NormalizeImageRefs(imageRefs)
-	if err := EnsureImages(ctx, refs, ""); err != nil {
-		return nil, err
-	}
-
 	versions := make([]string, 0, len(refs))
 	for _, ref := range refs {
 		version, err := clientVersion(ctx, ref)
@@ -56,20 +54,39 @@ func ClientVersions(ctx context.Context, imageRefs []string) ([]string, error) {
 	return versions, nil
 }
 
-// clientVersion runs the client of the given locally available image to have it
-// report its own version.
+// resolvedVersions holds the version every reference reported in this run.
+var resolvedVersions onceCache
+
+// clientVersion is the version the image of the given reference reports for its
+// client. A reference is asked once per run: it keeps resolving to the one
+// image EnsureImage pinned, so the answer cannot change, while every node of a
+// network otherwise starts a throwaway container to learn it again.
 func clientVersion(ctx context.Context, imageRef string) (string, error) {
+	return resolvedVersions.get(ctx, imageRef, func() (string, error) {
+		pinnedImage, err := EnsureImage(ctx, imageRef, "")
+		if err != nil {
+			return "", err
+		}
+		return askClientVersion(ctx, imageRef, pinnedImage)
+	})
+}
+
+// askClientVersion runs the client of the given locally available image to have
+// it report its own version. The image is named by the reference this run
+// pinned it under, so that this is the same image the nodes of the run start
+// from. The reference it was resolved from is only used to report failures.
+func askClientVersion(ctx context.Context, imageRef, pinnedImage string) (string, error) {
 	cmd := exec.CommandContext(ctx, "docker", "run", "--rm",
-		"--entrypoint", SonicdBinaryPath, imageRef, "version")
+		"--entrypoint", SonicdBinaryPath, pinnedImage, "version")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("failed to ask image %q for its client version: %w\n%s",
-			imageRef, err, strings.TrimSpace(string(output)))
+		return "", fmt.Errorf("failed to ask image %s (%s) for its client version: %w\n%s",
+			imageRef, pinnedImage, err, strings.TrimSpace(string(output)))
 	}
 	version, found := parseReportedVersion(output)
 	if !found {
-		return "", fmt.Errorf("image %q reported no client version:\n%s",
-			imageRef, strings.TrimSpace(string(output)))
+		return "", fmt.Errorf("image %s (%s) reported no client version:\n%s",
+			imageRef, pinnedImage, strings.TrimSpace(string(output)))
 	}
 	return version, nil
 }

--- a/driver/docker/client_version_test.go
+++ b/driver/docker/client_version_test.go
@@ -79,7 +79,7 @@ func TestClientVersions_AsksTheImagesForTheirVersion(t *testing.T) {
 		t.Skipf("docker socket not available: %v", err)
 	}
 
-	buildRoot, err := resolveBuildRoot(".")
+	buildRoot, err := ResolveBuildRoot(".")
 	if err != nil {
 		t.Fatalf("failed to resolve build root: %v", err)
 	}

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -35,6 +35,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
 	dockerNetwork "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -147,8 +148,13 @@ func (h *ExecHandle) setResult(exitCode int, err error) {
 
 // ContainerConfig defines parameters for running Docker Containers.
 type ContainerConfig struct {
-	Hostname        string
-	ImageName       string
+	Hostname string
+	// Image is the reference this run pinned the image the container runs
+	// under, see EnsureImage. It is not the reference that image was asked
+	// for: that one is shared with every other build on the host, and docker
+	// resolves it anew whenever it is used, so it can name another image by
+	// the time a container is created.
+	Image           string
 	ShutdownTimeout *time.Duration
 	Environment     map[string]string
 	Entrypoint      []string // Entrypoint to run when starting the container. Optional.
@@ -206,6 +212,32 @@ func Purge(ctx context.Context) error {
 		}
 	}
 
+	return removePinnedImages(ctx, cli)
+}
+
+// removePinnedImages drops the references norma kept the images of its runs
+// under, see EnsureImage. Only the reference is dropped: docker removes an
+// image with the last reference naming it, so what an image was built or pulled
+// under keeps it.
+func removePinnedImages(ctx context.Context, cli *Client) error {
+	pinned, err := cli.cli.ImageList(ctx, image.ListOptions{
+		Filters: filters.NewArgs(filters.Arg("reference", pinnedRepository+":*")),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list the pinned images: %w", err)
+	}
+	for _, img := range pinned {
+		for _, ref := range img.RepoTags {
+			if !strings.HasPrefix(ref, pinnedRepository+":") {
+				continue
+			}
+			// A reference another run still holds a container on is that run's
+			// to drop, and no reason to fail the purge of everything else.
+			if _, err := cli.cli.ImageRemove(ctx, ref, image.RemoveOptions{}); err != nil {
+				slog.Warn("failed to drop a pinned image reference", "ref", ref, "err", err)
+			}
+		}
+	}
 	return nil
 }
 
@@ -243,7 +275,7 @@ func (c *Client) Start(ctx context.Context, config *ContainerConfig) (*Container
 	init := true
 	stopTimeout := int(config.ShutdownTimeout.Seconds())
 	resp, err := c.cli.ContainerCreate(ctx, &container.Config{
-		Image:      config.ImageName,
+		Image:      config.Image,
 		Tty:        false,
 		Env:        envVars,
 		Entrypoint: config.Entrypoint,
@@ -442,7 +474,7 @@ func (c *Container) resolveIP() error {
 // SaveLogTo fetches the log of the container and saves it to the given directory.
 func (c *Container) SaveLogTo(ctx context.Context, directory string) error {
 	dst := filepath.Join(directory,
-		fmt.Sprintf("%s_%s.log", c.config.ImageName, c.id))
+		fmt.Sprintf("%s_%s.log", c.config.Hostname, c.id))
 
 	// When the payload process runs as a background exec, its output is
 	// not part of the container's stdout but is already captured in full

--- a/driver/docker/docker_test.go
+++ b/driver/docker/docker_test.go
@@ -326,6 +326,17 @@ func networkExists(t *testing.T, cli *Client, id string) bool {
 	return exists
 }
 
+// ensureTestImage returns the reference the image of the given one is pinned
+// under, pulling it if it is not available yet.
+func ensureTestImage(t *testing.T, imageRef string) string {
+	t.Helper()
+	pinnedImage, err := EnsureImage(t.Context(), imageRef, "")
+	if err != nil {
+		t.Fatalf("failed to ensure image %q: %v", imageRef, err)
+	}
+	return pinnedImage
+}
+
 func startContainer(t *testing.T) (*Client, *Container) {
 	cli, err := NewClient()
 	if err != nil {
@@ -335,7 +346,7 @@ func startContainer(t *testing.T) (*Client, *Container) {
 	timeout := time.Second
 	cont, err := cli.Start(t.Context(), &ContainerConfig{
 		Hostname:        t.Name(),
-		ImageName:       "hello-world",
+		Image:           ensureTestImage(t, "hello-world"),
 		ShutdownTimeout: &timeout,
 	})
 	if err != nil {
@@ -359,7 +370,7 @@ func startRunningContainer(t *testing.T, dn *Network) (*Client, *Container) {
 	timeout := time.Second
 	cont, err := cli.Start(t.Context(), &ContainerConfig{
 		Hostname:        t.Name(),
-		ImageName:       "alpine",                            // use minimal linux image
+		Image:           ensureTestImage(t, "alpine"),        // minimal linux image
 		Entrypoint:      []string{"tail", "-f", "/dev/null"}, // keep container running
 		ShutdownTimeout: &timeout,
 		Network:         dn,

--- a/driver/docker/images.go
+++ b/driver/docker/images.go
@@ -25,11 +25,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/client"
 )
 
 // sonicRepositoryURL is the canonical remote source used when building
@@ -67,104 +70,338 @@ func SonicLocalPath() string {
 	return sonicLocalPath
 }
 
-// imageBuildKind describes how an image should be materialized when it is not
-// already available locally.
-type imageBuildKind int
-
-const (
-	// imageBuildNone means no local build strategy applies. In this case the
-	// image is obtained by pullImage.
-	imageBuildNone imageBuildKind = iota
-	// imageBuildSonicRemote means the image should be built from the remote
-	// Sonic repository URL (optionally pinned to a tag via #<tag>).
-	imageBuildSonicRemote
-	// imageBuildSonicLocal means the image should be built from local Sonic
-	// sources (the repository's "sonic" directory).
-	imageBuildSonicLocal
-)
-
-// imageBuildPlan captures the selected provisioning strategy for one image
-// reference.
-//
-// clientSrc is passed to docker build as the value of the "client-src" build
-// context expected by the repository Dockerfile.
+// imageBuildPlan says where the client sources of one image reference come
+// from.
 type imageBuildPlan struct {
-	kind      imageBuildKind
-	clientSrc string
+	// source is where the client sources are taken from: a path on disk for a
+	// local build, the repository URL for a remote one, and nowhere for an
+	// image that is pulled rather than built. It is passed to docker build as
+	// the value of the "client-src" build context the repository Dockerfile
+	// expects.
+	source string
+	// gitRef is the branch, tag or commit to build in that repository. It is
+	// set for a remote build only.
+	gitRef string
 }
 
-// EnsureImages makes sure the given image refs are locally available.
+// builds reports whether the image is built from sources rather than pulled.
+func (p imageBuildPlan) builds() bool {
+	return p.source != ""
+}
+
+// clientSrc is the "client-src" build context docker is given. A remote build
+// names the commit the git ref points to right now rather than the ref itself,
+// so that what the image contains is decided and recorded here, and not by
+// whatever the ref names by the time docker looks.
+func (p imageBuildPlan) clientSrc(ctx context.Context) (string, error) {
+	if p.gitRef == "" {
+		return p.source, nil
+	}
+	commit, err := resolveCommit(ctx, p.source, p.gitRef)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s#%s", p.source, commit), nil
+}
+
+// gitHeadRef is the git ref naming the default branch of a repository.
+const gitHeadRef = "HEAD"
+
+// onceCache resolves a value for a key once and hands that result to every
+// caller asking later. Concurrent callers wait for the running resolution
+// instead of starting a second one. A failed resolution is forgotten, so a
+// later caller can try again.
+type onceCache struct {
+	mutex   sync.Mutex
+	entries map[string]*onceEntry
+}
+
+// onceEntry is the outcome of one resolution: the value it produced, or the
+// error that ended the attempt.
+type onceEntry struct {
+	done  chan struct{}
+	value string
+	err   error
+}
+
+func (c *onceCache) get(
+	ctx context.Context,
+	key string,
+	resolve func() (string, error),
+) (string, error) {
+	c.mutex.Lock()
+	if entry, found := c.entries[key]; found {
+		c.mutex.Unlock()
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-entry.done:
+			return entry.value, entry.err
+		}
+	}
+	entry := &onceEntry{done: make(chan struct{})}
+	if c.entries == nil {
+		c.entries = map[string]*onceEntry{}
+	}
+	c.entries[key] = entry
+	c.mutex.Unlock()
+
+	entry.value, entry.err = resolve()
+	close(entry.done)
+
+	if entry.err != nil {
+		c.forget(key)
+	}
+	return entry.value, entry.err
+}
+
+func (c *onceCache) forget(key string) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	delete(c.entries, key)
+}
+
+// resolvedImages holds the image every reference resolved to in this run.
+var resolvedImages onceCache
+
+// EnsureImage makes the image of the given reference locally available and
+// returns the reference this run keeps that image under.
 //
-// The function provides the runtime image provisioning path used by
-// scenario execution. It performs the following steps:
+// A reference is resolved once per run, and every caller after the first one
+// gets the image of that first resolution. Client references are mutable:
+// "sonic:local" builds from a working copy and "sonic:main" from a branch, so
+// resolving one twice can produce two different clients. The genesis of a
+// network is written for the versions its images reported (see ClientVersions),
+// and a node started from a later build of the same reference may be a client
+// that genesis does not suit, which forks it off the rest of the network.
 //
-//  1. Normalize and deduplicate image references.
-//  2. Resolve the Norma build root (see ResolveBuildRoot).
-//  3. For each image:
-//     - choose build or pull strategy via planImage;
-//     - build (Sonic-specific refs) or pull (all other refs).
+// The image that first resolution produced is therefore kept under a reference
+// of this run, and that is what callers start their containers from. Neither
+// the reference they asked for nor the bare image survives a run on its own:
+// the host is shared with every other build on it, one of which moves the
+// reference to its own client, and an image no reference names any more is the
+// first thing a docker prune reclaims - while a run keeps starting nodes long
+// after it resolved its images. The pinned reference is norma's own, and every
+// call re-establishes it, so a host that dropped it does not take the run along.
 //
-// For Sonic image refs, it lazily builds from the project's Dockerfile:
-//   - sonic: from sonicRepositoryURL
+// For Sonic image refs, the image is built from the project's Dockerfile:
+//   - sonic, sonic:latest: from the default branch of sonicRepositoryURL
 //   - sonic:local: from the currently configured sonic local path (see
 //     SetSonicLocalPath / SonicLocalPath, default DefaultSonicLocalPath)
-//   - sonic:<tag>: from sonicRepositoryURL#<tag>
-//   - sonic:<commit hash>: from sonicRepositoryURL#<commit hash>
+//   - sonic:<branch or tag>: from that ref of sonicRepositoryURL
+//   - sonic:<commit hash>: from that commit of sonicRepositoryURL
 //
-// Other images are pulled if missing.
-//
-// The operation is idempotent with respect to already present tags, and relies
-// on Docker's own image/layer cache for repeated builds.
-func EnsureImages(ctx context.Context, imageRefs []string, buildRoot string) error {
-	if len(imageRefs) == 0 {
-		return nil
-	}
-	if buildRoot == "" {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("failed to get working directory: %w", err)
-		}
-		buildRoot = cwd
-	}
-
-	buildRoot, err := ResolveBuildRoot(buildRoot)
+// Other images are pulled.
+func EnsureImage(ctx context.Context, imageRef, buildRoot string) (string, error) {
+	imageID, err := resolvedImages.get(ctx, imageRef, func() (string, error) {
+		return resolveImage(ctx, imageRef, buildRoot)
+	})
 	if err != nil {
-		return err
+		return "", err
 	}
-	slog.Info("resolved build root", "path", buildRoot)
+	return pinImage(ctx, imageRef, imageID, buildRoot)
+}
 
-	refs := NormalizeImageRefs(imageRefs)
-	slog.Info("checking images", "refs", refs)
+// pinnedRepository is the docker repository this run keeps the images it
+// resolved under. A reference in it is norma's own, so nothing but norma moves
+// it, and it keeps the image it names from being one no reference names.
+const pinnedRepository = "norma-pinned"
+
+// pinnedImageRef is the reference the image of the given ID is kept under. It
+// names the image itself, so a run that resolved the same image pins it under
+// the same reference, and one that resolved another image under another.
+func pinnedImageRef(imageID string) string {
+	return pinnedRepository + ":" + strings.TrimPrefix(imageID, "sha256:")
+}
+
+// pinMutex serializes pinning, so that nodes starting at the same time do not
+// each resolve the same lost image again.
+var pinMutex sync.Mutex
+
+// pinImage keeps the given image under its pinned reference, and returns that
+// reference.
+//
+// Pinning it is also how the host is asked whether it still has it: tagging an
+// image is idempotent, and the one way it fails is the image being gone - which
+// happens while a run is still starting nodes on it, either because a prune
+// reclaimed it or because a concurrent build of the reference it was resolved
+// from left it under no reference at all. It is then resolved again, and the run
+// only continues if that produced the same image: another one holds another
+// client than the genesis of the network was written for.
+func pinImage(ctx context.Context, imageRef, imageID, buildRoot string) (string, error) {
+	ref := pinnedImageRef(imageID)
+
+	pinMutex.Lock()
+	defer pinMutex.Unlock()
+
 	cli, err := NewClient()
 	if err != nil {
-		return fmt.Errorf("failed to create docker client: %w", err)
+		return "", fmt.Errorf("failed to create docker client: %w", err)
 	}
 	defer func() {
 		_ = cli.Close()
 	}()
 
-	for _, ref := range refs {
-
-		plan := planImage(ref)
-		start := time.Now()
-		switch plan.kind {
-		case imageBuildSonicRemote, imageBuildSonicLocal:
-			slog.Info("building image", "ref", ref, "clientSrc", plan.clientSrc)
-			if err := buildImage(ctx, buildRoot, ref, plan.clientSrc); err != nil {
-				return err
-			}
-		case imageBuildNone:
-			slog.Info("pulling image", "ref", ref)
-			if err := pullImage(ctx, cli, ref); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("unsupported image plan for %q", ref)
+	err = cli.cli.ImageTag(ctx, imageID, ref)
+	if client.IsErrNotFound(err) {
+		slog.Warn("the image of a reference is gone, resolving it again",
+			"ref", imageRef, "id", imageID)
+		again, resolveErr := resolveImage(ctx, imageRef, buildRoot)
+		if resolveErr != nil {
+			return "", fmt.Errorf("image %s (%s) is gone, and resolving it again failed: %w",
+				imageRef, imageID, resolveErr)
 		}
-		slog.Info("image ready", "ref", ref, "took", time.Since(start))
+		if again != imageID {
+			return "", fmt.Errorf("image %s is gone, and its sources now produce %s "+
+				"rather than the %s this run was set up for", imageRef, again, imageID)
+		}
+		err = cli.cli.ImageTag(ctx, imageID, ref)
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to pin image %s as %q: %w", imageID, ref, err)
+	}
+	return ref, nil
+}
+
+// EnsureImages makes sure the given image refs are locally available, see
+// EnsureImage. It serves callers that only want the images built or pulled,
+// like the build command; a caller that starts a container from one needs the
+// reference EnsureImage returns.
+func EnsureImages(ctx context.Context, imageRefs []string, buildRoot string) error {
+	refs := NormalizeImageRefs(imageRefs)
+	if len(refs) == 0 {
+		return nil
+	}
+	slog.Info("checking images", "refs", refs)
+	for _, ref := range refs {
+		if _, err := EnsureImage(ctx, ref, buildRoot); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// resolveImage builds or pulls the image of the given reference and returns the
+// ID of the image this produced.
+func resolveImage(ctx context.Context, imageRef, buildRoot string) (string, error) {
+	start := time.Now()
+	plan := planImage(imageRef)
+
+	var id string
+	if plan.builds() {
+		root, err := ResolveBuildRoot(buildRoot)
+		if err != nil {
+			return "", err
+		}
+		clientSrc, err := plan.clientSrc(ctx)
+		if err != nil {
+			return "", err
+		}
+		slog.Info("building image", "ref", imageRef, "buildRoot", root, "clientSrc", clientSrc)
+		if id, err = buildImage(ctx, root, imageRef, clientSrc); err != nil {
+			return "", err
+		}
+	} else {
+		cli, err := NewClient()
+		if err != nil {
+			return "", fmt.Errorf("failed to create docker client: %w", err)
+		}
+		defer func() {
+			_ = cli.Close()
+		}()
+		slog.Info("pulling image", "ref", imageRef)
+		if err := pullImage(ctx, cli, imageRef); err != nil {
+			return "", err
+		}
+		if id, err = imageID(ctx, cli, imageRef); err != nil {
+			return "", err
+		}
 	}
 
-	return nil
+	slog.Info("image ready", "ref", imageRef, "id", id, "took", time.Since(start))
+	return id, nil
+}
+
+// commitHash matches a git commit hash: the object name git ls-remote lists a
+// ref with, and the one git ref that no repository has to be asked about.
+var commitHash = regexp.MustCompile(`^[0-9a-fA-F]{7,40}$`)
+
+// peeledSuffix marks the line on which git ls-remote reports the commit an
+// annotated tag points to, next to the line reporting the tag object itself.
+const peeledSuffix = "^{}"
+
+// resolveCommit asks the remote repository which commit the given git ref
+// points to at this moment. A ref the repository does not know is taken to be a
+// commit hash, which is a ref only the repository itself can resolve.
+func resolveCommit(ctx context.Context, repositoryURL, gitRef string) (string, error) {
+	// The candidates are the refs git itself would try, in its order of
+	// precedence: a bare name is ambiguous, and a repository may well hold both
+	// a tag and a branch of that name.
+	candidates := []string{gitHeadRef}
+	if gitRef != gitHeadRef {
+		candidates = []string{"refs/tags/" + gitRef, "refs/heads/" + gitRef}
+	}
+
+	// Only the candidates are asked for: a repository the size of Sonic's has
+	// thousands of refs, and one is wanted. A pattern is matched against a whole
+	// ref name, so the peeled line of a tag is only reported if it is asked for
+	// under that name too.
+	args := []string{"ls-remote", repositoryURL}
+	for _, candidate := range candidates {
+		args = append(args, candidate, candidate+peeledSuffix)
+	}
+	cmd := exec.CommandContext(ctx, "git", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to ask %s for the commit of %q: %w\n%s",
+			repositoryURL, gitRef, err, strings.TrimSpace(string(output)))
+	}
+	commits := parseRemoteRefs(output)
+
+	for _, candidate := range candidates {
+		if commit, found := commits[candidate]; found {
+			return commit, nil
+		}
+	}
+	if commitHash.MatchString(gitRef) {
+		return gitRef, nil
+	}
+	return "", fmt.Errorf("repository %s has no branch or tag %q",
+		repositoryURL, gitRef)
+}
+
+// parseRemoteRefs reads the refs and the commits they point to from the output
+// of git ls-remote. An annotated tag is listed twice: as the tag object and,
+// marked with "^{}", as the commit it points to. The latter is what checking
+// out the tag yields, so it takes precedence.
+func parseRemoteRefs(output []byte) map[string]string {
+	commits := map[string]string{}
+	peeled := map[string]bool{}
+	for line := range strings.Lines(string(output)) {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || !commitHash.MatchString(fields[0]) {
+			continue
+		}
+		commit, ref := fields[0], fields[1]
+		if tag, found := strings.CutSuffix(ref, peeledSuffix); found {
+			commits[tag] = commit
+			peeled[tag] = true
+			continue
+		}
+		if !peeled[ref] {
+			commits[ref] = commit
+		}
+	}
+	return commits
+}
+
+// imageID reads the ID of the locally available image of the given reference.
+func imageID(ctx context.Context, cli *Client, imageRef string) (string, error) {
+	info, _, err := cli.cli.ImageInspectWithRaw(ctx, imageRef)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect image %q: %w", imageRef, err)
+	}
+	return info.ID, nil
 }
 
 // NormalizeImageRefs removes empty refs, deduplicates, and returns image refs
@@ -215,76 +452,76 @@ func pullImage(ctx context.Context, cli *Client, imageRef string) error {
 //
 // On failure, the function returns the docker command error along with captured
 // combined stdout/stderr output to aid diagnostics.
-func buildImage(ctx context.Context, buildRoot, imageRef, clientSrc string) error {
-	args := []string{"build", "--build-context", fmt.Sprintf("client-src=%s", clientSrc), ".", "-t", imageRef}
+//
+// The ID is what the build reports for its own result, not what the tag names
+// afterwards. The tag is shared with every other build on the host, and a run
+// of another norma builds its own client under it, so between tagging and
+// asking the tag it can already name an image this build never produced.
+func buildImage(ctx context.Context, buildRoot, imageRef, clientSrc string) (string, error) {
+	idFile, err := os.CreateTemp("", "norma-image-id-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create the id file for image %q: %w", imageRef, err)
+	}
+	idPath := idFile.Name()
+	_ = idFile.Close()
+	defer func() {
+		_ = os.Remove(idPath)
+	}()
+
+	args := []string{"build", "--build-context", fmt.Sprintf("client-src=%s", clientSrc),
+		"--iidfile", idPath, ".", "-t", imageRef}
 	cmd := exec.CommandContext(ctx, "docker", args...)
 	cmd.Dir = buildRoot
 	cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to build image %q: %w\n%s", imageRef, err, strings.TrimSpace(string(output)))
+		return "", fmt.Errorf("failed to build image %q: %w\n%s", imageRef, err, strings.TrimSpace(string(output)))
 	}
-	return nil
+
+	id, err := os.ReadFile(idPath) //#nosec G304 -- the path is the temporary file created above
+	if err != nil {
+		return "", fmt.Errorf("failed to read the id of image %q: %w", imageRef, err)
+	}
+	if len(strings.TrimSpace(string(id))) == 0 {
+		return "", fmt.Errorf("the build of image %q reported no image id", imageRef)
+	}
+	return strings.TrimSpace(string(id)), nil
 }
 
 // planImage resolves imageRef into an internal build plan.
 //
 // Current mapping rules:
-//   - "sonic"       => remote build from sonicRepositoryURL
+//   - "sonic", "sonic:latest" => remote build from the default branch of
+//     sonicRepositoryURL; "latest" is a Docker tag convention, not a git ref
 //   - "sonic:local" => local build from the currently configured sonic local
 //     path (see SetSonicLocalPath / SonicLocalPath, default
 //     DefaultSonicLocalPath)
-//   - "sonic:<tag>" => remote build from sonicRepositoryURL#<tag>
-//   - "sonic:<commit hash>" => remote build from sonicRepositoryURL#<commit hash>
+//   - "sonic:<branch, tag or commit hash>" => remote build from that ref of
+//     sonicRepositoryURL
 //   - everything else => no build strategy (pull)
 //
-// The returned plan is consumed by EnsureImages.
+// The returned plan is consumed by resolveImage.
 func planImage(imageRef string) imageBuildPlan {
-	if imageRef == "sonic" {
-		return imageBuildPlan{kind: imageBuildSonicRemote, clientSrc: sonicRepositoryURL}
+	if imageRef == "sonic" || imageRef == "sonic:latest" {
+		return imageBuildPlan{source: sonicRepositoryURL, gitRef: gitHeadRef}
 	}
 	if imageRef == "sonic:local" {
-		return imageBuildPlan{kind: imageBuildSonicLocal, clientSrc: sonicLocalPath}
+		return imageBuildPlan{source: sonicLocalPath}
 	}
-	if imageRef == "sonic:latest" {
-		// "latest" is a Docker tag convention, not a git ref; build from repo HEAD.
-		return imageBuildPlan{kind: imageBuildSonicRemote, clientSrc: sonicRepositoryURL}
+	if tag, found := strings.CutPrefix(imageRef, "sonic:"); found && tag != "" {
+		return imageBuildPlan{source: sonicRepositoryURL, gitRef: tag}
 	}
-	if strings.HasPrefix(imageRef, "sonic:") {
-		tag := strings.TrimPrefix(imageRef, "sonic:")
-		if tag != "" {
-			return imageBuildPlan{
-				kind:      imageBuildSonicRemote,
-				clientSrc: fmt.Sprintf("%s#%s", sonicRepositoryURL, tag),
-			}
-		}
-	}
-	return imageBuildPlan{kind: imageBuildNone}
+	return imageBuildPlan{}
 }
 
-// WillBuildImage reports whether EnsureImages will build (not pull) the given
+// WillBuildImage reports whether EnsureImage will build (not pull) the given
 // image reference.
 //
 // This is true for Sonic image refs handled via local or remote source build
-// contexts (e.g. sonic, sonic:local, sonic:<tag-or-commit>). For all other
-// refs, EnsureImages will pull instead.
+// contexts (e.g. sonic, sonic:local, sonic:<tag-or-commit>). All other refs are
+// pulled instead.
 func WillBuildImage(imageRef string) bool {
-	plan := planImage(imageRef)
-	return plan.kind == imageBuildSonicRemote || plan.kind == imageBuildSonicLocal
-}
-
-// deduplicateAndSort removes blank entries, deduplicates refs, and returns
-// them in lexical order.
-//
-// Sorting keeps execution deterministic and log output stable across runs.
-func deduplicateAndSort(in []string) []string {
-	return NormalizeImageRefs(in)
-}
-
-// resolveBuildRoot finds the Norma repository root to execute docker builds.
-// See ResolveBuildRoot.
-func resolveBuildRoot(startDir string) (string, error) {
-	return ResolveBuildRoot(startDir)
+	return planImage(imageRef).builds()
 }
 
 // normaModulePath is the Go module path of this repository. It is the only

--- a/driver/docker/images_test.go
+++ b/driver/docker/images_test.go
@@ -17,10 +17,18 @@
 package docker
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
+
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/client"
 )
 
 func TestPlanImage(t *testing.T) {
@@ -33,39 +41,42 @@ func TestPlanImage(t *testing.T) {
 			name:     "remote main image",
 			imageRef: "sonic",
 			want: imageBuildPlan{
-				kind:      imageBuildSonicRemote,
-				clientSrc: sonicRepositoryURL,
+				source: sonicRepositoryURL,
+				gitRef: gitHeadRef,
+			},
+		},
+		{
+			name:     "latest is the default branch, not a git ref",
+			imageRef: "sonic:latest",
+			want: imageBuildPlan{
+				source: sonicRepositoryURL,
+				gitRef: gitHeadRef,
 			},
 		},
 		{
 			name:     "local image",
 			imageRef: "sonic:local",
 			want: imageBuildPlan{
-				kind:      imageBuildSonicLocal,
-				clientSrc: "sonic",
+				source: "sonic",
 			},
 		},
 		{
 			name:     "tagged remote image",
 			imageRef: "sonic:v2.1.2",
 			want: imageBuildPlan{
-				kind:      imageBuildSonicRemote,
-				clientSrc: sonicRepositoryURL + "#v2.1.2",
+				source: sonicRepositoryURL,
+				gitRef: "v2.1.2",
 			},
 		},
 		{
 			name:     "non sonic image is pull-only plan",
 			imageRef: "alpine",
-			want: imageBuildPlan{
-				kind: imageBuildNone,
-			},
+			want:     imageBuildPlan{},
 		},
 		{
 			name:     "empty sonic tag falls back to pull-only",
 			imageRef: "sonic:",
-			want: imageBuildPlan{
-				kind: imageBuildNone,
-			},
+			want:     imageBuildPlan{},
 		},
 	}
 
@@ -95,7 +106,7 @@ func TestSetSonicLocalPath_OverridesLocalBuildContext(t *testing.T) {
 	}
 
 	plan := planImage("sonic:local")
-	want := imageBuildPlan{kind: imageBuildSonicLocal, clientSrc: custom}
+	want := imageBuildPlan{source: custom}
 	if plan != want {
 		t.Fatalf("planImage(sonic:local) after override: got %+v, want %+v",
 			plan, want)
@@ -108,11 +119,11 @@ func TestSetSonicLocalPath_OverridesLocalBuildContext(t *testing.T) {
 	}
 }
 
-func TestDeduplicateAndSort(t *testing.T) {
+func TestNormalizeImageRefs_DeduplicatesAndSorts(t *testing.T) {
 	input := []string{"sonic:v2.1", "", "sonic", "sonic:v2.1", "   ", "alpine"}
 	want := []string{"alpine", "sonic", "sonic:v2.1"}
 
-	got := deduplicateAndSort(input)
+	got := NormalizeImageRefs(input)
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("invalid refs, got %v, want %v", got, want)
 	}
@@ -142,7 +153,7 @@ func TestResolveBuildRoot(t *testing.T) {
 			t.Fatalf("failed to create deep directory: %v", err)
 		}
 
-		got, err := resolveBuildRoot(deep)
+		got, err := ResolveBuildRoot(deep)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -153,7 +164,7 @@ func TestResolveBuildRoot(t *testing.T) {
 
 	t.Run("fails when root markers are missing", func(t *testing.T) {
 		start := t.TempDir()
-		_, err := resolveBuildRoot(start)
+		_, err := ResolveBuildRoot(start)
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
@@ -182,7 +193,7 @@ func TestResolveBuildRoot(t *testing.T) {
 			t.Fatalf("failed to write nested go.mod: %v", err)
 		}
 
-		got, err := resolveBuildRoot(nested)
+		got, err := ResolveBuildRoot(nested)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -216,6 +227,216 @@ func TestFileExists(t *testing.T) {
 			t.Fatalf("expected false for missing path")
 		}
 	})
+}
+
+// forgetResolvedImage drops what a test resolved from the images this run has
+// resolved, so that it does not leak into another test.
+func forgetResolvedImage(t *testing.T, imageRef string) {
+	t.Cleanup(func() {
+		resolvedImages.forget(imageRef)
+		resolvedVersions.forget(imageRef)
+	})
+}
+
+// TestOnceCache_ResolvesAKeyOnce covers why images are resolved at all: a
+// reference like "sonic:local" or "sonic:main" names another image as soon as
+// its sources move, and a run has to keep testing the one it was set up for.
+func TestOnceCache_ResolvesAKeyOnce(t *testing.T) {
+	const imageRef = "test:resolved-once"
+	var cache onceCache
+
+	var mutex sync.Mutex
+	resolutions := 0
+	resolve := func() (string, error) {
+		mutex.Lock()
+		defer mutex.Unlock()
+		resolutions++
+		return fmt.Sprintf("sha256:image-%d", resolutions), nil
+	}
+
+	var callers sync.WaitGroup
+	for range 8 {
+		callers.Add(1)
+		go func() {
+			defer callers.Done()
+			id, err := cache.get(t.Context(), imageRef, resolve)
+			if err != nil {
+				t.Errorf("failed to resolve %s: %v", imageRef, err)
+				return
+			}
+			if id != "sha256:image-1" {
+				t.Errorf("invalid image, got %q, want %q", id, "sha256:image-1")
+			}
+		}()
+	}
+	callers.Wait()
+
+	if resolutions != 1 {
+		t.Fatalf("resolved %d times, want once", resolutions)
+	}
+}
+
+func TestOnceCache_ForgetsAFailedResolution(t *testing.T) {
+	const imageRef = "test:resolution-failed"
+	var cache onceCache
+
+	resolutions := 0
+	resolve := func() (string, error) {
+		resolutions++
+		if resolutions == 1 {
+			return "", fmt.Errorf("injected failure")
+		}
+		return "sha256:image", nil
+	}
+
+	if _, err := cache.get(t.Context(), imageRef, resolve); err == nil {
+		t.Fatalf("expected the injected failure, got none")
+	}
+	id, err := cache.get(t.Context(), imageRef, resolve)
+	if err != nil {
+		t.Fatalf("failed to resolve %s again: %v", imageRef, err)
+	}
+	if id != "sha256:image" {
+		t.Fatalf("invalid image, got %q, want %q", id, "sha256:image")
+	}
+}
+
+func TestParseRemoteRefs_ReadsTheCommitOfEveryRef(t *testing.T) {
+	// An annotated tag is listed as the tag object and, marked with "^{}", as
+	// the commit it points to - in either order.
+	const tag = "1111111111111111111111111111111111111111"
+	const tagged = "2222222222222222222222222222222222222222"
+	const head = "3333333333333333333333333333333333333333"
+	tagFirst := tag + "\trefs/tags/v1.0\n" +
+		tagged + "\trefs/tags/v1.0^{}\n" +
+		head + "\trefs/heads/main\n"
+	commitFirst := tagged + "\trefs/tags/v1.0^{}\n" +
+		tag + "\trefs/tags/v1.0\n" +
+		head + "\trefs/heads/main\n"
+
+	want := map[string]string{
+		"refs/tags/v1.0":  tagged,
+		"refs/heads/main": head,
+	}
+	for name, output := range map[string]string{
+		"tag object first": tagFirst,
+		"commit first":     commitFirst,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := parseRemoteRefs([]byte(output))
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("invalid refs, got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestParseRemoteRefs_IgnoresOutputWithoutRefs(t *testing.T) {
+	for name, output := range map[string]string{
+		"empty":             "",
+		"warning on stderr": "warning: redirecting to https://example.com/sonic.git/\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := parseRemoteRefs([]byte(output)); len(got) != 0 {
+				t.Fatalf("unexpected refs %v in %q", got, output)
+			}
+		})
+	}
+}
+
+// runGit runs a git command in the given repository and returns its output.
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=norma", "GIT_AUTHOR_EMAIL=norma@example.com",
+		"GIT_COMMITTER_NAME=norma", "GIT_COMMITTER_EMAIL=norma@example.com")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+// commitFile commits the given content and returns the commit it created.
+func commitFile(t *testing.T, repository, content string) string {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repository, "client.txt"),
+		[]byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write client file: %v", err)
+	}
+	runGit(t, repository, "add", "client.txt")
+	runGit(t, repository, "commit", "-m", content)
+	return runGit(t, repository, "rev-parse", "HEAD")
+}
+
+// TestResolveCommit_ReadsWhatARefPointsToNow covers the reason a ref is
+// resolved before an image is built: a branch names another commit as soon as
+// it moves, so the ref alone does not say what an image contains.
+func TestResolveCommit_ReadsWhatARefPointsToNow(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+
+	repository := t.TempDir()
+	runGit(t, repository, "init", "-q", "-b", "main")
+	first := commitFile(t, repository, "first")
+	runGit(t, repository, "tag", "-a", "v1.0", "-m", "release v1.0")
+	runGit(t, repository, "tag", "v1.0-light")
+
+	// An annotated tag resolves to the commit it points to, not to the tag
+	// object, which is what a docker build context has to name.
+	for name, ref := range map[string]string{
+		"branch":          "main",
+		"annotated tag":   "v1.0",
+		"lightweight tag": "v1.0-light",
+		"default branch":  gitHeadRef,
+	} {
+		t.Run(name, func(t *testing.T) {
+			commit, err := resolveCommit(t.Context(), repository, ref)
+			if err != nil {
+				t.Fatalf("failed to resolve %q: %v", ref, err)
+			}
+			if commit != first {
+				t.Fatalf("invalid commit for %q, got %q, want %q", ref, commit, first)
+			}
+		})
+	}
+
+	second := commitFile(t, repository, "second")
+	commit, err := resolveCommit(t.Context(), repository, "main")
+	if err != nil {
+		t.Fatalf("failed to resolve the moved branch: %v", err)
+	}
+	if commit != second {
+		t.Fatalf("invalid commit for the moved branch, got %q, want %q", commit, second)
+	}
+}
+
+func TestResolveCommit_TakesAnUnknownRefForACommit(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+
+	repository := t.TempDir()
+	runGit(t, repository, "init", "-q", "-b", "main")
+	commitFile(t, repository, "first")
+
+	// A commit hash is a ref no repository lists, and the one image references
+	// name directly.
+	const hash = "0123456789abcdef0123456789abcdef01234567"
+	commit, err := resolveCommit(t.Context(), repository, hash)
+	if err != nil {
+		t.Fatalf("failed to resolve a commit hash: %v", err)
+	}
+	if commit != hash {
+		t.Fatalf("invalid commit, got %q, want %q", commit, hash)
+	}
+
+	if _, err := resolveCommit(t.Context(), repository, "no-such-branch"); err == nil {
+		t.Fatalf("expected an error for an unknown ref, got none")
+	}
 }
 
 func TestEnsureImages_EmptyRefs_NoOp(t *testing.T) {
@@ -252,7 +473,7 @@ func TestBuildImage_Builds_SonicLocal(t *testing.T) {
 		t.Skipf("docker socket not available: %v", err)
 	}
 
-	buildRoot, err := resolveBuildRoot(".")
+	buildRoot, err := ResolveBuildRoot(".")
 	if err != nil {
 		t.Fatalf("failed to resolve build root: %v", err)
 	}
@@ -260,7 +481,8 @@ func TestBuildImage_Builds_SonicLocal(t *testing.T) {
 		t.Skipf("local sonic sources not available at %s: %v", filepath.Join(buildRoot, "sonic"), err)
 	}
 
-	if err := buildImage(t.Context(), buildRoot, "sonic:testlocal", "sonic"); err != nil {
+	id, err := buildImage(t.Context(), buildRoot, "sonic:testlocal", "sonic")
+	if err != nil {
 		t.Fatalf("failed to build sonic:testlocal image: %v", err)
 	}
 
@@ -269,8 +491,10 @@ func TestBuildImage_Builds_SonicLocal(t *testing.T) {
 		t.Fatalf("failed to create docker client: %v", err)
 	}
 
-	if _, _, err := cli.cli.ImageInspectWithRaw(t.Context(), "sonic:testlocal"); err != nil {
-		t.Fatalf("image sonic:testlocal not found after build: %v", err)
+	// The build reports the image it produced, and that image is what the run
+	// keeps using once the tag it was built under names something else.
+	if _, _, err := cli.cli.ImageInspectWithRaw(t.Context(), id); err != nil {
+		t.Fatalf("image %s not found after build: %v", id, err)
 	}
 }
 
@@ -279,7 +503,7 @@ func TestEnsureImages_BuildsSonicLocal(t *testing.T) {
 		t.Skipf("docker socket not available: %v", err)
 	}
 
-	buildRoot, err := resolveBuildRoot(".")
+	buildRoot, err := ResolveBuildRoot(".")
 	if err != nil {
 		t.Fatalf("failed to resolve build root: %v", err)
 	}
@@ -310,7 +534,7 @@ func TestEnsureImages_PullsImage(t *testing.T) {
 		t.Skipf("docker socket not available: %v", err)
 	}
 
-	buildRoot, err := resolveBuildRoot(".")
+	buildRoot, err := ResolveBuildRoot(".")
 	if err != nil {
 		t.Fatalf("failed to resolve build root: %v", err)
 	}
@@ -329,4 +553,178 @@ func TestEnsureImages_PullsImage(t *testing.T) {
 	if _, _, err := cli.cli.ImageInspectWithRaw(t.Context(), imageRef); err != nil {
 		t.Fatalf("image %s not found after EnsureImages pull: %v", imageRef, err)
 	}
+}
+
+func TestEnsureImage_ReportsTheImageEveryCallerGets(t *testing.T) {
+	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
+		t.Skipf("docker socket not available: %v", err)
+	}
+
+	imageRef := "hello-world:latest"
+	forgetResolvedImage(t, imageRef)
+
+	first, err := EnsureImage(t.Context(), imageRef, "")
+	if err != nil {
+		t.Fatalf("failed to ensure image %s: %v", imageRef, err)
+	}
+	if !strings.HasPrefix(first, pinnedRepository+":") {
+		t.Fatalf("invalid pinned reference %q", first)
+	}
+	if got := imageIDOf(t, first); pinnedImageRef(got) != first {
+		t.Fatalf("reference %q names image %s", first, got)
+	}
+
+	second, err := EnsureImage(t.Context(), imageRef, "")
+	if err != nil {
+		t.Fatalf("failed to ensure image %s again: %v", imageRef, err)
+	}
+	if second != first {
+		t.Fatalf("invalid image, got %q, want %q", second, first)
+	}
+}
+
+func TestPinnedImageRef_NamesTheImageItself(t *testing.T) {
+	const imageID = "sha256:0123456789abcdef"
+	if got, want := pinnedImageRef(imageID), pinnedRepository+":0123456789abcdef"; got != want {
+		t.Fatalf("invalid pinned reference, got %q, want %q", got, want)
+	}
+}
+
+// TestEnsureImage_KeepsTheImageWhoseReferenceIsTaken covers the host a run
+// shares with every other build on it: one of them takes the reference the run
+// resolved its image from, and the image the network is running on has to stay.
+func TestEnsureImage_KeepsTheImageWhoseReferenceIsTaken(t *testing.T) {
+	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
+		t.Skipf("docker socket not available: %v", err)
+	}
+
+	const imageRef = "hello-world:latest"
+	forgetResolvedImage(t, imageRef)
+
+	pinned, err := EnsureImage(t.Context(), imageRef, "")
+	if err != nil {
+		t.Fatalf("failed to ensure image %s: %v", imageRef, err)
+	}
+	imageID := imageIDOf(t, pinned)
+	restoreImageRef(t, imageRef, imageID)
+
+	// Another build of the reference names its own image, which for the image
+	// of this run is what dropping the reference is: nothing but its pin names
+	// it any more.
+	dropImageRef(t, imageRef)
+
+	again, err := EnsureImage(t.Context(), imageRef, "")
+	if err != nil {
+		t.Fatalf("failed to ensure image %s again: %v", imageRef, err)
+	}
+	if again != pinned {
+		t.Fatalf("invalid reference, got %q, want %q", again, pinned)
+	}
+	if got := imageIDOf(t, again); got != imageID {
+		t.Fatalf("invalid image, got %s, want %s", got, imageID)
+	}
+}
+
+// TestEnsureImage_RestoresAnImageTheHostLost covers a prune between two node
+// starts: the image the run is using is reclaimed, and the node still has to
+// start on the client the rest of the network is running.
+func TestEnsureImage_RestoresAnImageTheHostLost(t *testing.T) {
+	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
+		t.Skipf("docker socket not available: %v", err)
+	}
+
+	const imageRef = "hello-world:latest"
+	forgetResolvedImage(t, imageRef)
+
+	pinned, err := EnsureImage(t.Context(), imageRef, "")
+	if err != nil {
+		t.Fatalf("failed to ensure image %s: %v", imageRef, err)
+	}
+	imageID := imageIDOf(t, pinned)
+	restoreImageRef(t, imageRef, imageID)
+
+	dropImageRef(t, pinned)
+	dropImageRef(t, imageRef)
+	if _, found := lookupImage(t, imageID); found {
+		t.Fatalf("image %s is still available", imageID)
+	}
+
+	again, err := EnsureImage(t.Context(), imageRef, "")
+	if err != nil {
+		t.Fatalf("failed to ensure image %s again: %v", imageRef, err)
+	}
+	if again != pinned {
+		t.Fatalf("invalid reference, got %q, want %q", again, pinned)
+	}
+	if got := imageIDOf(t, again); got != imageID {
+		t.Fatalf("invalid image, got %s, want %s", got, imageID)
+	}
+}
+
+// lookupImage reports the image the given reference names on this host, if the
+// host has it.
+func lookupImage(t *testing.T, imageRef string) (string, bool) {
+	t.Helper()
+	cli, err := NewClient()
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+	defer func() {
+		_ = cli.Close()
+	}()
+
+	id, err := imageID(t.Context(), cli, imageRef)
+	if client.IsErrNotFound(err) {
+		return "", false
+	}
+	if err != nil {
+		t.Fatalf("failed to read the image of %q: %v", imageRef, err)
+	}
+	return id, true
+}
+
+// imageIDOf reports the image the given reference names on this host.
+func imageIDOf(t *testing.T, imageRef string) string {
+	t.Helper()
+	id, found := lookupImage(t, imageRef)
+	if !found {
+		t.Fatalf("image %q is not available", imageRef)
+	}
+	return id
+}
+
+// dropImageRef drops the given reference if the host has it, and with the last
+// reference naming an image the image itself.
+func dropImageRef(t *testing.T, imageRef string) {
+	t.Helper()
+	cli, err := NewClient()
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+	defer func() {
+		_ = cli.Close()
+	}()
+
+	_, err = cli.cli.ImageRemove(t.Context(), imageRef, image.RemoveOptions{})
+	if err != nil && !client.IsErrNotFound(err) {
+		t.Fatalf("failed to remove image %q: %v", imageRef, err)
+	}
+}
+
+// restoreImageRef puts the given reference back on the image it named once the
+// test is done, so that a test dropping it does not take it from another one.
+func restoreImageRef(t *testing.T, imageRef, imageID string) {
+	t.Cleanup(func() {
+		cli, err := NewClient()
+		if err != nil {
+			t.Errorf("failed to create docker client: %v", err)
+			return
+		}
+		defer func() {
+			_ = cli.Close()
+		}()
+		if err := cli.cli.ImageTag(context.Background(), imageID, imageRef); err != nil {
+			t.Errorf("failed to restore image %q: %v", imageRef, err)
+		}
+	})
 }

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -137,54 +137,6 @@ type OperaNodeConfig struct {
 	LogsDir string
 }
 
-// imageEnsureState stores the completion signal and final error for one
-// in-flight image provisioning operation.
-type imageEnsureState struct {
-	done chan struct{}
-	err  error
-}
-
-var (
-	imageEnsureMutex sync.Mutex
-	// imageEnsureInFlight tracks in-progress image provisioning by image tag.
-	//
-	// This allows concurrent node startups using the same image to share one
-	// EnsureImages call instead of triggering duplicate pull/build operations.
-	imageEnsureInFlight = map[string]*imageEnsureState{}
-)
-
-// ensureImageAvailable ensures the given image is locally available and
-// deduplicates concurrent ensure calls for the same image.
-//
-// If another goroutine is already provisioning the same image, this function
-// waits for that operation to complete and returns its result.
-func ensureImageAvailable(ctx context.Context, image string) error {
-	imageEnsureMutex.Lock()
-	if state, found := imageEnsureInFlight[image]; found {
-		imageEnsureMutex.Unlock()
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-state.done:
-			return state.err
-		}
-	}
-
-	state := &imageEnsureState{done: make(chan struct{})}
-	imageEnsureInFlight[image] = state
-	imageEnsureMutex.Unlock()
-
-	err := docker.EnsureImages(ctx, []string{image}, "")
-
-	imageEnsureMutex.Lock()
-	state.err = err
-	close(state.done)
-	delete(imageEnsureInFlight, image)
-	imageEnsureMutex.Unlock()
-
-	return err
-}
-
 // StartOperaDockerNode creates a new OperaNode running in a Docker container.
 func StartOperaDockerNode(
 	ctx context.Context,
@@ -328,7 +280,8 @@ func NewOperaNode(
 	config *OperaNodeConfig,
 ) (*OperaNode, error) {
 	image := driver.ResolveClientImageName(config.Image)
-	if err := ensureImageAvailable(ctx, image); err != nil {
+	pinnedImage, err := docker.EnsureImage(ctx, image, "")
+	if err != nil {
 		return nil, fmt.Errorf("failed to ensure image %q: %w", image, err)
 	}
 
@@ -398,7 +351,7 @@ func NewOperaNode(
 	container, err := client.Start(ctx,
 		&docker.ContainerConfig{
 			Hostname:        config.Label,
-			ImageName:       image,
+			Image:           pinnedImage,
 			ShutdownTimeout: &shutdownTimeout,
 			Environment:     envs,
 			Entrypoint:      containerEntrypoint,


### PR DESCRIPTION
Norma supports `imageName`s like sonic:main which can change within a scenario run, if a node starts later in the scenario it might use a different sonic version. This PR pins the sonic version during a scenario run.