### PR TITLE
Log each scenario step under its own name, coloured per operation

### DIFF
--- a/driver/executor/run.go
+++ b/driver/executor/run.go
@@ -83,6 +83,13 @@ func RunAndCaptureEventExecution(
 	return executions, err
 }
 
+// A step is logged twice, under the operation's own name, once as it starts and
+// once when it is done. These distinguish the two.
+const (
+	phaseStarted   = "started"
+	phaseCompleted = "completed"
+)
+
 // defaultScenarioTimeout is the maximum time a scenario is
 // allowed to run before being aborted.
 const defaultScenarioTimeout = 10 * time.Minute
@@ -149,9 +156,9 @@ func runWithObserver(
 		default:
 		}
 
-		slog.Info("executing step",
+		slog.Info(string(step.Function),
 			"step", i+1,
-			"function", step.Function,
+			"phase", phaseStarted,
 			"identifier", step.Identifier,
 		)
 
@@ -177,9 +184,9 @@ func runWithObserver(
 			return fmt.Errorf("step %d (%s %s) failed: %w", i+1, step.Function, step.Identifier, err)
 		}
 
-		slog.Info("step completed",
+		slog.Info(string(step.Function),
 			"step", i+1,
-			"function", step.Function,
+			"phase", phaseCompleted,
 			"duration", end.Sub(start),
 		)
 

--- a/driver/globalflags/logger.go
+++ b/driver/globalflags/logger.go
@@ -44,8 +44,7 @@ var AllLoggerFlags = []cli.Flag{
 func SetupLogger(ctx *cli.Context) error {
 
 	output := io.Writer(os.Stdout)
-	handler := log.NewTerminalHandler(output, canColor())
-	glogger := log.NewGlogHandler(handler)
+	glogger := log.NewGlogHandler(newLogHandler(output, canColor()))
 
 	verbosity := log.FromLegacyLevel(ctx.Int(verbosityFlag.Name))
 	glogger.Verbosity(verbosity)

--- a/driver/globalflags/operation_color_handler.go
+++ b/driver/globalflags/operation_color_handler.go
@@ -1,0 +1,147 @@
+package globalflags
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+
+	"github.com/0xsoniclabs/norma/driver/parser"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// newLogHandler builds the handler the application logs through. When the output
+// can carry colour, a line whose message is an operation has that message
+// printed in the operation's colour; the rest of the line, and every line that
+// names no operation, is left to go-ethereum's terminal handler exactly as
+// before.
+func newLogHandler(output io.Writer, useColor bool) slog.Handler {
+	if !useColor {
+		return log.NewTerminalHandler(output, false)
+	}
+
+	writer := newMessageColorWriter(output)
+	return newOperationColorHandler(log.NewTerminalHandler(writer, true), writer)
+}
+
+// operationColorHandler prints the message of a log line that names a node
+// operation in that operation's colour, giving each operation its own.
+//
+// The executor logs a step by using the operation as the message, so the
+// terminal handler's message column becomes a colour-coded column of step names.
+// Lines logged in between by the node, network, load, and check packages carry
+// messages of their own and are passed through untouched.
+type operationColorHandler struct {
+	inner  slog.Handler
+	writer *messageColorWriter
+	// mu makes selecting a colour and writing the line it applies to atomic
+	// against the many goroutines that log concurrently during a run. It is
+	// shared with every handler derived through WithAttrs or WithGroup, since
+	// they all write through the same writer.
+	mu *sync.Mutex
+}
+
+// newOperationColorHandler wraps inner so that operation lines are coloured.
+// inner must write to writer, and must emit one record per Write, as
+// go-ethereum's TerminalHandler does by formatting each record into a buffer and
+// writing it in a single call.
+func newOperationColorHandler(inner slog.Handler, writer *messageColorWriter) slog.Handler {
+	return &operationColorHandler{
+		inner:  inner,
+		writer: writer,
+		mu:     &sync.Mutex{},
+	}
+}
+
+func (h *operationColorHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h *operationColorHandler) Handle(ctx context.Context, r slog.Record) error {
+	// Warnings and errors keep the level colouring the terminal handler gives
+	// them. Tinting a failure in the colour of the step it happened in would mute
+	// the one line the reader most needs to notice.
+	color := ""
+	if r.Level < slog.LevelWarn {
+		color, _ = operationColor(parser.StepFunction(r.Message))
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if color != "" {
+		h.writer.color = color
+		h.writer.message = r.Message
+		defer func() {
+			h.writer.color, h.writer.message = "", ""
+		}()
+	}
+
+	return h.inner.Handle(ctx, r)
+}
+
+func (h *operationColorHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &operationColorHandler{
+		inner:  h.inner.WithAttrs(attrs),
+		writer: h.writer,
+		mu:     h.mu,
+	}
+}
+
+func (h *operationColorHandler) WithGroup(name string) slog.Handler {
+	return &operationColorHandler{
+		inner:  h.inner.WithGroup(name),
+		writer: h.writer,
+		mu:     h.mu,
+	}
+}
+
+// messageColorWriter colours the message inside an already formatted log line,
+// leaving every other part of it untouched.
+//
+// color and message are set and cleared by operationColorHandler.Handle while it
+// holds the shared lock, which is also what serialises the Write in between. An
+// empty colour passes the line through byte for byte.
+type messageColorWriter struct {
+	out     io.Writer
+	color   string
+	message string
+}
+
+func newMessageColorWriter(out io.Writer) *messageColorWriter {
+	return &messageColorWriter{out: out}
+}
+
+func (w *messageColorWriter) Write(p []byte) (int, error) {
+	if w.color == "" || w.message == "" {
+		return w.out.Write(p)
+	}
+
+	// The terminal handler writes "<level>[<time>] <message>", and the time
+	// format contains no ']', so the message follows the first "] ". Operation
+	// names are plain identifiers, so the handler never quotes or escapes them
+	// and the message appears verbatim. Requiring it to follow keeps a line
+	// formatted differently from being rewritten by accident.
+	const prefix = "] "
+	i := bytes.Index(p, []byte(prefix+w.message))
+	if i < 0 {
+		return w.out.Write(p)
+	}
+
+	start := i + len(prefix)
+	end := start + len(w.message)
+
+	buf := make([]byte, 0, len(p)+len(w.color)+len(colorReset))
+	buf = append(buf, p[:start]...)
+	buf = append(buf, w.color...)
+	buf = append(buf, p[start:end]...)
+	buf = append(buf, colorReset...)
+	buf = append(buf, p[end:]...)
+
+	if _, err := w.out.Write(buf); err != nil {
+		return 0, err
+	}
+	// Report the caller's length, not the recoloured one, so it sees a full write.
+	return len(p), nil
+}

--- a/driver/globalflags/operation_colors.go
+++ b/driver/globalflags/operation_colors.go
@@ -17,12 +17,12 @@ const colorReset = "\x1b[0m"
 // that colour, so the steps stand out from the rest of the output and from each
 // other.
 //
-// The values are 256-colour SGR sequences. Reds and yellows are deliberately
-// absent: go-ethereum's terminal handler uses them for the level of warnings
-// and errors, and an operation colour should not read as a failure.
+// The values are 256-colour SGR sequences. Bright reds and yellows are avoided
+// because go-ethereum's terminal handler uses them for warning/error levels,
+// and an operation colour should not read as a failure.
 //
 // Every operation in parser.AllStepFunctions must appear here;
-// TestOperationColors_CoverEveryStepFunction enforces that.
+// TestOperationColors_OperationColor_CoversEveryStepFunction enforces that.
 var operationColors = map[parser.StepFunction]string{
 	// Node lifecycle.
 	parser.FuncStartNode: "\x1b[38;5;42m",  // green — a node comes up

--- a/driver/globalflags/operation_colors.go
+++ b/driver/globalflags/operation_colors.go
@@ -1,0 +1,56 @@
+package globalflags
+
+import (
+	"github.com/0xsoniclabs/norma/driver/parser"
+)
+
+// This file holds the colour table used by the log handler in
+// operation_color_handler.go, and nothing else. It is kept separate so that
+// re-colouring an operation, or colouring a newly added one, is a change to a
+// lookup table rather than a change to logging logic.
+
+// colorReset ends a coloured run.
+const colorReset = "\x1b[0m"
+
+// operationColors gives every scenario operation its own colour. On a log line
+// that names an operation, the message and the operation name are printed in
+// that colour, so the steps stand out from the rest of the output and from each
+// other.
+//
+// The values are 256-colour SGR sequences. Reds and yellows are deliberately
+// absent: go-ethereum's terminal handler uses them for the level of warnings
+// and errors, and an operation colour should not read as a failure.
+//
+// Every operation in parser.AllStepFunctions must appear here;
+// TestOperationColors_CoverEveryStepFunction enforces that.
+var operationColors = map[parser.StepFunction]string{
+	// Node lifecycle.
+	parser.FuncStartNode: "\x1b[38;5;42m",  // green — a node comes up
+	parser.FuncStopNode:  "\x1b[38;5;208m", // orange — a node goes down
+	parser.FuncKillSonic: "\x1b[38;5;199m", // pink — a node is killed outright
+	parser.FuncHealDb:    "\x1b[38;5;51m",  // cyan — a node is repaired
+
+	// Load generation.
+	parser.FuncRunApp:  "\x1b[38;5;33m", // blue
+	parser.FuncStopApp: "\x1b[38;5;63m", // indigo
+
+	// Staking.
+	parser.FuncDelegate:     "\x1b[38;5;79m",  // aquamarine
+	parser.FuncUndelegate:   "\x1b[38;5;173m", // clay
+	parser.FuncVerifyStakes: "\x1b[38;5;156m", // pale green
+
+	// Network state.
+	parser.FuncUpdateRules:  "\x1b[38;5;214m", // amber
+	parser.FuncAdvanceEpoch: "\x1b[38;5;141m", // purple
+	parser.FuncWaitForEpoch: "\x1b[38;5;109m", // steel blue
+
+	// Passive steps.
+	parser.FuncChecks:  "\x1b[38;5;220m", // gold
+	parser.FuncWaitFor: "\x1b[38;5;244m", // grey — nothing is happening
+}
+
+// operationColor returns the colour assigned to op, or false if op has none.
+func operationColor(op parser.StepFunction) (string, bool) {
+	color, ok := operationColors[op]
+	return color, ok
+}

--- a/driver/globalflags/operation_colors_test.go
+++ b/driver/globalflags/operation_colors_test.go
@@ -1,0 +1,320 @@
+package globalflags
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xsoniclabs/norma/driver/parser"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperationColors_OperationColor_CoversEveryStepFunction(t *testing.T) {
+	require := require.New(t)
+
+	for _, op := range parser.AllStepFunctions() {
+		_, ok := operationColor(op)
+		require.True(ok, "operation %q has no colour assigned", op)
+	}
+}
+
+func TestOperationColors_OperationColor_AssignsUniqueColorPerOperation(t *testing.T) {
+	require := require.New(t)
+
+	seen := map[string]parser.StepFunction{}
+	for _, op := range parser.AllStepFunctions() {
+		color, ok := operationColor(op)
+		require.True(ok, "operation %q has no colour assigned", op)
+
+		previous, clash := seen[color]
+		require.False(clash, "operations %q and %q share colour %q", previous, op, color)
+		seen[color] = op
+	}
+}
+
+func TestLogHandler_NewLogHandler_WritesPlainOutputWhenColorIsOff(t *testing.T) {
+	require := require.New(t)
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(newLogHandler(buf, false))
+
+	logger.Info(string(parser.FuncKillSonic), "step", 1)
+
+	require.NotContains(buf.String(), "\x1b[")
+}
+
+func TestOperationColorHandler_Handle_ColorsTheMessage(t *testing.T) {
+	require := require.New(t)
+	logger, buf := newTestLogger(t)
+
+	logger.Info(string(parser.FuncHealDb), "step", 9, "identifier", "frail")
+
+	color, ok := operationColor(parser.FuncHealDb)
+	require.True(ok)
+	require.Equal([]string{"healDb"}, coloredSpans(buf.String(), color))
+}
+
+func TestOperationColorHandler_Handle_LeavesRestOfLineUntouched(t *testing.T) {
+	require := require.New(t)
+	logger, buf := newTestLogger(t)
+
+	logger.Info(string(parser.FuncHealDb), "step", 9, "identifier", "frail")
+
+	color, ok := operationColor(parser.FuncHealDb)
+	require.True(ok)
+
+	head, rest, found := strings.Cut(buf.String(), color)
+	require.True(found)
+	require.Contains(head, "INFO")
+	require.NotContains(head, "healDb")
+
+	_, tail, found := strings.Cut(rest, colorReset)
+	require.True(found)
+	require.Contains(tail, "step")
+	require.Contains(tail, "identifier")
+	require.Contains(tail, "=frail")
+	require.NotContains(tail, color)
+}
+
+func TestOperationColorHandler_Handle_ColorsEveryOperation(t *testing.T) {
+	for _, op := range parser.AllStepFunctions() {
+		t.Run(string(op), func(t *testing.T) {
+			require := require.New(t)
+			logger, buf := newTestLogger(t)
+
+			logger.Info(string(op), "step", 1, "duration", "1s")
+
+			color, ok := operationColor(op)
+			require.True(ok)
+			require.Equal([]string{string(op)}, coloredSpans(buf.String(), color))
+		})
+	}
+}
+
+func TestOperationColorHandler_Handle_UsesDifferentColorPerOperation(t *testing.T) {
+	require := require.New(t)
+	logger, buf := newTestLogger(t)
+
+	logger.Info(string(parser.FuncHealDb), "step", 1)
+	logger.Info(string(parser.FuncStartNode), "step", 2)
+
+	healColor, ok := operationColor(parser.FuncHealDb)
+	require.True(ok)
+	startColor, ok := operationColor(parser.FuncStartNode)
+	require.True(ok)
+
+	healLine, startLine, found := strings.Cut(buf.String(), "\n")
+	require.True(found)
+
+	require.Equal([]string{"healDb"}, coloredSpans(healLine, healColor))
+	require.NotContains(healLine, startColor)
+	require.Equal([]string{"startNode"}, coloredSpans(startLine, startColor))
+	require.NotContains(startLine, healColor)
+}
+
+// A line logged while an operation runs carries its own message and keeps its
+// own colour.
+func TestOperationColorHandler_Handle_DoesNotColorLaterLines(t *testing.T) {
+	require := require.New(t)
+	logger, buf := newTestLogger(t)
+
+	logger.Info(string(parser.FuncHealDb), "step", 1)
+	buf.Reset()
+	logger.Info("Stopping sonicd", "node", "frail")
+
+	color, ok := operationColor(parser.FuncHealDb)
+	require.True(ok)
+	require.NotContains(buf.String(), color)
+}
+
+// Setup, monitoring, and node output must come out as the terminal handler wrote it.
+func TestOperationColorHandler_Handle_PassesLinesWithoutOperationThrough(t *testing.T) {
+	require := require.New(t)
+
+	wrapped := &bytes.Buffer{}
+	logger := slog.New(newLogHandler(wrapped, true))
+
+	plain := &bytes.Buffer{}
+	reference := slog.New(log.NewTerminalHandler(plain, true))
+
+	for _, emit := range []func(l *slog.Logger){
+		func(l *slog.Logger) { l.Info("reading scenario file", "path", "scenario.yml") },
+		func(l *slog.Logger) { l.Info("Stopping sonicd", "node", "frail") },
+		func(l *slog.Logger) { l.Warn("node not responding", "node", "frail") },
+		func(l *slog.Logger) { l.Error("step failed", "step", 7) },
+	} {
+		emit(logger)
+		emit(reference)
+	}
+
+	require.Equal(stripTimestamps(plain.String()), stripTimestamps(wrapped.String()))
+}
+
+// A failure has to stay recognisable as one rather than read as a step.
+func TestOperationColorHandler_Handle_LeavesWarningsAndErrorsToTheirLevel(t *testing.T) {
+	tests := map[string]struct {
+		emit func(l *slog.Logger)
+	}{
+		"warning": {emit: func(l *slog.Logger) { l.Warn(string(parser.FuncChecks), "step", 6) }},
+		"error":   {emit: func(l *slog.Logger) { l.Error(string(parser.FuncChecks), "step", 6) }},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			logger, buf := newTestLogger(t)
+
+			test.emit(logger)
+
+			color, ok := operationColor(parser.FuncChecks)
+			require.True(ok)
+			require.NotContains(buf.String(), color)
+		})
+	}
+}
+
+// Check functions are not steps and have no colour of their own.
+func TestOperationColorHandler_Handle_IgnoresMessagesThatAreNotOperations(t *testing.T) {
+	require := require.New(t)
+	logger, buf := newTestLogger(t)
+
+	logger.Info(string(parser.FuncCheckBlockHashes), "step", 6)
+
+	require.NotContains(buf.String(), "\x1b[38;5;")
+}
+
+func TestOperationColorHandler_Handle_SerializesConcurrentWrites(t *testing.T) {
+	require := require.New(t)
+	logger, buf := newTestLogger(t)
+	handler := logger.Handler()
+
+	const goroutines = 8
+	const perGoroutine = 50
+	stamp := time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC)
+
+	done := make(chan struct{})
+	for i := range goroutines {
+		go func(i int) {
+			defer func() { done <- struct{}{} }()
+
+			message := "concurrent"
+			if i%2 == 0 {
+				message = string(parser.FuncStartNode)
+			}
+			for range perGoroutine {
+				r := slog.NewRecord(stamp, slog.LevelInfo, message, 0)
+				require.NoError(handler.Handle(context.Background(), r))
+			}
+		}(i)
+	}
+	for range goroutines {
+		<-done
+	}
+
+	require.Equal(goroutines*perGoroutine, strings.Count(buf.String(), "\n"))
+}
+
+func TestOperationColorHandler_WithAttrs_KeepsColoringOperationLines(t *testing.T) {
+	require := require.New(t)
+	logger, buf := newTestLogger(t)
+
+	logger.With("node", "frail").Info(string(parser.FuncStartNode), "step", 1)
+
+	color, ok := operationColor(parser.FuncStartNode)
+	require.True(ok)
+	require.Equal([]string{"startNode"}, coloredSpans(buf.String(), color))
+}
+
+func TestMessageColorWriter_Write_ColorsOnlyTheMessage(t *testing.T) {
+	const color = "\x1b[38;5;42m"
+
+	tests := map[string]struct {
+		message string
+		line    string
+		want    []string
+	}{
+		"message present": {
+			message: "startNode",
+			line:    "INFO [TIME] startNode    step=1 identifier=frail\n",
+			want:    []string{"startNode"},
+		},
+		"message absent": {
+			message: "startNode",
+			line:    "INFO [TIME] other message step=1\n",
+			want:    nil,
+		},
+		"name also in an attribute is left alone": {
+			message: "startNode",
+			line:    "INFO [TIME] startNode    node=startNode\n",
+			want:    []string{"startNode"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
+			out := &bytes.Buffer{}
+			w := newMessageColorWriter(out)
+			w.color, w.message = color, test.message
+
+			n, err := w.Write([]byte(test.line))
+			require.NoError(err)
+			require.Equal(len(test.line), n)
+			require.Equal(test.want, coloredSpans(out.String(), color))
+		})
+	}
+}
+
+func TestMessageColorWriter_Write_PassesLineThroughWithoutColor(t *testing.T) {
+	require := require.New(t)
+
+	const line = "INFO [TIME] startNode step=1\n"
+
+	out := &bytes.Buffer{}
+	w := newMessageColorWriter(out)
+
+	n, err := w.Write([]byte(line))
+	require.NoError(err)
+	require.Equal(len(line), n)
+	require.Equal(line, out.String())
+}
+
+// newTestLogger returns a logger writing coloured output into a buffer.
+func newTestLogger(t *testing.T) (*slog.Logger, *bytes.Buffer) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	return slog.New(newLogHandler(buf, true)), buf
+}
+
+// coloredSpans returns the regions of a line the given colour applies to.
+func coloredSpans(line, color string) []string {
+	var spans []string
+	rest := line
+	for {
+		i := strings.Index(rest, color)
+		if i < 0 {
+			return spans
+		}
+		rest = rest[i+len(color):]
+		end := strings.Index(rest, colorReset)
+		if end < 0 {
+			return spans
+		}
+		spans = append(spans, rest[:end])
+		rest = rest[end+len(colorReset):]
+	}
+}
+
+// timestampPattern matches the stamp the terminal handler writes, so output from
+// two loggers can be compared.
+var timestampPattern = regexp.MustCompile(`\[\d\d-\d\d\|\d\d:\d\d:\d\d\.\d\d\d\]`)
+
+func stripTimestamps(s string) string {
+	return timestampPattern.ReplaceAllString(s, "[TIME]")
+}

--- a/driver/parser/scenario.go
+++ b/driver/parser/scenario.go
@@ -90,6 +90,11 @@ var allCheckFunctions = [...]StepFunction{
 	FuncCheckValidatorsActive,
 }
 
+// AllStepFunctions returns every top-level step function a scenario may use.
+func AllStepFunctions() []StepFunction {
+	return slices.Clone(allStepFunctions[:])
+}
+
 // toStepFunction returns the StepFunction for a given string, or an error if not recognized.
 func toStepFunction(s string) (StepFunction, error) {
 	for _, fn := range allStepFunctions {


### PR DESCRIPTION
Currently, in a norma scenario log each line are colored the same. This makes it difficult to distinguish between the network progression and the operations written in the log. 
This PR makes it easier by coloring some operations.

A step is now logged under the operation's own name, with the phase carried as an attribute:

    INFO [11:59:59.992] healDb    step=7 phase=started   identifier=frail
    INFO [12:00:00.240] healDb    step=7 phase=completed duration=248.047105ms

The terminal handler pads the message, so this turns that column into an index of the steps a run performed, and each operation is given its own colour to make it scannable. The `function=` attribute is dropped, as the message now carries it.

The new log looks like this: 
<img width="1052" height="674" alt="image" src="https://github.com/user-attachments/assets/37214018-cd35-4ef8-a25c-ba3471a5774f" />
