### PR TITLE
Keep the treasury's nonce in one sequence

### DIFF
--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -95,7 +95,7 @@ type LocalNetwork struct {
 	appContextMu sync.Mutex
 
 	// systemRpcLabel is the node that transactions from the shared system
-	// account are sent through. See dialSystemRpc for why they must not be
+	// account are sent through. See DialSystemRpc for why they must not be
 	// spread over several nodes. Guarded by systemRpcMu.
 	systemRpcLabel string
 
@@ -442,7 +442,7 @@ func (n *LocalNetwork) dialAnyRpc() (rpcdriver.Client, string, error) {
 	return nil, "", fmt.Errorf("no reachable node found among %d active nodes", len(reliable))
 }
 
-// dialSystemRpc returns a client for the node that carries transactions sent
+// DialSystemRpc returns a client for the node that carries transactions sent
 // from the shared system account (fakenet key 1) — epoch advances and rule
 // updates.
 //
@@ -455,11 +455,10 @@ func (n *LocalNetwork) dialAnyRpc() (rpcdriver.Client, string, error) {
 //
 // Pinning them to one node rules that out: each waits for its own receipt from
 // this node, so by the time the next one asks, the node has the block and
-// reports the nonce following it. The pin is re-chosen only when the node it
-// names stops answering — a state it is probed for, since a node can accept a
-// connection while serving nothing — which is also the one moment the hazard can
-// return, unavoidable since the sequence has to continue somewhere.
-func (n *LocalNetwork) dialSystemRpc() (rpcdriver.Client, error) {
+// reports the nonce following it. The pin is only re-chosen when the node it
+// names has become unreachable, which is also the one moment the hazard can
+// return — unavoidable, since the sequence has to continue somewhere.
+func (n *LocalNetwork) DialSystemRpc() (rpcdriver.Client, error) {
 	n.systemRpcMu.Lock()
 	defer n.systemRpcMu.Unlock()
 
@@ -515,7 +514,7 @@ func probeRpc(client rpcdriver.Client) error {
 }
 
 func (n *LocalNetwork) ApplyNetworkRules(ctx context.Context, rules driver.NetworkRules) error {
-	client, err := n.dialSystemRpc()
+	client, err := n.DialSystemRpc()
 	if err != nil {
 		return fmt.Errorf("failed to connect to network: %w", err)
 	}
@@ -525,7 +524,7 @@ func (n *LocalNetwork) ApplyNetworkRules(ctx context.Context, rules driver.Netwo
 }
 
 func (n *LocalNetwork) AdvanceEpoch(ctx context.Context, epochIncrement int) error {
-	client, err := n.dialSystemRpc()
+	client, err := n.DialSystemRpc()
 	if err != nil {
 		return fmt.Errorf("failed to connect to network: %w", err)
 	}

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -648,7 +648,7 @@ func TestLocalNetwork_DialSystemRpc_ReturnsSameNodeOnEveryCall(t *testing.T) {
 
 	var first string
 	for i := range 5 {
-		client, err := net.dialSystemRpc()
+		client, err := net.DialSystemRpc()
 		require.NoError(err, "call %d", i+1)
 		client.Close()
 

--- a/load/app/context.go
+++ b/load/app/context.go
@@ -49,19 +49,30 @@ type AppContext interface {
 
 type RpcClientFactory interface {
 	DialRandomRpc() (rpc.Client, error)
+
+	// DialSystemRpc returns a client for the node that carries transactions sent
+	// from the shared system account, which the treasury is. See NewContext.
+	DialSystemRpc() (rpc.Client, error)
 }
 
-// NewContext initializes an application context bound to a random RPC client,
-// treasury account, and the scenario network rules patch. The provided context
-// is used for the network operations performed through this app context, so
-// cancelling it (for example on a check failure or timeout) aborts pending
-// receipt waits and RPC calls.
+// NewContext initializes an application context bound to the node that carries
+// the shared system account's transactions, the treasury account, and the
+// scenario network rules patch. The provided context is used for the network
+// operations performed through this app context, so cancelling it (for example
+// on a check failure or timeout) aborts pending receipt waits and RPC calls.
 func NewContext(ctx context.Context, factory RpcClientFactory, treasury *Account, networkRules genesis.NetworkRulesPatch) (AppContext, error) {
 	if ctx == nil {
 		return nil, fmt.Errorf("context cannot be nil")
 	}
 
-	rpcClient, err := factory.DialRandomRpc()
+	// Every transaction this context sends — contract deployments and account
+	// funding — is paid for by the treasury, which is the same on-chain account
+	// the driver sends epoch advances and rule updates from. Their nonce is read
+	// from the pending state of the node they go through, so spreading them over
+	// several nodes lets one read a nonce another has already spent. Sharing the
+	// driver's pinned node keeps that single sequence in order. Generated load
+	// still reaches the network through its own clients.
+	rpcClient, err := factory.DialSystemRpc()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to network: %w", err)
 	}
@@ -203,11 +214,12 @@ func (c *appContext) FundAccounts(accounts []common.Address, value *big.Int) err
 		}
 		txs = append(txs, tx)
 
-		nonce, err := c.rpcClient.PendingNonceAt(c.ctx, c.GetTreasure().address)
-		if err != nil {
-			return fmt.Errorf("failed to refresh pending nonce: %w", err)
-		}
-		opts.Nonce = new(big.Int).SetUint64(nonce)
+		// Advance the nonce from the one just spent rather than asking the node
+		// for it again. A node that has not yet taken this transaction into its
+		// pool still reports the nonce this batch used, and the next batch would
+		// then reuse it and quietly replace this one, leaving its accounts
+		// unfunded.
+		opts.Nonce = new(big.Int).Add(opts.Nonce, big.NewInt(1))
 	}
 
 	// Wait for all the transactions to be completed.

--- a/load/app/context_mock.go
+++ b/load/app/context_mock.go
@@ -196,3 +196,18 @@ func (mr *MockRpcClientFactoryMockRecorder) DialRandomRpc() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DialRandomRpc", reflect.TypeOf((*MockRpcClientFactory)(nil).DialRandomRpc))
 }
+
+// DialSystemRpc mocks base method.
+func (m *MockRpcClientFactory) DialSystemRpc() (rpc.Client, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DialSystemRpc")
+	ret0, _ := ret[0].(rpc.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DialSystemRpc indicates an expected call of DialSystemRpc.
+func (mr *MockRpcClientFactoryMockRecorder) DialSystemRpc() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DialSystemRpc", reflect.TypeOf((*MockRpcClientFactory)(nil).DialSystemRpc))
+}

--- a/load/app/context_test.go
+++ b/load/app/context_test.go
@@ -15,7 +15,7 @@ func TestNewContext_DoesNotDeployHelperContract(t *testing.T) {
 
 	mockRpc := rpc.NewMockClient(ctrl)
 	factory := NewMockRpcClientFactory(ctrl)
-	factory.EXPECT().DialRandomRpc().Return(mockRpc, nil)
+	factory.EXPECT().DialSystemRpc().Return(mockRpc, nil)
 
 	mockRpc.EXPECT().Close()
 
@@ -40,7 +40,7 @@ func TestFundAccounts_AttemptsToDeployHelperOnFirstCall(t *testing.T) {
 
 	mockRpc := rpc.NewMockClient(ctrl)
 	factory := NewMockRpcClientFactory(ctrl)
-	factory.EXPECT().DialRandomRpc().Return(mockRpc, nil)
+	factory.EXPECT().DialSystemRpc().Return(mockRpc, nil)
 
 	ctx, err := NewContext(context.Background(), factory, nil, genesis.NetworkRulesPatch{})
 	if err != nil {

--- a/load/controller/controller_test.go
+++ b/load/controller/controller_test.go
@@ -83,6 +83,7 @@ func TestLoadGeneration_CanRealizeConstantTrafficShape(t *testing.T) {
 
 			clientFactory := app.NewMockRpcClientFactory(ctrl)
 			clientFactory.EXPECT().DialRandomRpc().AnyTimes().Return(rpcClient, nil)
+			clientFactory.EXPECT().DialSystemRpc().AnyTimes().Return(rpcClient, nil)
 
 			shaper := shaper.NewConstantShaper(float64(rate))
 			appContext, err := app.NewContext(context.Background(), clientFactory, treasure, driver.NetworkRules{})


### PR DESCRIPTION
The treasury the load framework pays for setup with is the same on-chain account the driver sends epoch advances and rule updates from, and every one of those transactions takes its nonce from the pending state of the node it happens to be sent through. Nothing kept those readings in one order, so two of them could pick the same nonce; the loser can never be included, is dropped from the pool, and the wait for its receipt times out reporting the transaction as absent. This is the hazard fixed for the driver's own transactions in the previous commit, reached from the other side.

An app context now shares the node those driver transactions are pinned to, so contract deployments and account funding join the same sequence rather than reading it from a node that may not have seen the latest of them yet. Generated load is unaffected: it comes from accounts of its own and still reaches the network through its own clients. Pinning only concerns transactions that spend the shared account's nonce.

FundAccounts also asked the node for a new nonce after submitting each batch, which reports the nonce that batch just used until the node takes it into its pool. The next batch could therefore reuse it and quietly replace its predecessor, leaving those accounts unfunded while both transactions appeared to have been sent. It now advances from the nonce it spent, which is the value it already holds, and one RPC per batch goes away with it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>