### PR TITLE
Send system transactions through a single node

### DIFF
--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -94,6 +94,14 @@ type LocalNetwork struct {
 	// appContextMu guards lazy initialization of appContext.
 	appContextMu sync.Mutex
 
+	// systemRpcLabel is the node that transactions from the shared system
+	// account are sent through. See dialSystemRpc for why they must not be
+	// spread over several nodes. Guarded by systemRpcMu.
+	systemRpcLabel string
+
+	// systemRpcMu guards systemRpcLabel.
+	systemRpcMu sync.Mutex
+
 	// temporary host directory used while preparing genesis artifacts
 	genesisTmpDir string
 	// host path to the generated genesis.json file
@@ -393,9 +401,16 @@ func (n *LocalNetwork) RegisterTransactionObserver(observer driver.TransactionOb
 }
 
 func (n *LocalNetwork) DialRandomRpc() (rpcdriver.Client, error) {
+	client, _, err := n.dialAnyRpc()
+	return client, err
+}
+
+// dialAnyRpc dials a randomly chosen reachable node, reporting which one it
+// settled on so callers that need to keep using it can remember the label.
+func (n *LocalNetwork) dialAnyRpc() (rpcdriver.Client, string, error) {
 	nodes := n.GetActiveNodes()
 	if len(nodes) == 0 {
-		return nil, driver.ErrEmptyNetwork
+		return nil, "", driver.ErrEmptyNetwork
 	}
 	reliable := make([]driver.Node, 0, len(nodes))
 	for _, node := range nodes {
@@ -426,13 +441,61 @@ func (n *LocalNetwork) DialRandomRpc() (rpcdriver.Client, error) {
 			client.Close()
 			continue
 		}
-		return client, nil
+		return client, string(chosen.GetLabel()), nil
 	}
-	return nil, fmt.Errorf("no reachable node found among %d active nodes", len(reliable))
+	return nil, "", fmt.Errorf("no reachable node found among %d active nodes", len(reliable))
+}
+
+// dialSystemRpc returns a client for the node that carries transactions sent
+// from the shared system account (fakenet key 1) — epoch advances and rule
+// updates.
+//
+// Those transactions form a single nonce sequence, and their nonce is read from
+// the pending state of whichever node they are submitted through. Nodes observe
+// a block a moment apart, so submitting two of them through different nodes lets
+// the second read a nonce the first has already spent. Such a transaction can
+// never be included, is eventually dropped from the pool, and surfaces as a
+// receipt timeout reporting the transaction as "not present".
+//
+// Pinning them to one node rules that out: each waits for its own receipt from
+// this node, so by the time the next one asks, the node has the block and
+// reports the nonce following it. The pin is only re-chosen when the node it
+// names has become unreachable, which is also the one moment the hazard can
+// return — unavoidable, since the sequence has to continue somewhere.
+func (n *LocalNetwork) dialSystemRpc() (rpcdriver.Client, error) {
+	n.systemRpcMu.Lock()
+	defer n.systemRpcMu.Unlock()
+
+	if n.systemRpcLabel != "" {
+		if client, err := n.dialRpcByLabel(n.systemRpcLabel); err == nil {
+			return client, nil
+		}
+		slog.Warn("pinned system-transaction node is unreachable, choosing another",
+			"node", n.systemRpcLabel)
+	}
+
+	client, label, err := n.dialAnyRpc()
+	if err != nil {
+		return nil, err
+	}
+	n.systemRpcLabel = label
+	return client, nil
+}
+
+// dialRpcByLabel dials the named node, failing if it is not active or does not
+// answer.
+func (n *LocalNetwork) dialRpcByLabel(label string) (rpcdriver.Client, error) {
+	for _, node := range n.GetActiveNodes() {
+		if string(node.GetLabel()) != label {
+			continue
+		}
+		return node.DialRpc(n.ctx)
+	}
+	return nil, fmt.Errorf("node %q is no longer active", label)
 }
 
 func (n *LocalNetwork) ApplyNetworkRules(ctx context.Context, rules driver.NetworkRules) error {
-	client, err := n.DialRandomRpc()
+	client, err := n.dialSystemRpc()
 	if err != nil {
 		return fmt.Errorf("failed to connect to network: %w", err)
 	}
@@ -442,7 +505,7 @@ func (n *LocalNetwork) ApplyNetworkRules(ctx context.Context, rules driver.Netwo
 }
 
 func (n *LocalNetwork) AdvanceEpoch(ctx context.Context, epochIncrement int) error {
-	client, err := n.DialRandomRpc()
+	client, err := n.dialSystemRpc()
 	if err != nil {
 		return fmt.Errorf("failed to connect to network: %w", err)
 	}

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -431,11 +431,7 @@ func (n *LocalNetwork) dialAnyRpc() (rpcdriver.Client, string, error) {
 				"node", chosen.GetLabel(), "error", err)
 			continue
 		}
-		// Verify the connection is actually alive with a quick call.
-		probeCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		_, probeErr := client.BlockNumber(probeCtx)
-		cancel()
-		if probeErr != nil {
+		if probeErr := probeRpc(client); probeErr != nil {
 			slog.Warn("node not responding in DialRandomRpc, skipping",
 				"node", chosen.GetLabel(), "error", probeErr)
 			client.Close()
@@ -459,19 +455,21 @@ func (n *LocalNetwork) dialAnyRpc() (rpcdriver.Client, string, error) {
 //
 // Pinning them to one node rules that out: each waits for its own receipt from
 // this node, so by the time the next one asks, the node has the block and
-// reports the nonce following it. The pin is only re-chosen when the node it
-// names has become unreachable, which is also the one moment the hazard can
-// return — unavoidable, since the sequence has to continue somewhere.
+// reports the nonce following it. The pin is re-chosen only when the node it
+// names stops answering — a state it is probed for, since a node can accept a
+// connection while serving nothing — which is also the one moment the hazard can
+// return, unavoidable since the sequence has to continue somewhere.
 func (n *LocalNetwork) dialSystemRpc() (rpcdriver.Client, error) {
 	n.systemRpcMu.Lock()
 	defer n.systemRpcMu.Unlock()
 
 	if n.systemRpcLabel != "" {
-		if client, err := n.dialRpcByLabel(n.systemRpcLabel); err == nil {
+		client, err := n.dialRpcByLabel(n.systemRpcLabel)
+		if err == nil {
 			return client, nil
 		}
-		slog.Warn("pinned system-transaction node is unreachable, choosing another",
-			"node", n.systemRpcLabel)
+		slog.Warn("pinned system-transaction node is not answering, choosing another",
+			"node", n.systemRpcLabel, "error", err)
 	}
 
 	client, label, err := n.dialAnyRpc()
@@ -489,9 +487,31 @@ func (n *LocalNetwork) dialRpcByLabel(label string) (rpcdriver.Client, error) {
 		if string(node.GetLabel()) != label {
 			continue
 		}
-		return node.DialRpc(n.ctx)
+		client, err := node.DialRpc(n.ctx)
+		if err != nil {
+			return nil, err
+		}
+		if err := probeRpc(client); err != nil {
+			client.Close()
+			return nil, fmt.Errorf("node %q is not answering: %w", label, err)
+		}
+		return client, nil
 	}
 	return nil, fmt.Errorf("node %q is no longer active", label)
+}
+
+// rpcProbeTimeout bounds the call used to tell a live RPC from a socket that
+// merely accepts connections.
+const rpcProbeTimeout = 2 * time.Second
+
+// probeRpc reports whether a dialled client actually answers. A node can accept
+// a connection while its RPC serves nothing, so dialling alone does not
+// establish that it is usable.
+func probeRpc(client rpcdriver.Client) error {
+	ctx, cancel := context.WithTimeout(context.Background(), rpcProbeTimeout)
+	defer cancel()
+	_, err := client.BlockNumber(ctx)
+	return err
 }
 
 func (n *LocalNetwork) ApplyNetworkRules(ctx context.Context, rules driver.NetworkRules) error {

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/0xsoniclabs/norma/driver"
 	"github.com/0xsoniclabs/norma/driver/node"
+	"github.com/0xsoniclabs/norma/driver/rpc"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -661,6 +662,44 @@ func TestLocalNetwork_DialSystemRpc_ReturnsSameNodeOnEveryCall(t *testing.T) {
 			continue
 		}
 		require.Equal(first, label, "system node moved on call %d", i+1)
+	}
+}
+
+// A node can accept a connection while its RPC serves nothing. Dialling alone
+// would then look like success, and the pinned node would never be re-chosen.
+func TestLocalNetwork_ProbeRpc_FailsWhenNodeAcceptsButDoesNotAnswer(t *testing.T) {
+	tests := map[string]struct {
+		blockNumber func(m *rpc.MockClient)
+		wantErr     bool
+	}{
+		"answers": {
+			blockNumber: func(m *rpc.MockClient) {
+				m.EXPECT().BlockNumber(gomock.Any()).Return(uint64(1), nil)
+			},
+			wantErr: false,
+		},
+		"accepts but does not answer": {
+			blockNumber: func(m *rpc.MockClient) {
+				m.EXPECT().BlockNumber(gomock.Any()).Return(uint64(0), context.DeadlineExceeded)
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
+			client := rpc.NewMockClient(gomock.NewController(t))
+			test.blockNumber(client)
+
+			err := probeRpc(client)
+			if test.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+		})
 	}
 }
 

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -632,6 +632,38 @@ func getChecksum(net *LocalNetwork, image string) (string, error) {
 	return fields[0], nil
 }
 
+// Every transaction spending the shared system account's nonce must go through
+// the same node, so a lagging node cannot hand out a nonce already spent.
+func TestLocalNetwork_DialSystemRpc_ReturnsSameNodeOnEveryCall(t *testing.T) {
+	require := require.New(t)
+	t.Parallel()
+
+	config := driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())}
+	net, err := NewLocalLegacyNetwork(t.Context(), &config)
+	require.NoError(err)
+	t.Cleanup(func() {
+		require.NoError(net.Shutdown())
+	})
+
+	var first string
+	for i := range 5 {
+		client, err := net.dialSystemRpc()
+		require.NoError(err, "call %d", i+1)
+		client.Close()
+
+		net.systemRpcMu.Lock()
+		label := net.systemRpcLabel
+		net.systemRpcMu.Unlock()
+
+		require.NotEmpty(label, "call %d left no pinned node", i+1)
+		if i == 0 {
+			first = label
+			continue
+		}
+		require.Equal(first, label, "system node moved on call %d", i+1)
+	}
+}
+
 func TestLocalNetworkApplyNetworkRules_Success(t *testing.T) {
 	t.Parallel()
 	config := driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())}
@@ -723,6 +755,35 @@ func TestLocalNetworkAdvanceEpoch_Success(t *testing.T) {
 	if got, want := newEpoch, originalEpoch+hexutil.Uint64(epochIncrement); got < want {
 		t.Errorf("epoch did not advance correctly, got %d, want %d", got, want)
 	}
+}
+
+// Two advances in a row are what the parser appends to every scenario, and used
+// to fail the second one by reading a nonce the first had already spent.
+func TestLocalNetwork_AdvanceEpoch_SucceedsWhenCalledTwiceInARow(t *testing.T) {
+	require := require.New(t)
+	t.Parallel()
+
+	config := driver.NetworkConfig{Validators: driver.DefaultValidators(t.Name())}
+	net, err := NewLocalLegacyNetwork(t.Context(), &config)
+	require.NoError(err)
+	t.Cleanup(func() {
+		require.NoError(net.Shutdown())
+	})
+
+	for i := range 2 {
+		require.NoError(net.AdvanceEpoch(t.Context(), 1), "advance %d of 2", i+1)
+	}
+
+	net.systemRpcMu.Lock()
+	pinned := net.systemRpcLabel
+	net.systemRpcMu.Unlock()
+	require.NotEmpty(pinned, "no node was pinned for system transactions")
+
+	active := make([]string, 0, len(net.GetActiveNodes()))
+	for _, node := range net.GetActiveNodes() {
+		active = append(active, string(node.GetLabel()))
+	}
+	require.Contains(active, pinned)
 }
 
 func TestLocalNetwork_FailingFlagPropagated(t *testing.T) {


### PR DESCRIPTION
Two advanceEpoch steps in a row could fail the second one with a receipt timeout reporting the transaction as "not present", which is what the end-of-scenario checks appended to every scenario do.

Epoch advances and rule updates are both sent from the shared system account, so they form one nonce sequence, and neither sets a nonce explicitly: bind reads it from the pending state of whichever node the call dialed. DialRandomRpc chooses a fresh node every time, and nodes observe a block a moment apart, so the second call could read a nonce the first had already spent. Such a transaction can never be included; it is eventually dropped from the pool, and the wait for its receipt times out with the transaction no longer there.

Observed mid-run, moments after the first advance was mined, as the pending nonce of the system account across the four nodes of a scenario:

    nonce = 10  10  10  11
         stable-0  -1  -2  frail

Sending these transactions through one pinned node rules the reordering out. Each waits for its own receipt from that node, so by the time the next one asks for a nonce, the node demonstrably holds the block containing the previous transaction and reports the nonce following it. The pin is re-chosen only when the node it names stops answering, which is also the one moment the hazard can return, since the sequence has to continue somewhere.

Read-only uses of DialRandomRpc are left alone; only the two operations sending from the shared account are pinned.