### PR TITLE
Skip nodes with a suspended client when managing peers

### DIFF
--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -55,7 +55,14 @@ type LocalNetwork struct {
 	// validator nodes created during startup.
 	nodes map[driver.NodeID]*node.OperaNode
 
-	// nodesMutex synchronizes access to the list of nodes.
+	// suspended tracks nodes whose client process is known to be down
+	// (SuspendNode was called, e.g. after a killSonic step). Peer
+	// operations skip these nodes instead of retrying their dead RPC
+	// endpoint for minutes. Guarded by nodesMutex.
+	suspended map[driver.Node]bool
+
+	// nodesMutex synchronizes access to the list of nodes and the
+	// suspended set.
 	nodesMutex sync.Mutex
 
 	// bootstrapped is set once the first node has joined and never resets:
@@ -142,6 +149,7 @@ func NewLocalNetwork(ctx context.Context, config *driver.NetworkConfig) (*LocalN
 		config:         *config,
 		primaryAccount: primaryAccount,
 		nodes:          map[driver.NodeID]*node.OperaNode{},
+		suspended:      map[driver.Node]bool{},
 		apps:           []driver.Application{},
 		listeners:      map[driver.NetworkListener]bool{},
 		rpcWorkerPool:  rpc.NewRpcWorkerPool(ctx),
@@ -202,8 +210,16 @@ func (n *LocalNetwork) addNodeIntoNetwork(ctx context.Context, node *node.OperaN
 	if err != nil {
 		return fmt.Errorf("failed to get node id; %v", err)
 	}
-	var succeeded int
+	var attempted, succeeded int
 	for _, other := range n.nodes {
+		// A suspended node's client is known to be down; dialing it would
+		// only burn the retry budget. It re-peers itself when resumed.
+		if n.suspended[other] {
+			slog.Info("skipping suspended node while adding peers",
+				"node", other.GetLabel())
+			continue
+		}
+		attempted++
 		if err = other.AddPeer(ctx, id); err != nil {
 			label := other.GetLabel()
 			if checkErr := other.CheckRunning(ctx); checkErr != nil {
@@ -215,7 +231,7 @@ func (n *LocalNetwork) addNodeIntoNetwork(ctx context.Context, node *node.OperaN
 			succeeded++
 		}
 	}
-	if len(n.nodes) > 0 && succeeded == 0 {
+	if attempted > 0 && succeeded == 0 {
 		return fmt.Errorf("failed to add peer; no existing node was reachable")
 	}
 	n.nodes[id] = node
@@ -345,9 +361,12 @@ func (n *LocalNetwork) RemoveNode(node driver.Node) error {
 	}
 
 	delete(n.nodes, id)
+	delete(n.suspended, node)
 	for _, other := range n.nodes {
+		if n.suspended[other] {
+			continue
+		}
 		if err = other.RemovePeer(n.ctx, id); err != nil {
-			n.nodesMutex.Unlock()
 			return fmt.Errorf("failed to remove peer; %v", err)
 		}
 	}
@@ -582,6 +601,10 @@ func (n *LocalNetwork) UnregisterListener(listener driver.NetworkListener) {
 }
 
 func (n *LocalNetwork) SuspendNode(node driver.Node) {
+	n.nodesMutex.Lock()
+	n.suspended[node] = true
+	n.nodesMutex.Unlock()
+
 	n.listenerMutex.Lock()
 	for listener := range n.listeners {
 		listener.BeforeNodeRemoval(node)
@@ -590,6 +613,10 @@ func (n *LocalNetwork) SuspendNode(node driver.Node) {
 }
 
 func (n *LocalNetwork) ResumeNode(node driver.Node) {
+	n.nodesMutex.Lock()
+	delete(n.suspended, node)
+	n.nodesMutex.Unlock()
+
 	n.listenerMutex.Lock()
 	for listener := range n.listeners {
 		listener.AfterNodeCreation(node)

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/node"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -459,6 +460,46 @@ func TestLocalNetwork_CanRemoveNode(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconnectNodeAndRemoveNode_Succeed_WhenOnlyOtherNodeIsSuspended(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	config := driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())}
+	net, err := NewLocalLegacyNetwork(t.Context(), &config)
+	require.NoError(err, "failed to create new local network")
+	t.Cleanup(func() {
+		require.NoError(net.Shutdown())
+	})
+
+	validators := net.GetActiveNodes()
+	require.Len(validators, 1, "expected one genesis validator")
+	validator := validators[0]
+
+	observer, err := net.CreateNode(&driver.NodeConfig{
+		Name:  "observer-" + t.Name(),
+		Image: driver.DefaultClientDockerImageName,
+	})
+	require.NoError(err, "failed to create node")
+
+	// Take the validator's client down the way a killSonic step does:
+	// suspend first, then SIGKILL the client while the container lives on.
+	opera, ok := validator.(*node.OperaNode)
+	require.True(ok, "validator is not an OperaNode")
+	net.SuspendNode(validator)
+	require.NoError(opera.ForceStopSonicd(t.Context()),
+		"failed to kill validator client")
+
+	// The suspended validator is the only potential peer left. Both peer
+	// management operations must skip its dead RPC endpoint and succeed
+	// immediately, rather than retrying it for minutes and failing.
+	require.NoError(net.ReconnectNode(t.Context(), observer),
+		"reconnect stalled on suspended node")
+	require.NoError(net.RemoveNode(observer),
+		"remove stalled on suspended node")
+
+	require.NoError(observer.Stop(t.Context()), "failed to stop node")
+	require.NoError(observer.Cleanup(context.Background()), "failed to cleanup node")
 }
 
 func TestLocalNetwork_Num_Validators_Started(t *testing.T) {


### PR DESCRIPTION
Peer operations retry an unreachable RPC endpoint for 180 seconds before giving up. A node whose client was deliberately taken down (SuspendNode, e.g. by a killSonic step) fed that retry loop anyway, so restarting one of several concurrently killed validators stalled for minutes per dead peer and pushed db-heal scenarios past the 10-minute deadline.

The network now remembers which nodes are suspended and skips them when adding or removing peers; they re-establish their connections themselves when resumed. Joining a network whose remaining nodes are all suspended is no longer an error, and a failing RemovePeer call no longer double-unlocks the nodes mutex.